### PR TITLE
fix(admin-website#26): header nav + switcher href survive new languages

### DIFF
--- a/e2e/language-coverage.pw.ts
+++ b/e2e/language-coverage.pw.ts
@@ -66,6 +66,75 @@ test.describe('Language coverage — every code in settings must work', () => {
   });
 });
 
+test.describe('Language coverage — every page has a full header nav', () => {
+  /*
+   * The top header nav is driven by getNavLinks(lang), which in turn
+   * reads common/menu. Without a per-language fallback the nav
+   * silently disappeared on every page whose language had no menu
+   * translation — the visible break the user filed the bug about.
+   */
+  const probes = [
+    '/',
+    '/manifest',
+    '/blog',
+    '/positions',
+    '/newspaper',
+    '/blog/welcome-to-prometheus',
+  ] as const;
+
+  for (const code of codes) {
+    for (const p of probes) {
+      test(`/${code}${p} header nav has links`, async ({ page }) => {
+        await page.goto(`/${code}${p}`, { waitUntil: 'domcontentloaded' });
+        const navLinks = await page
+          .locator('[data-testid="desktop-nav"] a')
+          .evaluateAll((els) => els.map((el) => (el as HTMLAnchorElement).getAttribute('href')));
+        expect(navLinks.length, `nav links on /${code}${p}`).toBeGreaterThanOrEqual(4);
+        expect(navLinks).toEqual(
+          expect.arrayContaining([
+            `/${code}`,
+            `/${code}/blog`,
+            `/${code}/positions`,
+            `/${code}/manifest`,
+          ]),
+        );
+      });
+    }
+  }
+});
+
+test.describe('Language coverage — switcher href is path-aware', () => {
+  /*
+   * The switcher <a href> must preserve the current path, not point
+   * at /{code}. Otherwise middle-click / right-click / Ctrl+click /
+   * pre-hydration click drops the user on the language root instead
+   * of the same article in the new language.
+   */
+  const here = [
+    '/en/',
+    '/en/blog',
+    '/en/blog/welcome-to-prometheus',
+    '/en/positions/digital-sovereignty',
+    '/uk/blog/welcome-to-prometheus',
+  ] as const;
+
+  for (const from of here) {
+    for (const target of codes) {
+      test(`href on ${from} for ${target} preserves path`, async ({ page }) => {
+        await page.goto(from, { waitUntil: 'domcontentloaded' });
+        const href = await page
+          .locator(`${switcherSel} [data-testid="lang-option-${target}"]`)
+          .first()
+          .getAttribute('href');
+        const expected = from.replace(/^\/[a-z]{2}/, `/${target}`).replace(/\/$/, '');
+        const normalised = (href ?? '').replace(/\/$/, '');
+        const wanted = expected === '' ? `/${target}` : expected;
+        expect(normalised, `href on ${from} for ${target}`).toBe(wanted);
+      });
+    }
+  }
+});
+
 test.describe('Language coverage — detail pages do not 404 on new langs', () => {
   const detailProbes = [
     '/blog/welcome-to-prometheus',

--- a/src/config/translations.ts
+++ b/src/config/translations.ts
@@ -1,27 +1,68 @@
 import type { CollectionEntry } from 'astro:content';
 import { getCollection } from 'astro:content';
-import type { Language } from './i18n';
+import { DEFAULT_LANGUAGE, type Language } from './i18n';
 
-export const getPageData = async (
+const findIn = async (
+  collection: 'pages' | 'common',
   slug: string,
   lang: Language,
-): Promise<CollectionEntry<'pages'> | undefined> => {
-  const pages = await getCollection('pages', ({ data }) => data.lang === lang);
-  return pages.find((p) => p.id.startsWith(`${slug}/`));
-};
-
-export const getCommonData = async (
-  slug: string,
-  lang: Language,
-): Promise<CollectionEntry<'common'> | undefined> => {
-  const entries = await getCollection('common', ({ data }) => data.lang === lang);
+): Promise<CollectionEntry<'pages'> | CollectionEntry<'common'> | undefined> => {
+  const entries = await getCollection(collection, ({ data }) => data.lang === lang);
   return entries.find((e) => e.id.startsWith(`${slug}/`));
 };
 
-export const getMenuData = async (lang: Language) => getCommonData('menu', lang);
+const withFallback = async <T extends 'pages' | 'common'>(
+  collection: T,
+  slug: string,
+  lang: Language,
+): Promise<CollectionEntry<T> | undefined> => {
+  const direct = (await findIn(collection, slug, lang)) as CollectionEntry<T> | undefined;
+  if (direct) return direct;
+  if (lang === DEFAULT_LANGUAGE) return undefined;
+  return (await findIn(collection, slug, DEFAULT_LANGUAGE)) as CollectionEntry<T> | undefined;
+};
 
-export const getLabelsData = async (lang: Language) => getCommonData('labels', lang);
+/**
+ * Fetch a page entry for the given language, falling back to the
+ * default-language entry when the requested translation is missing.
+ * Keeps /{lang}/<page> functional for languages that haven't been
+ * translated yet.
+ *
+ * @param slug page slug (e.g. 'home', 'manifest')
+ * @param lang target language
+ * @returns entry in requested language or default fallback
+ */
+export const getPageData = (
+  slug: string,
+  lang: Language,
+): Promise<CollectionEntry<'pages'> | undefined> => withFallback('pages', slug, lang);
 
+/**
+ * Fetch a common-content entry for the given language, falling back
+ * to the default-language entry when missing.
+ *
+ * @param slug entry slug
+ * @param lang target language
+ * @returns entry or undefined
+ */
+export const getCommonData = (
+  slug: string,
+  lang: Language,
+): Promise<CollectionEntry<'common'> | undefined> => withFallback('common', slug, lang);
+
+export const getMenuData = (lang: Language) => getCommonData('menu', lang);
+
+export const getLabelsData = (lang: Language) => getCommonData('labels', lang);
+
+/**
+ * Resolve the navigation links for a language. Uses the menu entry
+ * with default-language fallback so that newly-added languages still
+ * show a working nav until their own translation lands.
+ *
+ * @param lang target language
+ * @returns nav-link tuples, or [] only when even the default lang
+ * has no menu entry (broken state)
+ */
 export const getNavLinks = async (lang: Language) => {
   const menu = await getMenuData(lang);
   if (!menu) return [];

--- a/src/features/navigation/components/LanguageSwitcher.astro
+++ b/src/features/navigation/components/LanguageSwitcher.astro
@@ -7,6 +7,13 @@ interface Props {
 }
 
 const { lang } = Astro.props;
+
+// Build a per-language href that preserves the current path instead
+// of pointing at the bare `/{code}` root. Critical for middle-click,
+// right-click "open in new tab", keyboard "copy link", and any code
+// path where the JS click handler below does not fire.
+const rest = Astro.url.pathname.replace(/^\/[a-z]{2}(?=\/|$)/, '');
+const hrefFor = (code: string) => (rest === '' ? `/${code}` : `/${code}${rest}`);
 ---
 
 <div class="lang-switcher" data-testid="language-switcher">
@@ -31,7 +38,7 @@ const { lang } = Astro.props;
     {SUPPORTED_LANGUAGES.map((code) => (
       <li role="option" aria-selected={code === lang}>
         <a
-          href={`/${code}`}
+          href={hrefFor(code)}
           data-lang={code}
           data-testid={`lang-option-${code}`}
           class:list={['lang-option', { active: code === lang }]}
@@ -88,18 +95,13 @@ const { lang } = Astro.props;
       }
     });
 
+    // Native anchor href is now server-rendered with the correct
+    // per-page path, so we just close the dropdown and let the
+    // browser (or astro view-transitions) follow the link. Handling
+    // Ctrl/Cmd/middle-click is automatic this way — they open in a
+    // new tab pointing at the correct article URL.
     dropdown.querySelectorAll<HTMLAnchorElement>('.lang-option').forEach((option) => {
-      option.addEventListener('click', (e: MouseEvent) => {
-        e.preventDefault();
-        const targetLang = option.dataset['lang'];
-        if (!targetLang) return;
-
-        const path = globalThis.location.pathname;
-        const newPath = path.replace(/^\/[a-z]{2}/, `/${targetLang}`);
-
-        close();
-        globalThis.location.href = newPath;
-      });
+      option.addEventListener('click', () => close());
     });
 
     updateCurrentLang();


### PR DESCRIPTION
The previous two fixes emitted the static paths and removed 404s, but visually the switcher STILL looked broken: after clicking uk from an /en/* page, the top navigation went blank. getNavLinks(lang) returned [] whenever common/menu for the target lang was missing, and the switcher <a href> pointed at the bare /{code} root so any non-left-click dropped the user on the language root instead of the same article.

## Fix
- `src/config/translations.ts`: `getPageData` / `getCommonData` now fall back to `DEFAULT_LANGUAGE` centrally. All call sites (menu, labels, page entries) inherit the fallback.
- `LanguageSwitcher.astro`: `<a href>` is server-rendered from `Astro.url.pathname` with the lang prefix swapped. JS handler reduced to just closing the dropdown; native anchor behaviour handles middle-click / Ctrl+click / pre-hydration.
- `e2e/language-coverage.pw.ts` extended with:
  - nav-has-links sweep across every code × top-level page;
  - server href path-preservation sweep.

## Verified
- `bun run build` — 156 pages.
- `npx playwright test e2e/language-coverage.pw.ts` — 149/149.

🤖 Generated with Claude Code