### PR TITLE
fix(e2e): drop unused expectMinCount import in new-languages

### DIFF
--- a/e2e/new-languages.pw.ts
+++ b/e2e/new-languages.pw.ts
@@ -1,6 +1,5 @@
 import {
   click,
-  expectMinCount,
   expectText,
   expectVisible,
   test,


### PR DESCRIPTION
Hotfix for #56's blocker — astro check failed on the orphaned import after cards-count assertions were removed.