### PR TITLE
feat: add /[lang]/about page, replace home body with intro+CTA

### DIFF
--- a/e2e/language-coverage.pw.ts
+++ b/e2e/language-coverage.pw.ts
@@ -187,10 +187,12 @@ test.describe('Language coverage — switcher click never lands on 404', () => {
       const last = documentStatuses.at(-1);
       expect(last, `last document status for ${from} → ${target}`).toBeLessThan(400);
       await expect(page.locator('h1').first()).toBeVisible();
-      // Nav must also reflect the new language. The visible bug was
-      // that clicking uk moved the URL but the header nav still
-      // said Home→/en, Blog→/en/blog because
-      // <header transition:persist> froze it at the landing page.
+      /*
+       * Nav must also reflect the new language. The visible bug:
+       * clicking uk moved the URL but the header nav still said
+       * Home→/en, Blog→/en/blog because <header transition:persist>
+       * froze it at the landing page.
+       */
       const navLangs = await page
         .locator('[data-testid="desktop-nav"] a')
         .evaluateAll((els) =>

--- a/src/config/translations.ts
+++ b/src/config/translations.ts
@@ -68,6 +68,7 @@ export const getNavLinks = async (lang: Language) => {
   if (!menu) return [];
   return [
     { href: `/${lang}`, label: menu.data.home ?? 'Home' },
+    { href: `/${lang}/about`, label: menu.data.about ?? 'About' },
     { href: `/${lang}/blog`, label: menu.data.blog ?? 'Blog' },
     { href: `/${lang}/positions`, label: menu.data.positions ?? 'Positions' },
     { href: `/${lang}/manifest`, label: menu.data.manifest ?? 'Manifest' },

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -50,6 +50,7 @@ const commonCollection = defineCollection({
     title: z.string(),
     lang: langEnum,
     home: z.string().optional(),
+    about: z.string().optional(),
     blog: z.string().optional(),
     positions: z.string().optional(),
     manifest: z.string().optional(),

--- a/src/pages/[lang]/about.astro
+++ b/src/pages/[lang]/about.astro
@@ -1,0 +1,70 @@
+---
+import { DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES } from '@/config/i18n';
+import { getPageData } from '@/config/translations';
+import BaseLayout from '@/layouts/BaseLayout.astro';
+
+export const getStaticPaths = () => SUPPORTED_LANGUAGES.map((lang) => ({ params: { lang } }));
+
+const { lang } = Astro.params;
+
+const page = (await getPageData('about', lang)) ?? (await getPageData('about', DEFAULT_LANGUAGE));
+if (!page) return Astro.redirect(`/${DEFAULT_LANGUAGE}`);
+
+const { Content } = await page.render();
+---
+
+<BaseLayout title={`${page.data.title} - Prometheus`} {...(page.data.description ? { description: page.data.description } : {})} lang={lang}>
+  <article class="section">
+    <div class="container">
+      <div class="about-header">
+        <h1>{page.data.title}</h1>
+        {page.data.description ? <p class="lead">{page.data.description}</p> : null}
+      </div>
+      <div class="prose">
+        <Content />
+      </div>
+    </div>
+  </article>
+</BaseLayout>
+
+<style>
+  .about-header {
+    max-width: 800px;
+    margin-inline: auto;
+    text-align: center;
+    margin-bottom: var(--spacing-2xl);
+  }
+
+  h1 {
+    font-size: clamp(2rem, 5vw, 3rem);
+    font-weight: 700;
+    line-height: 1.2;
+  }
+
+  .lead {
+    margin-top: var(--spacing-md);
+    color: var(--color-text-secondary);
+    font-size: 1.125rem;
+  }
+
+  .prose {
+    max-width: 800px;
+    margin-inline: auto;
+  }
+
+  .prose :global(h2) {
+    font-size: 1.75rem;
+    font-weight: 600;
+    margin-top: var(--spacing-xl);
+    margin-bottom: var(--spacing-md);
+  }
+
+  .prose :global(p) {
+    margin-bottom: var(--spacing-md);
+    line-height: 1.8;
+  }
+
+  .prose :global(strong) {
+    font-weight: 600;
+  }
+</style>

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -1,6 +1,6 @@
 ---
 import { DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES } from '@/config/i18n';
-import { getPageData } from '@/config/translations';
+import { getCommonData, getPageData } from '@/config/translations';
 import { getBlogPosts } from '@/features/blog/helpers/getBlogPosts';
 import Hero from '@/features/home/components/Hero.astro';
 import NewsSection from '@/features/home/components/NewsSection.astro';
@@ -21,14 +21,23 @@ const latestPositions = positions.slice(0, 3);
 const homePage = (await getPageData('home', lang)) ?? (await getPageData('home', DEFAULT_LANGUAGE));
 if (!homePage) return Astro.redirect(`/${DEFAULT_LANGUAGE}`);
 
-const { Content } = await homePage.render();
 const { title, description, heroTitle, latestNews, viewAllPosts } = homePage.data;
+
+const labels = await getCommonData('labels', lang);
+const readMoreLabel = labels?.data.readMore ?? 'Read more';
 ---
 
 <BaseLayout title={title} {...(description ? { description } : {})} lang={lang}>
   <Hero title={heroTitle ?? ''}>
-    <Content />
+    {description ? <p>{description}</p> : null}
+    <a class="button hero-cta" href={`/${lang}/about`}>{readMoreLabel} →</a>
   </Hero>
   <PositionsWidget lang={lang} positions={latestPositions} />
   <NewsSection posts={latestPosts} lang={lang} latestNewsLabel={latestNews ?? ''} viewAllLabel={viewAllPosts ?? ''} />
 </BaseLayout>
+
+<style>
+  .hero-cta {
+    margin-top: var(--spacing-lg);
+  }
+</style>


### PR DESCRIPTION
## Summary
- New \`/[lang]/about\` route mirrors the manifest layout and renders \`pages/about\` with title + description + body.
- Home page no longer renders the markdown body in the Hero. Hero shows the front-matter title + description and a "Read more" CTA → \`/[lang]/about\`. Read-more label comes from \`common/labels.readMore\`.
- \`content.config.ts\` adds an optional \`about\` field to \`commonCollection\` (menu localisation).
- \`getNavLinks\` injects About between Home and Blog so the link appears in desktop + mobile nav automatically.

## Test plan
- [x] \`bun run build\` — 163 pages built clean.
- [ ] Manual prod check.