### PR TITLE
fix(e2e): unblock master deploy — eslint jsdoc + tsconfig strict env access

### DIFF
--- a/e2e-toolkit/src/wait-for.ts
+++ b/e2e-toolkit/src/wait-for.ts
@@ -29,10 +29,9 @@ const DEFAULT: Required<WaitOptions> = {
 
 /**
  * Generic wait built on a request-graph listener: poll a `checker`,
- * track every outgoing request, and resolve as soon as both
- *   1. checker returns `true`, AND
- *   2. no new request has fired for `settleMs` since the condition
- *      first held.
+ * track every outgoing request, and resolve as soon as both (1) the
+ * checker returns true, AND (2) no new request has fired for
+ * `settleMs` since the condition first held.
  *
  * On a static site the listener never fires, so the wait returns on
  * the first poll where the checker passes — usually <1 frame. On a
@@ -40,11 +39,9 @@ const DEFAULT: Required<WaitOptions> = {
  * timeouts.
  *
  * @param page Playwright page used as the request listener source.
- * @param checker Async predicate. MUST NOT throw — wrap risky reads
- *   in `.catch(() => false)`.
+ * @param checker Async predicate. MUST NOT throw — wrap risky reads in `.catch(() => false)`.
  * @param options Tunables (rarely needed).
- * @throws when the maxMs ceiling is hit; the message names the last
- *   request URL so you can identify a runaway fetch.
+ * @throws when the maxMs ceiling is hit; the message names the last request URL so you can identify a runaway fetch.
  */
 export const waitForCondition = async (
   page: Page,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,15 @@
-import { defineConfig } from '@playwright/test';
+import process from 'node:process';
+import { defineConfig, type PlaywrightTestConfig } from '@playwright/test';
+
+const { CI } = process.env;
+const ciWorkers: Pick<PlaywrightTestConfig, 'workers'> = CI ? { workers: 4 } : {};
 
 export default defineConfig({
   testDir: './e2e',
   testMatch: '**/*.pw.ts',
   fullyParallel: true,
   retries: 0,
-  workers: process.env.CI ? 4 : undefined,
+  ...ciWorkers,
   reporter: 'list',
   /*
    * Per-test ceiling. Each network-aware wait inside the toolkit


### PR DESCRIPTION
## Summary
- jsdoc/check-indentation flagged the indented numbered list in the waitForCondition docblock (CI runs `eslint .`, local was just `astro build`). Flatten the list into prose.
- tsconfig has `noPropertyAccessFromIndexSignature` + `exactOptionalPropertyTypes`, so `process.env.CI` and `workers: undefined` both fail astro check. Destructure CI off `process.env` and conditionally spread `{ workers: 4 }` so `undefined` is never assigned.

## Test plan
- [x] `bun run build` passes
- [x] `npx playwright test --project=chromium` passes 172/172