### PR TITLE
feat: 404 + missing-translation UX, kill mobile tap highlight

### DIFF
--- a/src/features/i18n/MissingTranslation.astro
+++ b/src/features/i18n/MissingTranslation.astro
@@ -1,0 +1,117 @@
+---
+import { LANGUAGE_LABELS, type Language } from '@/config/i18n';
+
+interface Props {
+  /** Current locale shown in the URL prefix. */
+  readonly lang: Language;
+  /** Locales where this content actually exists, in display order. */
+  readonly availableLangs: ReadonlyArray<Language>;
+  /**
+   * Site path under the locale prefix — the same string for every
+   * lang link so switching keeps the user on the same article.
+   * E.g. for /en/blog/foo this is `/blog/foo`.
+   */
+  readonly relativePath: string;
+}
+
+interface Copy {
+  readonly heading: string;
+  readonly body: string;
+  readonly availableHeading: string;
+}
+
+const EN: Copy = {
+  heading: 'Not translated yet',
+  body: 'This material is not yet available in your language.',
+  availableHeading: 'Available in:',
+};
+
+const TEXTS: Readonly<Record<string, Copy>> = {
+  en: EN,
+  ru: {
+    heading: 'Перевод ещё не готов',
+    body: 'Этот материал пока не доступен на выбранном языке.',
+    availableHeading: 'Доступно на:',
+  },
+  it: {
+    heading: 'Non ancora tradotto',
+    body: 'Questo materiale non è ancora disponibile nella lingua scelta.',
+    availableHeading: 'Disponibile in:',
+  },
+  es: {
+    heading: 'Traducción pendiente',
+    body: 'Este material aún no está disponible en el idioma elegido.',
+    availableHeading: 'Disponible en:',
+  },
+};
+
+const { lang, availableLangs, relativePath } = Astro.props;
+const t: Copy = TEXTS[lang] ?? EN;
+---
+
+<section class="missing-translation">
+  <h2>{t.heading}</h2>
+  <p>{t.body}</p>
+  {availableLangs.length > 0 && (
+    <p class="available">
+      <span class="available-label">{t.availableHeading}</span>
+      <span class="available-langs">
+        {availableLangs.map((l) => (
+          <a href={`/${l}${relativePath}`} hreflang={l}>{LANGUAGE_LABELS[l] ?? l}</a>
+        ))}
+      </span>
+    </p>
+  )}
+</section>
+
+<style>
+  .missing-translation {
+    max-width: 720px;
+    margin-inline: auto;
+    padding: clamp(var(--spacing-lg), 4vw, var(--spacing-2xl));
+    background: var(--color-surface);
+    border-left: 3px solid var(--color-accent);
+    border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  }
+
+  .missing-translation h2 {
+    font-size: clamp(1.25rem, 4vw, 1.5rem);
+    font-weight: 600;
+    margin-bottom: var(--spacing-sm);
+  }
+
+  .missing-translation p {
+    font-size: 1rem;
+    color: var(--color-text-secondary);
+    line-height: 1.7;
+    margin-bottom: var(--spacing-md);
+  }
+
+  .available {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-sm);
+    align-items: baseline;
+  }
+
+  .available-label {
+    color: var(--color-text-primary);
+    font-weight: 500;
+  }
+
+  .available-langs {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-sm);
+  }
+
+  .available-langs a {
+    color: var(--color-accent);
+    text-decoration: none;
+    border-bottom: 1px solid currentColor;
+  }
+
+  .available-langs a:hover {
+    color: var(--color-accent-hover);
+  }
+</style>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,112 @@
+---
+import { DEFAULT_LANGUAGE } from '@/config/i18n';
+import BaseLayout from '@/layouts/BaseLayout.astro';
+
+/*
+ * Multilingual 404 page. CF Workers Assets serves this verbatim for
+ * any path that does not exist in `dist/`, with the original URL
+ * preserved (no redirect). The layout reads `lang` from the URL prefix
+ * client-side so that switching language on the 404 still routes to
+ * the chosen locale once a real page is reached.
+ */
+const TEXTS = {
+  en: {
+    title: 'Page not found — Communist Prometheus',
+    heading: 'This page does not exist',
+    body: 'The address you opened has no content yet. The link may be stale, or the article hasn’t been published in this language.',
+    home: 'Back to home',
+  },
+  ru: {
+    title: 'Страница не найдена — Коммунистический Прометей',
+    heading: 'Такой страницы нет',
+    body: 'По адресу, который вы открыли, ничего не опубликовано. Возможно, ссылка устарела или материал ещё не переведён на этот язык.',
+    home: 'На главную',
+  },
+  it: {
+    title: 'Pagina non trovata — Prometeo Comunista',
+    heading: 'Questa pagina non esiste',
+    body: 'L’indirizzo che hai aperto non contiene ancora nulla. Il link potrebbe essere obsoleto, oppure il materiale non è ancora stato tradotto in questa lingua.',
+    home: 'Torna alla home',
+  },
+  es: {
+    title: 'Página no encontrada — Prometeo Comunista',
+    heading: 'Esta página no existe',
+    body: 'La dirección que abriste no tiene todavía contenido. El enlace puede haber caducado, o el material aún no se ha traducido a este idioma.',
+    home: 'Volver al inicio',
+  },
+} as const;
+
+type Lang = keyof typeof TEXTS;
+---
+
+<BaseLayout title={TEXTS.en.title} lang={DEFAULT_LANGUAGE}>
+  <div class="section not-found">
+    <div class="container">
+      {(Object.keys(TEXTS) as readonly Lang[]).map((lang) => {
+        const t = TEXTS[lang];
+        return (
+          <article class="not-found-block" lang={lang} data-lang={lang}>
+            <h1>{t.heading}</h1>
+            <p>{t.body}</p>
+            <a href={`/${lang}`} class="home-link">{t.home} →</a>
+          </article>
+        );
+      })}
+    </div>
+  </div>
+</BaseLayout>
+
+<script is:inline>
+  /*
+   * Show only the block for the language matched by the URL prefix.
+   * Falls back to the first block (English) for paths that don’t
+   * carry a /xx/ prefix at all.
+   */
+  (function () {
+    var match = location.pathname.match(/^\/([a-z]{2})(\/|$)/);
+    var pick = match ? match[1] : 'en';
+    var blocks = document.querySelectorAll('.not-found-block');
+    var found = false;
+    blocks.forEach(function (b) {
+      if (b.getAttribute('data-lang') === pick) {
+        found = true;
+      } else {
+        b.hidden = true;
+      }
+    });
+    if (!found && blocks[0]) blocks[0].hidden = false;
+    document.documentElement.lang = pick;
+  })();
+</script>
+
+<style>
+  .not-found {
+    padding-top: clamp(var(--spacing-xl), 8vw, var(--spacing-2xl));
+    padding-bottom: clamp(var(--spacing-xl), 8vw, var(--spacing-2xl));
+  }
+
+  .not-found-block h1 {
+    font-size: clamp(1.75rem, 5vw, 2.5rem);
+    font-weight: 700;
+    margin-bottom: var(--spacing-md);
+  }
+
+  .not-found-block p {
+    font-size: 1.0625rem;
+    line-height: 1.7;
+    color: var(--color-text-secondary);
+    max-width: 60ch;
+    margin-bottom: var(--spacing-lg);
+  }
+
+  .home-link {
+    color: var(--color-accent);
+    text-decoration: none;
+    font-weight: 500;
+    border-bottom: 1px solid currentColor;
+  }
+
+  .home-link:hover {
+    color: var(--color-accent-hover);
+  }
+</style>

--- a/src/pages/[lang]/blog/[...slug].astro
+++ b/src/pages/[lang]/blog/[...slug].astro
@@ -1,50 +1,94 @@
 ---
-import { getCollection } from 'astro:content';
-import { DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES } from '@/config/i18n';
+import { type CollectionEntry, getCollection } from 'astro:content';
+import { type Language, SUPPORTED_LANGUAGES } from '@/config/i18n';
 import BlogPicture from '@/features/blog/components/BlogPicture.astro';
 import { getArticleSlug } from '@/features/blog/helpers/getBlogPosts';
+import MissingTranslation from '@/features/i18n/MissingTranslation.astro';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
+/*
+ * Emit one path per (supported language × slug that exists in *any*
+ * language). When the slug has a translation in `lang`, render the
+ * post; otherwise hand the language switcher / placeholder so a
+ * switch to an untranslated locale lands on a clear "not yet
+ * translated" message instead of silently falling back to the
+ * default-language version under a misleading URL prefix.
+ */
 export const getStaticPaths = async () => {
   const posts = await getCollection('blog', ({ data }) => data.published === true);
   const slugs = new Set(posts.map((p) => getArticleSlug(p)));
   const byKey = new Map(posts.map((p) => [`${p.data.lang}/${getArticleSlug(p)}`, p] as const));
+  const slugToLangs = new Map<string, ReadonlyArray<Language>>();
+  for (const slug of slugs) {
+    slugToLangs.set(
+      slug,
+      SUPPORTED_LANGUAGES.filter((lang) => byKey.has(`${lang}/${slug}`)),
+    );
+  }
   return SUPPORTED_LANGUAGES.flatMap((lang) =>
-    [...slugs].flatMap((slug) => {
-      const post = byKey.get(`${lang}/${slug}`) ?? byKey.get(`${DEFAULT_LANGUAGE}/${slug}`);
-      return post ? [{ params: { lang, slug }, props: { post } }] : [];
-    }),
+    [...slugs].map((slug) => ({
+      params: { lang, slug },
+      props: {
+        post: byKey.get(`${lang}/${slug}`),
+        availableLangs: slugToLangs.get(slug) ?? [],
+      },
+    })),
   );
 };
 
-const { post } = Astro.props;
-const { Content } = await post.render();
+interface Props {
+  readonly post?: CollectionEntry<'blog'>;
+  readonly availableLangs: ReadonlyArray<Language>;
+}
 
-const { lang } = Astro.params;
+const { post, availableLangs } = Astro.props as Props;
+const { lang, slug } = Astro.params;
+const Content = post ? (await post.render()).Content : undefined;
+
+const pageTitle = post ? `${post.data.title} - Communist Prometheus` : 'Communist Prometheus';
+const pageDescription = post?.data.description;
 ---
 
-<BaseLayout title={`${post.data.title} - Prometheus`} description={post.data.description} lang={lang}>
-  <article class="section">
-    <div class="container">
-      <div class="post-header">
-        <span class="category">{post.data.category}</span>
-        <h1>{post.data.title}</h1>
-        <p class="post-meta">
-          {
-            (post.data.publishDate ?? post.data.pubDate).toLocaleDateString(lang, {
+<BaseLayout
+  title={pageTitle}
+  {...(pageDescription ? { description: pageDescription } : {})}
+  lang={lang}
+>
+  {post && Content ? (
+    <article class="section">
+      <div class="container">
+        <div class="post-header">
+          <span class="category">{post.data.category}</span>
+          <h1>{post.data.title}</h1>
+          <p class="post-meta">
+            {(post.data.publishDate ?? post.data.pubDate).toLocaleDateString(lang, {
               year: 'numeric',
               month: 'long',
               day: 'numeric',
-            })
-          }
-        </p>
+            })}
+          </p>
+        </div>
+        {post.data.image && (
+          <div class="featured-image">
+            <BlogPicture image={post.data.image} alt={post.data.title} preset="featured" loading="eager" />
+          </div>
+        )}
+        <div class="prose">
+          <Content />
+        </div>
       </div>
-      {post.data.image && <div class="featured-image"><BlogPicture image={post.data.image} alt={post.data.title} preset="featured" loading="eager" /></div>}
-      <div class="prose">
-        <Content />
+    </article>
+  ) : (
+    <div class="section">
+      <div class="container">
+        <MissingTranslation
+          lang={lang}
+          availableLangs={availableLangs}
+          relativePath={`/blog/${slug}`}
+        />
       </div>
     </div>
-  </article>
+  )}
 </BaseLayout>
 
 <style>

--- a/src/pages/[lang]/positions/[...slug].astro
+++ b/src/pages/[lang]/positions/[...slug].astro
@@ -1,39 +1,77 @@
 ---
-import { getCollection } from 'astro:content';
-import { DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES } from '@/config/i18n';
+import { type CollectionEntry, getCollection } from 'astro:content';
+import { DEFAULT_LANGUAGE, type Language, SUPPORTED_LANGUAGES } from '@/config/i18n';
 import { getLabelsData } from '@/config/translations';
+import MissingTranslation from '@/features/i18n/MissingTranslation.astro';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
+/*
+ * Emit one path per (supported language × slug that exists in *any*
+ * language). When the slug has a translation in `lang`, render the
+ * entry; otherwise show the "not yet translated" placeholder. Same
+ * shape as blog/[...slug].astro — keeps the URL the user typed and
+ * avoids silently swapping to the default-language entry.
+ */
 export const getStaticPaths = async () => {
   const slugFrom = (id: string) => id.split('/').at(0) ?? id;
   const entries = await getCollection('positions', ({ data }) => data.published === true);
   const slugs = new Set(entries.map((e) => slugFrom(e.id)));
   const byKey = new Map(entries.map((e) => [`${e.data.lang}/${slugFrom(e.id)}`, e] as const));
+  const slugToLangs = new Map<string, ReadonlyArray<Language>>();
+  for (const slug of slugs) {
+    slugToLangs.set(
+      slug,
+      SUPPORTED_LANGUAGES.filter((lang) => byKey.has(`${lang}/${slug}`)),
+    );
+  }
   return SUPPORTED_LANGUAGES.flatMap((lang) =>
-    [...slugs].flatMap((slug) => {
-      const entry = byKey.get(`${lang}/${slug}`) ?? byKey.get(`${DEFAULT_LANGUAGE}/${slug}`);
-      return entry ? [{ params: { lang, slug }, props: { entry } }] : [];
-    }),
+    [...slugs].map((slug) => ({
+      params: { lang, slug },
+      props: {
+        entry: byKey.get(`${lang}/${slug}`),
+        availableLangs: slugToLangs.get(slug) ?? [],
+      },
+    })),
   );
 };
 
-const { entry } = Astro.props;
-const { lang } = Astro.params;
-const { Content } = await entry.render();
+interface Props {
+  readonly entry?: CollectionEntry<'positions'>;
+  readonly availableLangs: ReadonlyArray<Language>;
+}
+
+const { entry, availableLangs } = Astro.props as Props;
+const { lang, slug } = Astro.params;
+const Content = entry ? (await entry.render()).Content : undefined;
 const labels = (await getLabelsData(lang)) ?? (await getLabelsData(DEFAULT_LANGUAGE));
 const backLabel = labels?.data.backToList ?? '← Back';
+
+const pageTitle = entry ? `${entry.data.title} - Communist Prometheus` : 'Communist Prometheus';
+const pageDescription = entry?.data.description;
 ---
 
-<BaseLayout title={`${entry.data.title} - Prometheus`} description={entry.data.description} lang={lang}>
+<BaseLayout
+  title={pageTitle}
+  {...(pageDescription ? { description: pageDescription } : {})}
+  lang={lang}
+>
   <div class="section">
     <div class="container">
       <a href={`/${lang}/positions`} class="back-link">{backLabel}</a>
-      <article>
-        <h1>{entry.data.title}</h1>
-        <div class="content">
-          <Content />
-        </div>
-      </article>
+      {entry && Content ? (
+        <article>
+          <h1>{entry.data.title}</h1>
+          <div class="content">
+            <Content />
+          </div>
+        </article>
+      ) : (
+        <MissingTranslation
+          lang={lang}
+          availableLangs={availableLangs}
+          relativePath={`/positions/${slug}`}
+        />
+      )}
     </div>
   </div>
 </BaseLayout>

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -130,6 +130,13 @@ html {
   background: var(--color-background);
   scrollbar-gutter: stable;
   overflow-x: hidden;
+  /*
+   * Mobile Safari / Android Chrome paint a translucent grey square
+   * over every tappable element on tap. Override globally to
+   * transparent so our own :active / :hover / :focus-visible styles
+   * are the only feedback the user sees.
+   */
+  -webkit-tap-highlight-color: transparent;
 }
 
 body {
@@ -145,6 +152,15 @@ canvas,
 svg {
   display: block;
   max-width: 100%;
+}
+
+input,
+button,
+textarea,
+select,
+a {
+  /* Belt-and-braces override; some Android skins ignore the html-level rule. */
+  -webkit-tap-highlight-color: transparent;
 }
 
 input,

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,7 +2,14 @@
   "name": "public-website",
   "compatibility_date": "2026-03-23",
   "assets": {
-    "directory": "./dist"
+    "directory": "./dist",
+    /*
+     * Serve src/pages/404.astro (built into dist/404.html) for any
+     * path that has no asset. CF preserves the requested URL — no
+     * redirect — which is the UX the editors asked for ("keep what
+     * the user typed, just say the content does not exist").
+     */
+    "not_found_handling": "404-page"
   },
   "env": {
     // Develop environment — deploys from the `develop` branch into a


### PR DESCRIPTION
Three editor-requested fixes in the public-website chrome.

1. **404 / unknown URL** — `src/pages/404.astro` plus `not_found_handling: "404-page"` in wrangler.jsonc. CF preserves the requested URL — no redirect — which is the UX the editors explicitly asked for.
2. **Missing translation** — switching language on a detail page that has no translation in the target locale used to silently fall back to the default-language entry. blog/[...slug] and positions/[...slug] now emit one path per (locale × slug-that-exists-anywhere) and render a new `MissingTranslation` block when the requested locale is missing, listing the locales that DO have it.
3. **Mobile tap highlight** — global `-webkit-tap-highlight-color: transparent` so the grey square mobile Safari/Chrome paints over every tap is gone (admin's MobileMenuFab already had this; public site was missing).

## Test plan
- [x] `bun run build` clean — `dist/404.html` emitted
- [x] Built tap-highlight rule visible in dist/en/index.html
- [ ] After deploy: navigate to /en/foobar — 404 stays on the URL, RU/IT/ES variants work too
- [ ] After deploy: switch language tab on an article that has only ru — get the MissingTranslation card + correct "Available in: ru" link