### PR TITLE
fix(e2e): point fixtures at slugs that exist after the corpus swap

### DIFF
--- a/e2e/blog-filter.pw.ts
+++ b/e2e/blog-filter.pw.ts
@@ -11,7 +11,8 @@ import { expect, test } from '@playwright/test';
  * 5. Filter works after SPA navigation to blog page
  */
 
-const BLOG = '/en/blog';
+// Blog has content in ru / it; en is intentionally empty in prod.
+const BLOG = '/ru/blog';
 
 test.describe('Blog category filter', () => {
   test.beforeEach(async ({ page }) => {
@@ -76,10 +77,10 @@ test.describe('Blog category filter', () => {
   });
 
   test('filter works after SPA navigation to blog', async ({ page }) => {
-    await page.goto('/en');
+    await page.goto('/ru');
     await page.waitForLoadState('networkidle');
 
-    const blogLink = page.locator('a[href="/en/blog"]').first();
+    const blogLink = page.locator('a[href="/ru/blog"]').first();
     await blogLink.click();
     await page.waitForURL('**/blog');
 

--- a/e2e/language-coverage.pw.ts
+++ b/e2e/language-coverage.pw.ts
@@ -79,7 +79,7 @@ test.describe('Language coverage — every page has a full header nav', () => {
     '/blog',
     '/positions',
     '/newspaper',
-    '/blog/welcome-to-prometheus',
+    '/blog/appeal-to-russian-workers',
   ] as const;
 
   for (const code of codes) {
@@ -113,9 +113,9 @@ test.describe('Language coverage — switcher href is path-aware', () => {
   const here = [
     '/en/',
     '/en/blog',
-    '/en/blog/welcome-to-prometheus',
+    '/en/blog/appeal-to-russian-workers',
     '/en/positions/digital-sovereignty',
-    '/uk/blog/welcome-to-prometheus',
+    '/uk/blog/appeal-to-russian-workers',
   ] as const;
 
   for (const from of here) {
@@ -137,8 +137,8 @@ test.describe('Language coverage — switcher href is path-aware', () => {
 
 test.describe('Language coverage — detail pages do not 404 on new langs', () => {
   const detailProbes = [
-    '/blog/welcome-to-prometheus',
-    '/blog/modern-web-development',
+    '/blog/appeal-to-russian-workers',
+    '/blog/iran-imperialism-crisis',
     '/positions/digital-sovereignty',
   ] as const;
 
@@ -164,10 +164,10 @@ test.describe('Language coverage — switcher click never lands on 404', () => {
   const clicks: readonly { readonly from: string; readonly target: string }[] = [
     { from: '/en/', target: 'uk' },
     { from: '/en/blog', target: 'uk' },
-    { from: '/en/blog/welcome-to-prometheus', target: 'uk' },
+    { from: '/en/blog/appeal-to-russian-workers', target: 'uk' },
     { from: '/en/positions/digital-sovereignty', target: 'uk' },
     { from: '/ru/blog', target: 'bl' },
-    { from: '/uk/blog/welcome-to-prometheus', target: 'en' },
+    { from: '/uk/blog/appeal-to-russian-workers', target: 'en' },
     { from: '/pl/manifest', target: 'it' },
     { from: '/bl/', target: 'pl' },
   ];

--- a/e2e/new-languages.pw.ts
+++ b/e2e/new-languages.pw.ts
@@ -34,9 +34,8 @@ for (const lang of languages) {
       await page.waitForLoadState('networkidle');
 
       await expect(page.locator('h1')).toBeVisible();
-      const cards = page.locator('.post-card');
-      const count = await cards.count();
-      expect(count).toBeGreaterThanOrEqual(1);
+      // Post count varies by language — `it` carries the full corpus,
+      // `es` ships nav + page chrome only until a translation lands.
     });
 
     test('positions page renders translated heading', async ({ page }) => {

--- a/e2e/translations.pw.ts
+++ b/e2e/translations.pw.ts
@@ -24,7 +24,8 @@ test.describe('Translations - English', () => {
 
     await expect(page.locator('h1')).toHaveText('Blog');
     await expect(page.locator('.category-btn[data-category="all"]')).toHaveText('All');
-    await expect(page.locator('text=Read more').first()).toBeVisible();
+    // /en/blog has no posts in prod — only ru/it carry content. The post
+    // card "Read more" assertion lives in the Russian variant below.
   });
 
   test('navigation renders English labels', async ({ page }) => {


### PR DESCRIPTION
The April content cleanup deleted \`welcome-to-prometheus\` and the other demo slugs, but the E2E suite still hard-coded them — every code-only push to master started failing the deploy. Without this fix, the new logo PR (#49) and any future code change can't roll out.

## Changes
- **language-coverage.pw.ts** — replace the deleted \`welcome-to-prometheus\` / \`modern-web-development\` references with \`appeal-to-russian-workers\` / \`iran-imperialism-crisis\` (current slugs).
- **blog-filter.pw.ts** — point \`BLOG\` and the SPA-navigation case at \`/ru/blog\`, where the corpus actually lives. \`/en/blog\` is intentionally empty in prod.
- **new-languages.pw.ts** — drop the "≥ 1 post-card" assertion on \`/{lang}/blog\`. \`es\` ships chrome only; the h1 check still covers page-render.
- **translations.pw.ts** — remove the "Read more" assertion from \`/en/blog\`. No English posts → no card chrome.

## Test plan
- [x] \`astro check\` — 0 errors / 0 warnings / 0 hints.
- [ ] CI deploys this PR + previously-merged logo change to comprom.org.