### PR TITLE
fix(blog): fix category filter querying wrong elements #6

### DIFF
--- a/e2e/blog-filter.pw.ts
+++ b/e2e/blog-filter.pw.ts
@@ -1,0 +1,111 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Blog category filter E2E tests.
+ *
+ * Covers:
+ * 1. All posts visible by default
+ * 2. Clicking a category shows only matching posts
+ * 3. Clicking "All" restores all posts
+ * 4. Active button styling follows selection
+ * 5. Filter works after SPA navigation to blog page
+ */
+
+const BLOG = '/en/blog';
+
+test.describe('Blog category filter', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(BLOG);
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('all posts are visible by default', async ({ page }) => {
+    const posts = page.locator('.grid [data-category]');
+    const count = await posts.count();
+    expect(count).toBeGreaterThanOrEqual(2);
+
+    for (let i = 0; i < count; i++) {
+      await expect(posts.nth(i)).toBeVisible();
+    }
+  });
+
+  test('"All" button is active by default', async ({ page }) => {
+    const allBtn = page.locator('.category-btn[data-category="all"]');
+    await expect(allBtn).toHaveClass(/active/);
+  });
+
+  test('clicking a category filters posts correctly', async ({ page }) => {
+    const categoryBtns = page.locator('.category-btn:not([data-category="all"])');
+    const btnCount = await categoryBtns.count();
+    expect(btnCount).toBeGreaterThanOrEqual(1);
+
+    const firstCategoryBtn = categoryBtns.first();
+    const category = await firstCategoryBtn.getAttribute('data-category');
+    await firstCategoryBtn.click();
+
+    await expect(firstCategoryBtn).toHaveClass(/active/);
+
+    const allPosts = page.locator('.grid [data-category]');
+    const totalCount = await allPosts.count();
+
+    for (let i = 0; i < totalCount; i++) {
+      const post = allPosts.nth(i);
+      const postCategory = await post.getAttribute('data-category');
+      if (postCategory === category) {
+        await expect(post).toBeVisible();
+      } else {
+        await expect(post).not.toBeVisible();
+      }
+    }
+  });
+
+  test('clicking "All" restores all posts', async ({ page }) => {
+    const categoryBtns = page.locator('.category-btn:not([data-category="all"])');
+    await categoryBtns.first().click();
+
+    const allBtn = page.locator('.category-btn[data-category="all"]');
+    await allBtn.click();
+
+    await expect(allBtn).toHaveClass(/active/);
+
+    const posts = page.locator('.grid [data-category]');
+    const count = await posts.count();
+    for (let i = 0; i < count; i++) {
+      await expect(posts.nth(i)).toBeVisible();
+    }
+  });
+
+  test('filter works after SPA navigation to blog', async ({ page }) => {
+    await page.goto('/en');
+    await page.waitForLoadState('networkidle');
+
+    const blogLink = page.locator('a[href="/en/blog"]').first();
+    await blogLink.click();
+    await page.waitForURL('**/blog');
+
+    const categoryBtns = page.locator('.category-btn:not([data-category="all"])');
+    const btnCount = await categoryBtns.count();
+    expect(btnCount).toBeGreaterThanOrEqual(1);
+
+    const firstCategoryBtn = categoryBtns.first();
+    const category = await firstCategoryBtn.getAttribute('data-category');
+    await firstCategoryBtn.click();
+
+    const allPosts = page.locator('.grid [data-category]');
+    const totalCount = await allPosts.count();
+    let visibleCount = 0;
+
+    for (let i = 0; i < totalCount; i++) {
+      const post = allPosts.nth(i);
+      const postCategory = await post.getAttribute('data-category');
+      if (postCategory === category) {
+        await expect(post).toBeVisible();
+        visibleCount++;
+      } else {
+        await expect(post).not.toBeVisible();
+      }
+    }
+
+    expect(visibleCount).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/features/blog/components/CategoryFilter.astro
+++ b/src/features/blog/components/CategoryFilter.astro
@@ -17,26 +17,33 @@ const allLabel = lang === 'en' ? 'All' : 'Все';
 </div>
 
 <script>
-  const buttons = document.querySelectorAll('.category-btn');
-  const posts = document.querySelectorAll('.post-card');
+  const setupCategoryFilter = () => {
+    const buttons = document.querySelectorAll<HTMLButtonElement>('.category-btn');
+    const posts = document.querySelectorAll<HTMLElement>('.grid [data-category]');
 
-  buttons.forEach((button) => {
-    button.addEventListener('click', () => {
-      const category = button.getAttribute('data-category');
+    if (buttons.length === 0 || posts.length === 0) return;
 
-      buttons.forEach((btn) => btn.classList.remove('active'));
-      button.classList.add('active');
-
+    const filterByCategory = (category: string) => {
       posts.forEach((post) => {
         const postCategory = post.getAttribute('data-category');
-        if (category === 'all' || postCategory === category) {
-          (post as HTMLElement).style.display = 'flex';
-        } else {
-          (post as HTMLElement).style.display = 'none';
-        }
+        post.style.display = category === 'all' || postCategory === category ? '' : 'none';
+      });
+    };
+
+    buttons.forEach((button) => {
+      button.addEventListener('click', () => {
+        const category = button.getAttribute('data-category') ?? 'all';
+
+        buttons.forEach((btn) => btn.classList.remove('active'));
+        button.classList.add('active');
+
+        filterByCategory(category);
       });
     });
-  });
+  };
+
+  setupCategoryFilter();
+  document.addEventListener('astro:after-swap', setupCategoryFilter);
 </script>
 
 <style>


### PR DESCRIPTION
## Summary\nFixes #6 — Blog category filter buttons made post lists empty instead of filtering.\n\n## Root Cause\nCategoryFilter.astro script queried .post-card elements which don't have data-category attribute. The data-category is on parent div wrappers in the blog page template.\n\n## Fix\n- Query .grid [data-category] containers instead of .post-card\n- Use typed querySelectorAll<HTMLElement> to avoid type casting (s)\n- Add stro:after-swap handler for SPA navigation support\n\n## Testing\n- 5 new E2E tests in e2e/blog-filter.pw.ts\n- All 30 tests pass (15 chromium + 15 mobile)\n- Manual browser verification confirmed