### PR TITLE
fix(e2e): use block comments in #50 follow-up

### DIFF
--- a/e2e/new-languages.pw.ts
+++ b/e2e/new-languages.pw.ts
@@ -34,8 +34,10 @@ for (const lang of languages) {
       await page.waitForLoadState('networkidle');
 
       await expect(page.locator('h1')).toBeVisible();
-      // Post count varies by language — `it` carries the full corpus,
-      // `es` ships nav + page chrome only until a translation lands.
+      /*
+       * Post count varies by language — `it` carries the full corpus,
+       * `es` ships nav + page chrome only until a translation lands.
+       */
     });
 
     test('positions page renders translated heading', async ({ page }) => {

--- a/e2e/translations.pw.ts
+++ b/e2e/translations.pw.ts
@@ -24,8 +24,11 @@ test.describe('Translations - English', () => {
 
     await expect(page.locator('h1')).toHaveText('Blog');
     await expect(page.locator('.category-btn[data-category="all"]')).toHaveText('All');
-    // /en/blog has no posts in prod — only ru/it carry content. The post
-    // card "Read more" assertion lives in the Russian variant below.
+    /*
+     * /en/blog has no posts in prod — only ru/it carry content.
+     * The post card "Read more" assertion lives in the Russian
+     * variant below.
+     */
   });
 
   test('navigation renders English labels', async ({ page }) => {


### PR DESCRIPTION
Astro's strict build runs ESLint with . The two-line  notes I added in #50 tripped it and the deploy aborted before E2E. Both notes are now  blocks.