### PR TITLE
fix: refresh switcher hrefs on astro:after-swap + relax existing tests

### DIFF
--- a/e2e/language-switcher.pw.ts
+++ b/e2e/language-switcher.pw.ts
@@ -30,7 +30,7 @@ test.describe('Language switcher - Desktop', () => {
     await expect(ruOption).toBeVisible();
     await ruOption.click();
 
-    await page.waitForURL('**/ru/blog');
+    await page.waitForURL(/\/ru\/blog\/?$/);
     await expect(page.locator('h1')).toBeVisible();
   });
 
@@ -45,7 +45,7 @@ test.describe('Language switcher - Desktop', () => {
     await expect(enOption).toBeVisible();
     await enOption.click();
 
-    await page.waitForURL('**/en/manifest');
+    await page.waitForURL(/\/en\/manifest\/?$/);
     await expect(page.locator('h1')).toBeVisible();
   });
 
@@ -59,7 +59,7 @@ test.describe('Language switcher - Desktop', () => {
     const ruOption = switcher.locator('[data-testid="lang-option-ru"]');
     await ruOption.click();
 
-    await page.waitForURL('**/ru');
+    await page.waitForURL(/\/ru\/?$/);
     await expect(page).toHaveURL(/\/ru\/?$/);
   });
 
@@ -97,7 +97,7 @@ test.describe('Language switcher - Desktop', () => {
     await page.waitForLoadState('networkidle');
 
     await page.locator(`${desktopNav} a[href="/en/blog"]`).click();
-    await page.waitForURL('**/en/blog');
+    await page.waitForURL(/\/en\/blog\/?$/);
 
     const switcher = page.locator(switcherSel);
     await switcher.click();
@@ -106,6 +106,6 @@ test.describe('Language switcher - Desktop', () => {
     await expect(ruOption).toBeVisible();
     await ruOption.click();
 
-    await page.waitForURL('**/ru/blog');
+    await page.waitForURL(/\/ru\/blog\/?$/);
   });
 });

--- a/e2e/new-languages.pw.ts
+++ b/e2e/new-languages.pw.ts
@@ -89,7 +89,7 @@ for (const lang of languages) {
       const option = switcher.locator(`[data-testid="lang-option-${lang.code}"]`);
       await option.click();
 
-      await page.waitForURL(`**/${lang.code}/blog`);
+      await page.waitForURL(new RegExp(`/${lang.code}/blog/?$`));
       await expect(page.locator('h1')).toBeVisible();
     });
   });

--- a/src/features/navigation/components/LanguageSwitcher.astro
+++ b/src/features/navigation/components/LanguageSwitcher.astro
@@ -95,14 +95,13 @@ const hrefFor = (code: string) => (rest === '' ? `/${code}` : `/${code}${rest}`)
       }
     });
 
-    // Native anchor href is now server-rendered with the correct
-    // per-page path, so we just close the dropdown and let the
-    // browser (or astro view-transitions) follow the link. Handling
-    // Ctrl/Cmd/middle-click is automatic this way — they open in a
-    // new tab pointing at the correct article URL.
-    dropdown.querySelectorAll<HTMLAnchorElement>('.lang-option').forEach((option) => {
-      option.addEventListener('click', () => close());
-    });
+    // The anchor href is server-rendered with the correct per-page
+    // path, so native navigation handles every flavour of click
+    // (left / middle / Ctrl / keyboard). We do NOT attach a click
+    // listener here: calling `close()` flips `visibility: hidden`
+    // on the dropdown mid-click, which can abort the left-click's
+    // default navigation on some browsers. The dropdown naturally
+    // disappears once the whole document swaps under us.
 
     updateCurrentLang();
 
@@ -111,11 +110,17 @@ const hrefFor = (code: string) => (rest === '' ? `/${code}` : `/${code}${rest}`)
       const langMatch = path.match(/^\/([a-z]{2})/);
       const activeLang = langMatch?.[1] ?? 'en';
 
+      // Rest of the path after the lang prefix. Keep the trailing
+      // slash that Astro uses so the anchor href matches the
+      // canonical static URL exactly (no extra 307 hop).
+      const rest = path.replace(/^\/[a-z]{2}(?=\/|$)/, '');
+
       const label = switcher.querySelector<HTMLElement>('.lang-current');
       if (label) label.textContent = activeLang.toUpperCase();
 
       switcher.querySelectorAll<HTMLAnchorElement>('.lang-option').forEach((option) => {
         const optionLang = option.dataset['lang'];
+        if (optionLang) option.href = rest === '' ? `/${optionLang}` : `/${optionLang}${rest}`;
         option.classList.toggle('active', optionLang === activeLang);
         option.closest('li')?.setAttribute('aria-selected', String(optionLang === activeLang));
       });


### PR DESCRIPTION
Follow-up to #33 which landed but its CI deploy failed on two existing tests that asserted the pre-slash URL.

## Bugs shipped in #33
1. `<header transition:persist>` freezes the server-rendered switcher hrefs at the original landing page. After an SPA nav they still pointed at `/{code}/`, dropping users on the language root instead of the same article.
2. Existing `language-switcher.pw.ts` and `new-languages.pw.ts` used `waitForURL("**/ru/blog")` — the old switcher hit `/ru/blog` (no slash) which got 307→`/ru/blog/`; test pattern matched the pre-redirect URL. Now that the href is canonical with trailing slash, navigation goes straight to `/ru/blog/` and the glob never matches.

## Fix
- `LanguageSwitcher.astro`: `updateCurrentLang` (runs on load + `astro:after-swap`) rewrites every option `href` from the current path. SPA navigation now survives correctly.
- `e2e/language-switcher.pw.ts` + `e2e/new-languages.pw.ts`: replaced the glob with a trailing-slash-tolerant regex.

## Verified
- `bun run build` — 156 pages.
- `npx playwright test --project=chromium` — **212/212** green.

🤖 Generated with Claude Code