### PR TITLE
feat: home subtitle + concurrency-guard deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches: [master]
 
+# Serialise deploys per ref. When a new commit on master arrives while
+# an older deploy is still building, cancel the in-flight one — its
+# image would otherwise overwrite the newer commit's image. This
+# prevents the race we saw between a code push and a content-sync
+# subtree commit landing seconds apart.
+concurrency:
+  group: deploy-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/e2e/verify-about-page.pw.ts
+++ b/e2e/verify-about-page.pw.ts
@@ -6,13 +6,12 @@ import { expect, test } from '@playwright/test';
 /**
  * Manual prod probe for the new About page split.
  *
- * - /{lang} home shows compact Hero (heroTitle + description) + a
- *   "Read more" CTA, no longer renders the long markdown body.
- * - /{lang}/about renders the full About content with title, lead and
- *   prose body.
- * - The site nav contains a localised About link.
+ * Asserts: /{lang} home shows compact Hero (heroTitle + subtitle) +
+ * a "Read more" CTA, /{lang}/about renders the full About content
+ * with title and prose body, and the site nav has a localised About
+ * link.
  */
-const PROD = process.env.PROBE_BASE_URL ?? 'https://comprom.org';
+const PROD = process.env['PROBE_BASE_URL'] ?? 'https://comprom.org';
 const SHOTS = resolve(process.cwd(), 'screenshots/about-verify');
 mkdirSync(SHOTS, { recursive: true });
 

--- a/playwright.config.prod.ts
+++ b/playwright.config.prod.ts
@@ -4,8 +4,7 @@ import { defineConfig } from '@playwright/test';
  * Prod-only Playwright config used to drive opt-in probes against
  * https://comprom.org without spinning up a local astro preview.
  *
- * Run a probe with:
- *   bun run playwright test e2e/verify-about-page.pw.ts --config playwright.config.prod.ts
+ * Run a probe with: bun run playwright test e2e/verify-about-page.pw.ts --config playwright.config.prod.ts
  */
 export default defineConfig({
   testDir: './e2e',

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -25,6 +25,7 @@ const pagesCollection = defineCollection({
     description: z.string().optional(),
     lang: langEnum,
     heroTitle: z.string().optional(),
+    subtitle: z.string().optional(),
     latestNews: z.string().optional(),
     viewAllPosts: z.string().optional(),
     heading: z.string().optional(),

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -21,7 +21,7 @@ const latestPositions = positions.slice(0, 3);
 const homePage = (await getPageData('home', lang)) ?? (await getPageData('home', DEFAULT_LANGUAGE));
 if (!homePage) return Astro.redirect(`/${DEFAULT_LANGUAGE}`);
 
-const { title, description, heroTitle, latestNews, viewAllPosts } = homePage.data;
+const { title, description, heroTitle, subtitle, latestNews, viewAllPosts } = homePage.data;
 
 const labels = await getCommonData('labels', lang);
 const readMoreLabel = labels?.data.readMore ?? 'Read more';
@@ -29,7 +29,7 @@ const readMoreLabel = labels?.data.readMore ?? 'Read more';
 
 <BaseLayout title={title} {...(description ? { description } : {})} lang={lang}>
   <Hero title={heroTitle ?? ''}>
-    {description ? <p>{description}</p> : null}
+    {subtitle ? <p>{subtitle}</p> : null}
     <a class="button hero-cta" href={`/${lang}/about`}>{readMoreLabel} →</a>
   </Hero>
   <PositionsWidget lang={lang} positions={latestPositions} />


### PR DESCRIPTION
## Summary
- Adds optional \`subtitle\` to the pages schema. Home Hero now renders \`subtitle\`; \`description\` remains the SEO meta source via BaseLayout.
- \`.github/workflows/deploy.yml\` gets a concurrency group with \`cancel-in-progress: true\` so when a fresh master commit lands while an older deploy is still building, the in-flight build is cancelled. Stops the race we saw between a code push and the content-sync subtree commit landing seconds apart, where the older build finished last and clobbered the newer content.
- Small lint cleanup on the about prod-verify probe.

## Test plan
- [x] \`bun run build\` (astro check + e2e config + 163 pages) clean.
- [ ] After deploy: prod \`/{lang}\` Hero shows the new \`subtitle\` text; second commit landing during a deploy cancels the older run instead of clobbering.