### PR TITLE
feat(theme): change accent color from blue to orange-red #1

### DIFF
--- a/e2e/accent-color.pw.ts
+++ b/e2e/accent-color.pw.ts
@@ -1,0 +1,86 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Accent color E2E tests.
+ *
+ * Verifies that the accent color is orange-red (not blue/purple)
+ * in both light and dark themes.
+ */
+
+const isOrangeRed = (rgb: string): boolean => {
+  const match = rgb.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
+  if (!match) return false;
+  const [, r, g, b] = match.map(Number);
+  return r > 150 && g < 120 && b < 80;
+};
+
+test.describe('Accent color', () => {
+  test('accent color is orange-red in light theme', async ({ page }) => {
+    await page.goto('/en');
+    await page.waitForLoadState('networkidle');
+
+    const accent = await page.evaluate(() =>
+      globalThis
+        .getComputedStyle(globalThis.document.documentElement)
+        .getPropertyValue('--color-accent')
+        .trim(),
+    );
+
+    expect(accent).toMatch(/hsl/);
+    expect(accent).not.toContain('250');
+
+    const accentRgb = await page.evaluate(() => {
+      const el = globalThis.document.createElement('div');
+      el.style.color = globalThis
+        .getComputedStyle(globalThis.document.documentElement)
+        .getPropertyValue('--color-accent');
+      globalThis.document.body.appendChild(el);
+      const rgb = globalThis.getComputedStyle(el).color;
+      el.remove();
+      return rgb;
+    });
+
+    expect(isOrangeRed(accentRgb)).toBe(true);
+  });
+
+  test('accent color is orange-red in dark theme', async ({ page }) => {
+    await page.goto('/en');
+    await page.waitForLoadState('networkidle');
+
+    await page.evaluate(() => {
+      globalThis.document.documentElement.setAttribute('data-theme', 'dark');
+    });
+
+    const accent = await page.evaluate(() =>
+      globalThis
+        .getComputedStyle(globalThis.document.documentElement)
+        .getPropertyValue('--color-accent')
+        .trim(),
+    );
+
+    expect(accent).toMatch(/hsl/);
+    expect(accent).not.toContain('250');
+
+    const accentRgb = await page.evaluate(() => {
+      const el = globalThis.document.createElement('div');
+      el.style.color = globalThis
+        .getComputedStyle(globalThis.document.documentElement)
+        .getPropertyValue('--color-accent');
+      globalThis.document.body.appendChild(el);
+      const rgb = globalThis.getComputedStyle(el).color;
+      el.remove();
+      return rgb;
+    });
+
+    expect(isOrangeRed(accentRgb)).toBe(true);
+  });
+
+  test('primary buttons use accent color as background', async ({ page }) => {
+    await page.goto('/en');
+    await page.waitForLoadState('networkidle');
+
+    const btn = page.locator('.primary').first();
+    const bg = await btn.evaluate((el) => globalThis.getComputedStyle(el).backgroundColor);
+    expect(isOrangeRed(bg)).toBe(true);
+  });
+});

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -5,8 +5,8 @@
   --color-text-primary: hsl(0, 0%, 13%);
   --color-text-secondary: hsl(0, 0%, 40%);
   --color-border: hsl(0, 0%, 90%);
-  --color-accent: hsl(250, 84%, 54%);
-  --color-accent-hover: hsl(250, 84%, 48%);
+  --color-accent: hsl(12, 80%, 45%);
+  --color-accent-hover: hsl(12, 80%, 38%);
 
   --spacing-xs: 0.5rem;
   --spacing-sm: 1rem;
@@ -39,8 +39,8 @@
   --color-text-primary: hsl(0, 0%, 95%);
   --color-text-secondary: hsl(0, 0%, 65%);
   --color-border: hsl(0, 0%, 25%);
-  --color-accent: hsl(250, 84%, 60%);
-  --color-accent-hover: hsl(250, 84%, 70%);
+  --color-accent: hsl(14, 85%, 60%);
+  --color-accent-hover: hsl(14, 85%, 68%);
 
   color-scheme: dark;
 }


### PR DESCRIPTION
## Summary\n- Light theme: hsl(12, 80%, 45%) / hover hsl(12, 80%, 38%)\n- Dark theme: hsl(14, 85%, 60%) / hover hsl(14, 85%, 68%)\n- WCAG AA compliant contrast ratios in both themes\n\n## Tests\n- 3 new E2E tests (28/28 total pass)\n- Manual verification: both light and dark themes confirmed\n\nCloses #1