### PR TITLE
fix(admin-website#26): only surface languages with baseline content

### DIFF
--- a/src/config/ready-languages.ts
+++ b/src/config/ready-languages.ts
@@ -1,0 +1,52 @@
+import { getCollection } from 'astro:content';
+import { type Language, SUPPORTED_LANGUAGES } from './i18n';
+
+/**
+ * Slugs that must exist in every "ready" language. Advertising a
+ * language on the public site without these guarantees at least a
+ * usable home page, menu, and primary content pages.
+ */
+export const BASELINE_SLUGS: readonly {
+  readonly collection: 'pages' | 'common';
+  readonly slug: string;
+}[] = [
+  { collection: 'pages', slug: 'home' },
+  { collection: 'pages', slug: 'manifest' },
+  { collection: 'common', slug: 'menu' },
+  { collection: 'common', slug: 'labels' },
+];
+
+const langHas = async (
+  collection: 'pages' | 'common',
+  slug: string,
+  lang: Language,
+): Promise<boolean> => {
+  const entries = await getCollection(collection, ({ data }) => data.lang === lang);
+  return entries.some((e) => e.id.startsWith(`${slug}/`));
+};
+
+const isLangReady = async (lang: Language): Promise<boolean> => {
+  const checks = await Promise.all(BASELINE_SLUGS.map((b) => langHas(b.collection, b.slug, lang)));
+  return checks.every(Boolean);
+};
+
+/**
+ * Return the subset of SUPPORTED_LANGUAGES that actually has the
+ * baseline pages/common entries. Used by `getStaticPaths` on every
+ * `[lang]/*` route and by the public language switcher so that adding
+ * a code to `settings/languages.json` alone never creates dead links.
+ *
+ * @returns list of ready language codes in the order they appear in
+ * the settings file; falls back to the default language when nothing
+ * qualifies.
+ */
+export const getReadyLanguages = async (): Promise<readonly Language[]> => {
+  const checks = await Promise.all(
+    SUPPORTED_LANGUAGES.map(async (lang) => ({
+      lang,
+      ready: await isLangReady(lang),
+    })),
+  );
+  const ready = checks.filter((c) => c.ready).map((c) => c.lang);
+  return ready.length > 0 ? ready : [SUPPORTED_LANGUAGES[0] ?? 'en'];
+};

--- a/src/features/navigation/components/LanguageSwitcher.astro
+++ b/src/features/navigation/components/LanguageSwitcher.astro
@@ -1,12 +1,14 @@
 ---
 import type { Language } from '@/config/i18n';
-import { LANGUAGE_LABELS, SUPPORTED_LANGUAGES } from '@/config/i18n';
+import { LANGUAGE_LABELS } from '@/config/i18n';
+import { getReadyLanguages } from '@/config/ready-languages';
 
 interface Props {
   lang: Language;
 }
 
 const { lang } = Astro.props;
+const readyLangs = await getReadyLanguages();
 ---
 
 <div class="lang-switcher" data-testid="language-switcher">
@@ -28,7 +30,7 @@ const { lang } = Astro.props;
     aria-label="Available languages"
     data-testid="language-dropdown"
   >
-    {SUPPORTED_LANGUAGES.map((code) => (
+    {readyLangs.map((code) => (
       <li role="option" aria-selected={code === lang}>
         <a
           href={`/${code}`}

--- a/src/pages/[lang]/blog/index.astro
+++ b/src/pages/[lang]/blog/index.astro
@@ -1,5 +1,5 @@
 ---
-import { SUPPORTED_LANGUAGES } from '@/config/i18n';
+import { getReadyLanguages } from '@/config/ready-languages';
 import { getLabelsData, getPageData } from '@/config/translations';
 import CategoryFilter from '@/features/blog/components/CategoryFilter.astro';
 import PostCard from '@/features/blog/components/PostCard.astro';
@@ -10,7 +10,8 @@ import {
 } from '@/features/blog/helpers/getBlogPosts';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
-export const getStaticPaths = () => SUPPORTED_LANGUAGES.map((lang) => ({ params: { lang } }));
+export const getStaticPaths = async () =>
+  (await getReadyLanguages()).map((lang) => ({ params: { lang } }));
 
 const { lang } = Astro.params;
 

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -1,5 +1,6 @@
 ---
-import { SUPPORTED_LANGUAGES } from '@/config/i18n';
+import { DEFAULT_LANGUAGE } from '@/config/i18n';
+import { getReadyLanguages } from '@/config/ready-languages';
 import { getPageData } from '@/config/translations';
 import { getBlogPosts } from '@/features/blog/helpers/getBlogPosts';
 import Hero from '@/features/home/components/Hero.astro';
@@ -8,7 +9,8 @@ import PositionsWidget from '@/features/positions/components/PositionsWidget.ast
 import { getPositions } from '@/features/positions/helpers/getPositions';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
-export const getStaticPaths = () => SUPPORTED_LANGUAGES.map((lang) => ({ params: { lang } }));
+export const getStaticPaths = async () =>
+  (await getReadyLanguages()).map((lang) => ({ params: { lang } }));
 
 const { lang } = Astro.params;
 
@@ -18,8 +20,8 @@ const latestPosts = posts.slice(0, 3);
 const positions = await getPositions(lang);
 const latestPositions = positions.slice(0, 3);
 
-const homePage = await getPageData('home', lang);
-if (!homePage) return Astro.redirect(`/${lang}`);
+const homePage = (await getPageData('home', lang)) ?? (await getPageData('home', DEFAULT_LANGUAGE));
+if (!homePage) return Astro.redirect(`/${DEFAULT_LANGUAGE}`);
 
 const { Content } = await homePage.render();
 const { title, description, heroTitle, latestNews, viewAllPosts } = homePage.data;

--- a/src/pages/[lang]/manifest.astro
+++ b/src/pages/[lang]/manifest.astro
@@ -1,18 +1,21 @@
 ---
 import { getCollection } from 'astro:content';
-import { SUPPORTED_LANGUAGES } from '@/config/i18n';
+import { DEFAULT_LANGUAGE } from '@/config/i18n';
+import { getReadyLanguages } from '@/config/ready-languages';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
-export const getStaticPaths = () => SUPPORTED_LANGUAGES.map((lang) => ({ params: { lang } }));
+export const getStaticPaths = async () =>
+  (await getReadyLanguages()).map((lang) => ({ params: { lang } }));
 
 const { lang } = Astro.params;
 
-const manifestPages = await getCollection('pages', ({ data }) => data.lang === lang);
-const page = manifestPages.find((p) => p.id.startsWith('manifest/'));
+const manifestIn = async (l: string) => {
+  const pages = await getCollection('pages', ({ data }) => data.lang === l);
+  return pages.find((p) => p.id.startsWith('manifest/'));
+};
+const page = (await manifestIn(lang)) ?? (await manifestIn(DEFAULT_LANGUAGE));
 
-if (!page) {
-  return Astro.redirect(`/${lang}`);
-}
+if (!page) return Astro.redirect(`/${DEFAULT_LANGUAGE}`);
 
 const { Content } = await page.render();
 ---

--- a/src/pages/[lang]/newspaper/index.astro
+++ b/src/pages/[lang]/newspaper/index.astro
@@ -1,11 +1,12 @@
 ---
-import { SUPPORTED_LANGUAGES } from '@/config/i18n';
+import { getReadyLanguages } from '@/config/ready-languages';
 import { getLabelsData } from '@/config/translations';
 import NewspaperCard from '@/features/newspaper/components/NewspaperCard.astro';
 import { getNewspaperItems } from '@/features/newspaper/helpers/getNewspaperItems';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
-export const getStaticPaths = () => SUPPORTED_LANGUAGES.map((lang) => ({ params: { lang } }));
+export const getStaticPaths = async () =>
+  (await getReadyLanguages()).map((lang) => ({ params: { lang } }));
 
 const { lang } = Astro.params;
 

--- a/src/pages/[lang]/positions/index.astro
+++ b/src/pages/[lang]/positions/index.astro
@@ -1,11 +1,12 @@
 ---
-import { SUPPORTED_LANGUAGES } from '@/config/i18n';
+import { getReadyLanguages } from '@/config/ready-languages';
 import { getLabelsData, getPageData } from '@/config/translations';
 import PositionCard from '@/features/positions/components/PositionCard.astro';
 import { getPositions } from '@/features/positions/helpers/getPositions';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
-export const getStaticPaths = () => SUPPORTED_LANGUAGES.map((lang) => ({ params: { lang } }));
+export const getStaticPaths = async () =>
+  (await getReadyLanguages()).map((lang) => ({ params: { lang } }));
 
 const { lang } = Astro.params;
 


### PR DESCRIPTION
Closes communist-prometheus/admin-website#26.

## Summary
Adding a language in the admin (settings/languages.json) used to light up `/${code}/*` routes with zero content, triggering an infinite redirect on the home page and dead links in the switcher. Now a language is **ready** only when all four baseline entries exist (`pages/home`, `pages/manifest`, `common/menu`, `common/labels`); not-ready languages are never pre-rendered nor offered in the UI.

## Changes
- `src/config/ready-languages.ts` — `getReadyLanguages()` filter.
- `[lang]/*` pages — `getStaticPaths` uses the filter; home / manifest fall back to the default-language entry instead of looping.
- `LanguageSwitcher.astro` — only lists ready languages.

## Verified
- `bun run build` — 60 pages generated, all checks green.

🤖 Generated with Claude Code