### PR TITLE
fix: home Hero reads about page; about lead reads subtitle

### DIFF
--- a/src/pages/[lang]/about.astro
+++ b/src/pages/[lang]/about.astro
@@ -11,6 +11,10 @@ const page = (await getPageData('about', lang)) ?? (await getPageData('about', D
 if (!page) return Astro.redirect(`/${DEFAULT_LANGUAGE}`);
 
 const { Content } = await page.render();
+// `subtitle` is the visible lead under the title; `description` is
+// the SEO meta source. Fall back to description until subtitle is
+// authored.
+const lead = page.data.subtitle ?? page.data.description;
 ---
 
 <BaseLayout title={`${page.data.title} - Prometheus`} {...(page.data.description ? { description: page.data.description } : {})} lang={lang}>
@@ -18,7 +22,7 @@ const { Content } = await page.render();
     <div class="container">
       <div class="about-header">
         <h1>{page.data.title}</h1>
-        {page.data.description ? <p class="lead">{page.data.description}</p> : null}
+        {lead ? <p class="lead">{lead}</p> : null}
       </div>
       <div class="prose">
         <Content />

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -21,7 +21,14 @@ const latestPositions = positions.slice(0, 3);
 const homePage = (await getPageData('home', lang)) ?? (await getPageData('home', DEFAULT_LANGUAGE));
 if (!homePage) return Astro.redirect(`/${DEFAULT_LANGUAGE}`);
 
-const { title, description, heroTitle, subtitle, latestNews, viewAllPosts } = homePage.data;
+const { title, description, heroTitle, latestNews, viewAllPosts } = homePage.data;
+
+// The visible Hero subtitle is the description of the About page —
+// home is an entry-point teaser that previews About, not a page with
+// its own copy. `description` on home stays as the SEO meta source.
+const aboutPage =
+  (await getPageData('about', lang)) ?? (await getPageData('about', DEFAULT_LANGUAGE));
+const heroIntro = aboutPage?.data.description;
 
 const labels = await getCommonData('labels', lang);
 const readMoreLabel = labels?.data.readMore ?? 'Read more';
@@ -29,7 +36,7 @@ const readMoreLabel = labels?.data.readMore ?? 'Read more';
 
 <BaseLayout title={title} {...(description ? { description } : {})} lang={lang}>
   <Hero title={heroTitle ?? ''}>
-    {subtitle ? <p>{subtitle}</p> : null}
+    {heroIntro ? <p>{heroIntro}</p> : null}
     <a class="button hero-cta" href={`/${lang}/about`}>{readMoreLabel} →</a>
   </Hero>
   <PositionsWidget lang={lang} positions={latestPositions} />


### PR DESCRIPTION
## Summary
- \`[lang]/index.astro\` Hero now sources the visible intro from \`pages/about\` description (not a home-local subtitle field). Home is a teaser for About; its intro copy lives on About so the homepage Hero and the SEO meta on /[lang]/about share a single source of truth.
- \`[lang]/about.astro\` lead under the title now uses the new \`subtitle\` front-matter field on About, falling back to description until subtitle is authored. Editors can now keep description short (it doubles as the Hero text + SEO meta) and put a longer lead under the About h1 via subtitle.

## Test plan
- [x] \`bun run build\` clean (163 pages built; ru and en home Hero locally render the about description as expected).
- [ ] Manual: prod /{lang} Hero shows about's description; /{lang}/about lead falls back to description until subtitle is authored.