### PR TITLE
fix(admin-website#26): generate blog/positions detail pages for every language

### DIFF
--- a/e2e/language-coverage.pw.ts
+++ b/e2e/language-coverage.pw.ts
@@ -5,11 +5,15 @@ import { expect, test } from '@playwright/test';
 
 /**
  * Regression: every language in settings/languages.json must (a) appear
- * in the switcher, (b) have a working /{code}/ route, (c) render with
- * the correct <html lang> attribute, (d) keep all five top-level pages
- * reachable. Previously a "ready-language" filter silently hid any
- * freshly-added code and emitted zero static paths for it, leaving
- * the new-language flow broken on prod.
+ * in the switcher, (b) have a working /{code}/ route + /{code}/{page}
+ * for every top-level page, (c) render with the correct <html lang>
+ * attribute, (d) have working detail pages for blog / positions that
+ * fall back to the default-language content, (e) survive an actual
+ * switcher click from any page to any other language WITHOUT landing
+ * on a 404. Previously a "ready-language" filter silently hid any
+ * freshly-added code and emitted zero static paths for it, and even
+ * after that fix a click from /en/blog/<slug> to /uk/ landed on a 404
+ * because the per-article route was not emitted for the new language.
  */
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -22,14 +26,14 @@ interface LangEntry {
 
 const languages = JSON.parse(readFileSync(settingsPath, 'utf8')) as LangEntry[];
 const codes = languages.map((l) => l.code);
-const paths = ['', '/manifest', '/blog', '/positions', '/newspaper'] as const;
+const pages = ['', '/manifest', '/blog', '/positions', '/newspaper'] as const;
 
 const switcherSel = 'header .desktop-only [data-testid="language-switcher"]';
 
 test.describe('Language coverage — every code in settings must work', () => {
   for (const { code, label } of languages) {
     test.describe(`${label} (${code})`, () => {
-      for (const p of paths) {
+      for (const p of pages) {
         test(`/${code}${p} renders with lang="${code}"`, async ({ page }) => {
           const res = await page.goto(`/${code}${p}`, {
             waitUntil: 'domcontentloaded',
@@ -60,4 +64,60 @@ test.describe('Language coverage — every code in settings must work', () => {
       );
     expect(new Set(rendered)).toEqual(new Set(codes));
   });
+});
+
+test.describe('Language coverage — detail pages do not 404 on new langs', () => {
+  const detailProbes = [
+    '/blog/welcome-to-prometheus',
+    '/blog/modern-web-development',
+    '/positions/digital-sovereignty',
+  ] as const;
+
+  for (const code of codes) {
+    for (const detail of detailProbes) {
+      test(`/${code}${detail} renders (fallback OK)`, async ({ page }) => {
+        const res = await page.goto(`/${code}${detail}`, {
+          waitUntil: 'domcontentloaded',
+        });
+        expect(res?.status(), `status for /${code}${detail}`).toBeLessThan(400);
+        await expect(page.locator('h1').first()).toBeVisible();
+      });
+    }
+  }
+});
+
+test.describe('Language coverage — switcher click never lands on 404', () => {
+  /*
+   * A compact but representative matrix so this test finishes quickly.
+   * Covers the two classes that used to break: a new language as the
+   * target (uk, bl, pl, it) and a listing / article page as the start.
+   */
+  const clicks: readonly { readonly from: string; readonly target: string }[] = [
+    { from: '/en/', target: 'uk' },
+    { from: '/en/blog', target: 'uk' },
+    { from: '/en/blog/welcome-to-prometheus', target: 'uk' },
+    { from: '/en/positions/digital-sovereignty', target: 'uk' },
+    { from: '/ru/blog', target: 'bl' },
+    { from: '/uk/blog/welcome-to-prometheus', target: 'en' },
+    { from: '/pl/manifest', target: 'it' },
+    { from: '/bl/', target: 'pl' },
+  ];
+
+  for (const { from, target } of clicks) {
+    test(`${from} → click ${target} stays < 400`, async ({ page }) => {
+      const documentStatuses: number[] = [];
+      page.on('response', (resp) => {
+        if (resp.request().resourceType() === 'document') {
+          documentStatuses.push(resp.status());
+        }
+      });
+      await page.goto(from, { waitUntil: 'domcontentloaded' });
+      await page.locator(switcherSel).click();
+      await page.locator(`${switcherSel} [data-testid="lang-option-${target}"]`).click();
+      await page.waitForURL(new RegExp(`/${target}(/|$)`), { timeout: 10_000 });
+      const last = documentStatuses.at(-1);
+      expect(last, `last document status for ${from} → ${target}`).toBeLessThan(400);
+      await expect(page.locator('h1').first()).toBeVisible();
+    });
+  }
 });

--- a/src/pages/[lang]/blog/[...slug].astro
+++ b/src/pages/[lang]/blog/[...slug].astro
@@ -1,15 +1,20 @@
 ---
 import { getCollection } from 'astro:content';
+import { DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES } from '@/config/i18n';
 import BlogPicture from '@/features/blog/components/BlogPicture.astro';
 import { getArticleSlug } from '@/features/blog/helpers/getBlogPosts';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
 export const getStaticPaths = async () => {
   const posts = await getCollection('blog');
-  return posts.map((post) => ({
-    params: { lang: post.data.lang, slug: getArticleSlug(post) },
-    props: { post },
-  }));
+  const slugs = new Set(posts.map((p) => getArticleSlug(p)));
+  const byKey = new Map(posts.map((p) => [`${p.data.lang}/${getArticleSlug(p)}`, p] as const));
+  return SUPPORTED_LANGUAGES.flatMap((lang) =>
+    [...slugs].flatMap((slug) => {
+      const post = byKey.get(`${lang}/${slug}`) ?? byKey.get(`${DEFAULT_LANGUAGE}/${slug}`);
+      return post ? [{ params: { lang, slug }, props: { post } }] : [];
+    }),
+  );
 };
 
 const { post } = Astro.props;

--- a/src/pages/[lang]/positions/[...slug].astro
+++ b/src/pages/[lang]/positions/[...slug].astro
@@ -1,20 +1,26 @@
 ---
 import { getCollection } from 'astro:content';
+import { DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES } from '@/config/i18n';
 import { getLabelsData } from '@/config/translations';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
 export const getStaticPaths = async () => {
+  const slugFrom = (id: string) => id.split('/').at(0) ?? id;
   const entries = await getCollection('positions');
-  return entries.map((entry) => ({
-    params: { lang: entry.data.lang, slug: entry.id.split('/').at(0) ?? entry.id },
-    props: { entry },
-  }));
+  const slugs = new Set(entries.map((e) => slugFrom(e.id)));
+  const byKey = new Map(entries.map((e) => [`${e.data.lang}/${slugFrom(e.id)}`, e] as const));
+  return SUPPORTED_LANGUAGES.flatMap((lang) =>
+    [...slugs].flatMap((slug) => {
+      const entry = byKey.get(`${lang}/${slug}`) ?? byKey.get(`${DEFAULT_LANGUAGE}/${slug}`);
+      return entry ? [{ params: { lang, slug }, props: { entry } }] : [];
+    }),
+  );
 };
 
 const { entry } = Astro.props;
 const { lang } = Astro.params;
 const { Content } = await entry.render();
-const labels = await getLabelsData(lang);
+const labels = (await getLabelsData(lang)) ?? (await getLabelsData(DEFAULT_LANGUAGE));
 const backLabel = labels?.data.backToList ?? '← Back';
 ---
 


### PR DESCRIPTION
Re-opens and finishes off communist-prometheus/admin-website#26.

## What was still broken after the previous two PRs
Switcher showed every language, `/uk/`, `/uk/blog`, `/uk/manifest` etc. rendered. But clicking **uk** from `/en/blog/welcome-to-prometheus` dropped the user on `/uk/blog/welcome-to-prometheus` — hard 404 from Cloudflare, because `getStaticPaths` for `[lang]/blog/[...slug].astro` emitted only `(lang, slug)` pairs for which an actual translation existed. Same for positions detail.

## Fix
- `[lang]/blog/[...slug].astro` + `[lang]/positions/[...slug].astro`: emit **every** `(lang, slug)` pair from `SUPPORTED_LANGUAGES × unique-slugs`, falling back to the default-language entry when the specific translation is missing. `/uk/blog/welcome-to-prometheus` now renders the English article with `<html lang="uk">` until an `index.uk.md` is written.

## Regression coverage added
- `e2e/language-coverage.pw.ts` now contains three sweeps:
  1. Every `/code/` + five top-level pages per code.
  2. Blog / position detail URLs for every code against a representative slug list (would have caught the 404).
  3. An actual switcher click matrix — clicks an option and asserts the final document status stays below 400.

## Local
- `bun run build` — 156 pages (was 75).
- `npx playwright test e2e/language-coverage.pw.ts` — 72/72.

🤖 Generated with Claude Code