### PR TITLE
fix: strict per-field translations on nav and About lead

### DIFF
--- a/src/config/translations.ts
+++ b/src/config/translations.ts
@@ -55,23 +55,29 @@ export const getMenuData = (lang: Language) => getCommonData('menu', lang);
 export const getLabelsData = (lang: Language) => getCommonData('labels', lang);
 
 /**
- * Resolve the navigation links for a language. Uses the menu entry
- * with default-language fallback so that newly-added languages still
- * show a working nav until their own translation lands.
+ * Resolve the navigation links for a language. Each link is rendered
+ * only when its localised label exists in the menu entry — no
+ * English string fallbacks. If a translation is missing, fix the
+ * content; the link is dropped from the nav until then.
  *
  * @param lang target language
  * @returns nav-link tuples, or [] only when even the default lang
  * has no menu entry (broken state)
  */
-export const getNavLinks = async (lang: Language) => {
+export const getNavLinks = async (
+  lang: Language,
+): Promise<ReadonlyArray<{ readonly href: string; readonly label: string }>> => {
   const menu = await getMenuData(lang);
   if (!menu) return [];
-  return [
-    { href: `/${lang}`, label: menu.data.home ?? 'Home' },
-    { href: `/${lang}/about`, label: menu.data.about ?? 'About' },
-    { href: `/${lang}/blog`, label: menu.data.blog ?? 'Blog' },
-    { href: `/${lang}/positions`, label: menu.data.positions ?? 'Positions' },
-    { href: `/${lang}/manifest`, label: menu.data.manifest ?? 'Manifest' },
-    { href: `/${lang}/newspaper`, label: menu.data.newspaper ?? 'Newspaper' },
-  ];
+  const candidates = [
+    { href: `/${lang}`, label: menu.data.home },
+    { href: `/${lang}/about`, label: menu.data.about },
+    { href: `/${lang}/blog`, label: menu.data.blog },
+    { href: `/${lang}/positions`, label: menu.data.positions },
+    { href: `/${lang}/manifest`, label: menu.data.manifest },
+    { href: `/${lang}/newspaper`, label: menu.data.newspaper },
+  ] as const;
+  return candidates.flatMap((c) =>
+    typeof c.label === 'string' && c.label.length > 0 ? [{ href: c.href, label: c.label }] : [],
+  );
 };

--- a/src/pages/[lang]/about.astro
+++ b/src/pages/[lang]/about.astro
@@ -11,10 +11,6 @@ const page = (await getPageData('about', lang)) ?? (await getPageData('about', D
 if (!page) return Astro.redirect(`/${DEFAULT_LANGUAGE}`);
 
 const { Content } = await page.render();
-// `subtitle` is the visible lead under the title; `description` is
-// the SEO meta source. Fall back to description until subtitle is
-// authored.
-const lead = page.data.subtitle ?? page.data.description;
 ---
 
 <BaseLayout title={`${page.data.title} - Prometheus`} {...(page.data.description ? { description: page.data.description } : {})} lang={lang}>
@@ -22,7 +18,7 @@ const lead = page.data.subtitle ?? page.data.description;
     <div class="container">
       <div class="about-header">
         <h1>{page.data.title}</h1>
-        {lead ? <p class="lead">{lead}</p> : null}
+        {page.data.subtitle ? <p class="lead">{page.data.subtitle}</p> : null}
       </div>
       <div class="prose">
         <Content />


### PR DESCRIPTION
## Summary
- \`src/config/translations.ts\` — \`getNavLinks\` no longer falls back to English strings. Each link is rendered only when its localised label exists in the menu entry. Pairs with the content fix that re-adds the missing newspaper translations.
- \`src/pages/[lang]/about.astro\` — the lead under the About h1 is now strictly \`page.data.subtitle\`, no \`?? description\` fallback. Subtitle = visible lead, description = SEO meta + homepage Hero copy. Until subtitle is authored, the About page renders title + body without a lead.

## Test plan
- [x] \`bun run build\` clean.
- [ ] Manual prod check after deploy.