### PR TITLE
fix(admin-website#26): unpin header so nav + switcher reflect current lang after SPA

### DIFF
--- a/e2e/language-coverage.pw.ts
+++ b/e2e/language-coverage.pw.ts
@@ -187,6 +187,18 @@ test.describe('Language coverage — switcher click never lands on 404', () => {
       const last = documentStatuses.at(-1);
       expect(last, `last document status for ${from} → ${target}`).toBeLessThan(400);
       await expect(page.locator('h1').first()).toBeVisible();
+      // Nav must also reflect the new language. The visible bug was
+      // that clicking uk moved the URL but the header nav still
+      // said Home→/en, Blog→/en/blog because
+      // <header transition:persist> froze it at the landing page.
+      const navLangs = await page
+        .locator('[data-testid="desktop-nav"] a')
+        .evaluateAll((els) =>
+          els
+            .map((el) => (el as HTMLAnchorElement).getAttribute('href') ?? '')
+            .map((h) => h.match(/^\/([a-z]{2})/)?.[1]),
+        );
+      expect(new Set(navLangs), `nav langs after ${from} → ${target}`).toEqual(new Set([target]));
     });
   }
 });

--- a/e2e/language-switcher.pw.ts
+++ b/e2e/language-switcher.pw.ts
@@ -30,7 +30,7 @@ test.describe('Language switcher - Desktop', () => {
     await expect(ruOption).toBeVisible();
     await ruOption.click();
 
-    await page.waitForURL('**/ru/blog');
+    await page.waitForURL(/\/ru\/blog\/?$/);
     await expect(page.locator('h1')).toBeVisible();
   });
 
@@ -45,7 +45,7 @@ test.describe('Language switcher - Desktop', () => {
     await expect(enOption).toBeVisible();
     await enOption.click();
 
-    await page.waitForURL('**/en/manifest');
+    await page.waitForURL(/\/en\/manifest\/?$/);
     await expect(page.locator('h1')).toBeVisible();
   });
 
@@ -59,7 +59,7 @@ test.describe('Language switcher - Desktop', () => {
     const ruOption = switcher.locator('[data-testid="lang-option-ru"]');
     await ruOption.click();
 
-    await page.waitForURL('**/ru');
+    await page.waitForURL(/\/ru\/?$/);
     await expect(page).toHaveURL(/\/ru\/?$/);
   });
 
@@ -97,7 +97,7 @@ test.describe('Language switcher - Desktop', () => {
     await page.waitForLoadState('networkidle');
 
     await page.locator(`${desktopNav} a[href="/en/blog"]`).click();
-    await page.waitForURL('**/en/blog');
+    await page.waitForURL(/\/en\/blog\/?$/);
 
     const switcher = page.locator(switcherSel);
     await switcher.click();
@@ -106,6 +106,6 @@ test.describe('Language switcher - Desktop', () => {
     await expect(ruOption).toBeVisible();
     await ruOption.click();
 
-    await page.waitForURL('**/ru/blog');
+    await page.waitForURL(/\/ru\/blog\/?$/);
   });
 });

--- a/e2e/new-languages.pw.ts
+++ b/e2e/new-languages.pw.ts
@@ -89,7 +89,7 @@ for (const lang of languages) {
       const option = switcher.locator(`[data-testid="lang-option-${lang.code}"]`);
       await option.click();
 
-      await page.waitForURL(`**/${lang.code}/blog`);
+      await page.waitForURL(new RegExp(`/${lang.code}/blog/?$`));
       await expect(page.locator('h1')).toBeVisible();
     });
   });

--- a/src/features/navigation/components/Header.astro
+++ b/src/features/navigation/components/Header.astro
@@ -12,7 +12,7 @@ interface Props {
 const { lang } = Astro.props;
 ---
 
-<header transition:persist="header">
+<header>
   <div class="header-container">
     <div class="header-content">
       <a href={`/${lang}`} class="logo">Prometheus</a>


### PR DESCRIPTION
The visible bug the user kept pointing at: click uk from /en/blog/<post>, URL changes to /uk/..., body switches to fallback — BUT the header nav (Home/Blog/Positions/...) still points at /en/... because `<header transition:persist>` froze it at the original landing.

## Fix
- Remove `transition:persist` from `<header>`. It now re-renders on every page load / SPA swap with the correct `lang` prop.
- Fix existing `language-switcher.pw.ts` and `new-languages.pw.ts` which used `waitForURL("**/ru/blog")` and accidentally matched only the pre-redirect URL. Trailing-slash-tolerant regex now.
- `e2e/language-coverage.pw.ts`: after every switcher click, assert every header nav href starts with the target language — exactly the regression this PR cures.

## Verified
- `bun run build` — 156 pages.
- Full playwright suite — 212/212.