### PR TITLE
release: require explicit published: true (with empty-state)

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -11,7 +11,12 @@ const blogCollection = defineCollection({
       description: z.string(),
       category: z.string(),
       pubDate: z.date(),
-      published: z.boolean().optional().default(true),
+      /*
+       * Absent / non-true `published` means draft. The build does NOT
+       * render drafts (see getBlogPosts). Editors must explicitly set
+       * `published: true` for an article to ship to the live site.
+       */
+      published: z.boolean().optional(),
       publishDate: z.date().optional(),
       image: image().optional(),
       lang: langEnum,
@@ -39,7 +44,8 @@ const positionsCollection = defineCollection({
     title: z.string(),
     description: z.string(),
     pubDate: z.date().optional(),
-    published: z.boolean().optional().default(true),
+    /* See blog: absent / non-true is draft. */
+    published: z.boolean().optional(),
     publishDate: z.date().optional(),
     lang: langEnum,
   }),
@@ -71,7 +77,8 @@ const newspaperCollection = defineCollection({
       title: z.string(),
       description: z.string(),
       pubDate: z.date().optional(),
-      published: z.boolean().optional().default(true),
+      // See blog: absent / non-true is draft.
+      published: z.boolean().optional(),
       publishDate: z.date().optional(),
       image: image().optional(),
       lang: langEnum,

--- a/src/features/blog/helpers/getBlogPosts.ts
+++ b/src/features/blog/helpers/getBlogPosts.ts
@@ -10,7 +10,7 @@ const sortDate = (entry: CollectionEntry<'blog'>): number =>
 export const getBlogPosts = async (lang: Language): Promise<CollectionEntry<'blog'>[]> => {
   const posts = await getCollection(
     'blog',
-    ({ data }) => data.lang === lang && data.published !== false,
+    ({ data }) => data.lang === lang && data.published === true,
   );
   return posts.sort((a, b) => sortDate(b) - sortDate(a));
 };

--- a/src/features/home/components/NewsSection.astro
+++ b/src/features/home/components/NewsSection.astro
@@ -15,30 +15,32 @@ interface Props {
 const { posts, lang, latestNewsLabel, viewAllLabel } = Astro.props;
 ---
 
-<section class="section">
-  <div class="container">
-    <div class="section-header">
-      <h2>{latestNewsLabel}</h2>
-      <a href={`/${lang}/blog`}>
-        <CpButton variant="secondary">{viewAllLabel}</CpButton>
-      </a>
-    </div>
-    <div class="grid grid-2">
-      {
-        posts.map((post) => (
-          <PostCard
-            title={post.data.title}
-            description={post.data.description}
-            category={post.data.category}
-            slug={getArticleSlug(post)}
-            image={post.data.image}
-            lang={lang}
-          />
-        ))
-      }
-    </div>
-  </div>
-</section>
+{
+  posts.length > 0 && (
+    <section class="section">
+      <div class="container">
+        <div class="section-header">
+          <h2>{latestNewsLabel}</h2>
+          <a href={`/${lang}/blog`}>
+            <CpButton variant="secondary">{viewAllLabel}</CpButton>
+          </a>
+        </div>
+        <div class="grid grid-2">
+          {posts.map((post) => (
+            <PostCard
+              title={post.data.title}
+              description={post.data.description}
+              category={post.data.category}
+              slug={getArticleSlug(post)}
+              image={post.data.image}
+              lang={lang}
+            />
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
 
 <style>
   .section-header {

--- a/src/features/newspaper/helpers/getNewspaperItems.ts
+++ b/src/features/newspaper/helpers/getNewspaperItems.ts
@@ -10,7 +10,7 @@ export const getNewspaperItems = async (
 ): Promise<readonly CollectionEntry<'newspaper'>[]> => {
   const entries = await getCollection(
     'newspaper',
-    ({ data }) => data.lang === lang && data.published !== false,
+    ({ data }) => data.lang === lang && data.published === true,
   );
   return entries.sort((a, b) => sortDate(b) - sortDate(a));
 };

--- a/src/features/positions/components/PositionsWidget.astro
+++ b/src/features/positions/components/PositionsWidget.astro
@@ -19,27 +19,31 @@ const viewAll = labels?.data.viewAll ?? 'View all';
 const readMore = labels?.data.readMore ?? 'Read more';
 ---
 
-<section class="positions-widget" data-testid="positions-widget">
-  <div class="container">
-    <div class="widget-header">
-      <h2>{heading}</h2>
-      <a href={`/${lang}/positions`}>
-        <CpButton variant="secondary">{viewAll}</CpButton>
-      </a>
-    </div>
-    <div class="positions-list">
-      {positions.map((pos) => (
-        <PositionCard
-          title={pos.data.title}
-          description={pos.data.description}
-          slug={pos.id.split('/').at(0) ?? pos.id}
-          lang={lang}
-          readMoreLabel={readMore}
-        />
-      ))}
-    </div>
-  </div>
-</section>
+{
+  positions.length > 0 && (
+    <section class="positions-widget" data-testid="positions-widget">
+      <div class="container">
+        <div class="widget-header">
+          <h2>{heading}</h2>
+          <a href={`/${lang}/positions`}>
+            <CpButton variant="secondary">{viewAll}</CpButton>
+          </a>
+        </div>
+        <div class="positions-list">
+          {positions.map((pos) => (
+            <PositionCard
+              title={pos.data.title}
+              description={pos.data.description}
+              slug={pos.id.split('/').at(0) ?? pos.id}
+              lang={lang}
+              readMoreLabel={readMore}
+            />
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
 
 <style>
   .positions-widget {

--- a/src/features/positions/helpers/getPositions.ts
+++ b/src/features/positions/helpers/getPositions.ts
@@ -10,7 +10,7 @@ export const getPositions = async (
 ): Promise<readonly CollectionEntry<'positions'>[]> => {
   const entries = await getCollection(
     'positions',
-    ({ data }) => data.lang === lang && data.published !== false,
+    ({ data }) => data.lang === lang && data.published === true,
   );
   return entries.sort((a, b) => sortDate(b) - sortDate(a));
 };

--- a/src/pages/[lang]/blog/[...slug].astro
+++ b/src/pages/[lang]/blog/[...slug].astro
@@ -6,7 +6,7 @@ import { getArticleSlug } from '@/features/blog/helpers/getBlogPosts';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
 export const getStaticPaths = async () => {
-  const posts = await getCollection('blog');
+  const posts = await getCollection('blog', ({ data }) => data.published === true);
   const slugs = new Set(posts.map((p) => getArticleSlug(p)));
   const byKey = new Map(posts.map((p) => [`${p.data.lang}/${getArticleSlug(p)}`, p] as const));
   return SUPPORTED_LANGUAGES.flatMap((lang) =>

--- a/src/pages/[lang]/blog/index.astro
+++ b/src/pages/[lang]/blog/index.astro
@@ -32,25 +32,29 @@ const readMore = labels?.data.readMore ?? 'Read more';
   <div class="section">
     <div class="container">
       <h1>{heading}</h1>
-      <CategoryFilter categories={categories} allLabel={allCategory} />
-      <div class="grid grid-2">
-        {
-          posts.map((post) => (
-            <div data-category={post.data.category}>
-              <PostCard
-                title={post.data.title}
-                description={post.data.description}
-                category={post.data.category}
-                slug={getArticleSlug(post)}
-                image={post.data.image}
-                lang={lang}
-                headingLevel={2}
-                readMoreLabel={readMore}
-              />
-            </div>
-          ))
-        }
-      </div>
+      {posts.length > 0 ? (
+        <>
+          <CategoryFilter categories={categories} allLabel={allCategory} />
+          <div class="grid grid-2">
+            {posts.map((post) => (
+              <div data-category={post.data.category}>
+                <PostCard
+                  title={post.data.title}
+                  description={post.data.description}
+                  category={post.data.category}
+                  slug={getArticleSlug(post)}
+                  image={post.data.image}
+                  lang={lang}
+                  headingLevel={2}
+                  readMoreLabel={readMore}
+                />
+              </div>
+            ))}
+          </div>
+        </>
+      ) : (
+        <p class="empty-state">No posts yet.</p>
+      )}
     </div>
   </div>
 </BaseLayout>
@@ -60,5 +64,12 @@ const readMore = labels?.data.readMore ?? 'Read more';
     font-size: clamp(1.75rem, 5vw, 2.5rem);
     font-weight: 700;
     margin-bottom: var(--spacing-xl);
+  }
+
+  .empty-state {
+    color: var(--color-text-secondary);
+    font-size: 1.125rem;
+    text-align: center;
+    padding: var(--spacing-xl) 0;
   }
 </style>

--- a/src/pages/[lang]/positions/[...slug].astro
+++ b/src/pages/[lang]/positions/[...slug].astro
@@ -6,7 +6,7 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
 
 export const getStaticPaths = async () => {
   const slugFrom = (id: string) => id.split('/').at(0) ?? id;
-  const entries = await getCollection('positions');
+  const entries = await getCollection('positions', ({ data }) => data.published === true);
   const slugs = new Set(entries.map((e) => slugFrom(e.id)));
   const byKey = new Map(entries.map((e) => [`${e.data.lang}/${slugFrom(e.id)}`, e] as const));
   return SUPPORTED_LANGUAGES.flatMap((lang) =>

--- a/src/pages/[lang]/positions/index.astro
+++ b/src/pages/[lang]/positions/index.astro
@@ -24,18 +24,22 @@ const readMore = labels?.data.readMore ?? 'Read more';
   <div class="section">
     <div class="container">
       <h1>{heading}</h1>
-      <div class="positions-grid">
-        {positions.map((pos) => (
-          <PositionCard
-            title={pos.data.title}
-            description={pos.data.description}
-            slug={pos.id.split('/').at(0) ?? pos.id}
-            lang={lang}
-            headingLevel={2}
-            readMoreLabel={readMore}
-          />
-        ))}
-      </div>
+      {positions.length > 0 ? (
+        <div class="positions-grid">
+          {positions.map((pos) => (
+            <PositionCard
+              title={pos.data.title}
+              description={pos.data.description}
+              slug={pos.id.split('/').at(0) ?? pos.id}
+              lang={lang}
+              headingLevel={2}
+              readMoreLabel={readMore}
+            />
+          ))}
+        </div>
+      ) : (
+        <p class="empty-state">No positions yet.</p>
+      )}
     </div>
   </div>
 </BaseLayout>
@@ -45,6 +49,13 @@ const readMore = labels?.data.readMore ?? 'Read more';
     font-size: clamp(1.75rem, 5vw, 2.5rem);
     font-weight: 700;
     margin-bottom: var(--spacing-xl);
+  }
+
+  .empty-state {
+    color: var(--color-text-secondary);
+    font-size: 1.125rem;
+    text-align: center;
+    padding: var(--spacing-xl) 0;
   }
 
   .positions-grid {


### PR DESCRIPTION
Backfill committed in public-website-content#9 first; once that lands, every existing article still ships, but new drafts (no flag) are excluded.