### PR TITLE
feat: reader-mode semantics, newspaper link cover, per-locale RSS (#11 #13 #15)

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -4,6 +4,7 @@ import newspaperPdfs from './src/integrations/newspaper-pdfs';
 import swManifest from './src/integrations/sw-manifest';
 
 export default defineConfig({
+  site: 'https://comprom.org',
   cacheDir: './.astro-cache',
   integrations: [contentMedia(), newspaperPdfs(), swManifest()],
   vite: {

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,7 @@
   "workspaces": {
     "": {
       "dependencies": {
+        "@astrojs/rss": "^4.0.18",
         "astro": "^5.17.1",
       },
       "devDependencies": {
@@ -37,6 +38,8 @@
     "@astrojs/markdown-remark": ["@astrojs/markdown-remark@6.3.10", "", { "dependencies": { "@astrojs/internal-helpers": "0.7.5", "@astrojs/prism": "3.3.0", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "hast-util-to-text": "^4.0.2", "import-meta-resolve": "^4.2.0", "js-yaml": "^4.1.1", "mdast-util-definitions": "^6.0.0", "rehype-raw": "^7.0.0", "rehype-stringify": "^10.0.1", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-smartypants": "^3.0.2", "shiki": "^3.19.0", "smol-toml": "^1.5.2", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.0.0", "unist-util-visit-parents": "^6.0.2", "vfile": "^6.0.3" } }, "sha512-kk4HeYR6AcnzC4QV8iSlOfh+N8TZ3MEStxPyenyCtemqn8IpEATBFMTJcfrNW32dgpt6MY3oCkMM/Tv3/I4G3A=="],
 
     "@astrojs/prism": ["@astrojs/prism@3.3.0", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ=="],
+
+    "@astrojs/rss": ["@astrojs/rss@4.0.18", "", { "dependencies": { "fast-xml-parser": "^5.5.7", "piccolore": "^0.1.3", "zod": "^4.3.6" } }, "sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg=="],
 
     "@astrojs/telemetry": ["@astrojs/telemetry@3.3.0", "", { "dependencies": { "ci-info": "^4.2.0", "debug": "^4.4.0", "dlv": "^1.1.3", "dset": "^3.1.4", "is-docker": "^3.0.0", "is-wsl": "^3.1.0", "which-pm-runs": "^1.1.0" } }, "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ=="],
 
@@ -233,6 +236,8 @@
     "@lhci/cli": ["@lhci/cli@0.15.1", "", { "dependencies": { "@lhci/utils": "0.15.1", "chrome-launcher": "^0.13.4", "compression": "^1.7.4", "debug": "^4.3.1", "express": "^4.17.1", "inquirer": "^6.3.1", "isomorphic-fetch": "^3.0.0", "lighthouse": "12.6.1", "lighthouse-logger": "1.2.0", "open": "^7.1.0", "proxy-agent": "^6.4.0", "tmp": "^0.1.0", "uuid": "^8.3.1", "yargs": "^15.4.1", "yargs-parser": "^13.1.2" }, "bin": { "lhci": "./src/cli.js" } }, "sha512-yhC0oXnXqGHYy1xl4D8YqaydMZ/khFAnXGY/o2m/J3PqPa/D0nj3V6TLoH02oVMFeEF2AQim7UbmdXMiXx2tOw=="],
 
     "@lhci/utils": ["@lhci/utils@0.15.1", "", { "dependencies": { "debug": "^4.3.1", "isomorphic-fetch": "^3.0.0", "js-yaml": "^3.13.1", "lighthouse": "12.6.1", "tree-kill": "^1.2.1" } }, "sha512-WclJnUQJeOMY271JSuaOjCv/aA0pgvuHZS29NFNdIeI14id8eiFsjith85EGKYhljgoQhJ2SiW4PsVfFiakNNw=="],
+
+    "@nodable/entities": ["@nodable/entities@2.1.0", "", {}, "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -790,6 +795,10 @@
 
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
+    "fast-xml-builder": ["fast-xml-builder@1.1.5", "", { "dependencies": { "path-expression-matcher": "^1.1.3" } }, "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.7.2", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.5", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w=="],
+
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
     "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
@@ -1222,6 +1231,8 @@
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
+    "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
+
     "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
@@ -1440,6 +1451,8 @@
 
     "strip-ansi": ["strip-ansi@5.2.0", "", { "dependencies": { "ansi-regex": "^4.1.0" } }, "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA=="],
 
+    "strnum": ["strnum@2.2.3", "", {}, "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg=="],
+
     "stubborn-fs": ["stubborn-fs@2.0.0", "", { "dependencies": { "stubborn-utils": "^1.0.1" } }, "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA=="],
 
     "stubborn-utils": ["stubborn-utils@1.0.2", "", {}, "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg=="],
@@ -1656,7 +1669,7 @@
 
     "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.4.2", "", {}, "sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
@@ -1708,6 +1721,8 @@
 
     "astro/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
+    "astro/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
     "astro-eslint-parser/eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
 
     "astro-eslint-parser/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
@@ -1723,6 +1738,8 @@
     "boxen/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "chrome-launcher/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
+
+    "chromium-bidi/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "cli-truncate/string-width": ["string-width@8.1.1", "", { "dependencies": { "get-east-asian-width": "^1.3.0", "strip-ansi": "^7.1.0" } }, "sha512-KpqHIdDL9KwYk22wEOg/VIqYbrnLeSApsKT/bSj6Ez7pn3CftUiLAv2Lccpq1ALcpLV9UX1Ppn92npZWu2w/aw=="],
 
@@ -1831,6 +1848,8 @@
     "yaml-language-server/yaml": ["yaml@2.7.1", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ=="],
 
     "yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "zod-to-ts/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@lhci/cli/lighthouse/@paulirish/trace_engine": ["@paulirish/trace_engine@0.0.53", "", { "dependencies": { "legacy-javascript": "latest", "third-party-web": "latest" } }, "sha512-PUl/vlfo08Oj804VI5nDPeSk9vyslnBlVzDDwFt8SUVxY8+KdGMkra/vrXjEEHe8gb7+RqVTfOIlGw0nyrEelA=="],
 

--- a/e2e/footer.pw.ts
+++ b/e2e/footer.pw.ts
@@ -1,0 +1,37 @@
+import { expect, expectVisible, test, visit } from '@prometheus/e2e-toolkit';
+
+/*
+ * Footer regression suite.
+ *
+ * Validates copyright and the two link widgets shipped in #15:
+ * - RSS feed link points to the per-locale feed at /<lang>/rss.xml
+ *   and resolves to a non-empty XML document.
+ * - GitHub link points to the org page on github.com.
+ */
+
+test.describe('Footer widgets', () => {
+  test('RSS link resolves to a feed for the locale', async ({ page }) => {
+    await visit(page, '/en');
+    const rss = page.getByTestId('footer-rss');
+    await expectVisible(page, rss);
+    await expect(rss).toHaveAttribute('href', '/en/rss.xml');
+    const response = await page.request.get('/en/rss.xml');
+    expect(response.ok()).toBe(true);
+    const body = await response.text();
+    expect(body).toContain('<rss');
+    expect(body).toContain('<language>en</language>');
+  });
+
+  test('GitHub link points to the org page', async ({ page }) => {
+    await visit(page, '/en');
+    const gh = page.getByTestId('footer-github');
+    await expectVisible(page, gh);
+    await expect(gh).toHaveAttribute('href', 'https://github.com/communist-prometheus');
+    await expect(gh).toHaveAttribute('rel', /noopener/);
+  });
+
+  test('copyright still renders in Russian locale', async ({ page }) => {
+    await visit(page, '/ru');
+    await expectVisible(page, page.locator('footer').getByText('Communist Prometheus'));
+  });
+});

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
+    "@astrojs/rss": "^4.0.18",
     "astro": "^5.17.1"
   },
   "packageManager": "bun@latest",

--- a/src/features/navigation/components/Footer.astro
+++ b/src/features/navigation/components/Footer.astro
@@ -11,13 +11,64 @@ const { lang } = Astro.props;
 const currentYear = new Date().getFullYear();
 const nav = await getMenuData(lang);
 const copyright = nav?.data.copyright ?? '© All rights reserved';
+
+const rssHref = `/${lang}/rss.xml`;
+const githubHref = 'https://github.com/communist-prometheus';
 ---
 
 <footer transition:persist="footer">
   <div class="container">
     <p class="text-secondary text-sm">
-      {currentYear} Prometheus. {copyright}
+      {currentYear} Communist Prometheus. {copyright}
     </p>
+    <ul class="footer-links" data-testid="footer-links">
+      <li>
+        <a
+          href={rssHref}
+          class="footer-link"
+          aria-label="RSS feed"
+          data-testid="footer-rss"
+        >
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path
+              fill="currentColor"
+              d="M6.18 17.82a2.18 2.18 0 1 1-4.36 0a2.18 2.18 0 0 1 4.36 0M2 8.7v3a9 9 0 0 1 9 9h3A12 12 0 0 0 2 8.7m0-5.7v3a14 14 0 0 1 14 14h3A17 17 0 0 0 2 3"
+            />
+          </svg>
+          <span>RSS</span>
+        </a>
+      </li>
+      <li>
+        <a
+          href={githubHref}
+          class="footer-link"
+          aria-label="GitHub organisation"
+          rel="noopener me"
+          target="_blank"
+          data-testid="footer-github"
+        >
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path
+              fill="currentColor"
+              d="M12 .3a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2c-3.3.7-4-1.6-4-1.6c-.55-1.4-1.34-1.8-1.34-1.8c-1.1-.74.08-.73.08-.73c1.2.08 1.84 1.24 1.84 1.24c1.07 1.83 2.8 1.3 3.5 1c.1-.78.42-1.3.76-1.6c-2.66-.3-5.46-1.32-5.46-5.9c0-1.3.46-2.36 1.22-3.2c-.12-.3-.53-1.5.12-3.16c0 0 1-.32 3.3 1.22a11.5 11.5 0 0 1 6 0C17.4 4.5 18.4 4.82 18.4 4.82c.65 1.66.24 2.86.12 3.16c.76.84 1.22 1.9 1.22 3.2c0 4.6-2.8 5.6-5.48 5.9c.43.36.8 1.08.8 2.18v3.24c0 .32.2.7.8.6A12 12 0 0 0 12 .3"
+            />
+          </svg>
+          <span>GitHub</span>
+        </a>
+      </li>
+    </ul>
   </div>
 </footer>
 
@@ -30,5 +81,31 @@ const copyright = nav?.data.copyright ?? '© All rights reserved';
 
   p {
     text-align: center;
+  }
+
+  .footer-links {
+    display: flex;
+    justify-content: center;
+    gap: var(--spacing-md);
+    list-style: none;
+    margin: var(--spacing-md) 0 0;
+    padding: 0;
+  }
+
+  .footer-link {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+    padding: var(--spacing-xs) var(--spacing-sm);
+    border-radius: var(--radius-sm);
+    color: var(--color-text-secondary);
+    text-decoration: none;
+    min-height: 44px;
+    transition: color var(--transition-fast);
+  }
+
+  .footer-link:hover,
+  .footer-link:focus-visible {
+    color: var(--color-accent);
   }
 </style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -52,6 +52,12 @@ const absoluteImage = shareImage.startsWith('http') ? shareImage : `${SITE_URL}$
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="canonical" href={canonical} />
+    <link
+      rel="alternate"
+      type="application/rss+xml"
+      title={`Communist Prometheus — ${lang}`}
+      href={`/${lang}/rss.xml`}
+    />
     <title>{title}</title>
     {description && <meta name="description" content={description} />}
     <meta property="og:type" content="website" />

--- a/src/pages/[lang]/blog/[...slug].astro
+++ b/src/pages/[lang]/blog/[...slug].astro
@@ -1,6 +1,7 @@
 ---
+import { Picture } from 'astro:assets';
 import { type CollectionEntry, getCollection } from 'astro:content';
-import { type Language, SUPPORTED_LANGUAGES } from '@/config/i18n';
+import { DEFAULT_LANGUAGE, type Language, SUPPORTED_LANGUAGES } from '@/config/i18n';
 import BlogPicture from '@/features/blog/components/BlogPicture.astro';
 import { getArticleSlug } from '@/features/blog/helpers/getBlogPosts';
 import { deriveDescription } from '@/features/content/helpers/deriveDescription';
@@ -53,6 +54,25 @@ const pageTitle = post ? `${post.data.title} - Communist Prometheus` : 'Communis
  * + share previews still reflect the article instead of going empty.
  */
 const pageDescription = post ? deriveDescription(post.data.description, post.body) : undefined;
+
+const publishedDate = post ? (post.data.publishDate ?? post.data.pubDate) : undefined;
+const isoDate = publishedDate?.toISOString();
+
+const newspaperRef = await (async () => {
+  if (!post?.data.newspaper) return undefined;
+  const issues = await getCollection('newspaper');
+  const slugFrom = (id: string) => id.split('/').at(0) ?? id;
+  const byKey = new Map(issues.map((i) => [`${i.data.lang}/${slugFrom(i.id)}`, i] as const));
+  const issue =
+    byKey.get(`${lang}/${post.data.newspaper}`) ??
+    byKey.get(`${DEFAULT_LANGUAGE}/${post.data.newspaper}`);
+  if (!issue) return undefined;
+  return {
+    title: issue.data.title,
+    image: issue.data.image,
+    href: `/${lang}/newspaper/${post.data.newspaper}`,
+  };
+})();
 ---
 
 <BaseLayout
@@ -61,35 +81,46 @@ const pageDescription = post ? deriveDescription(post.data.description, post.bod
   lang={lang}
 >
   {post && Content ? (
-    <article class="section">
+    <article class="section" itemscope itemtype="https://schema.org/Article">
+      <meta itemprop="headline" content={post.data.title} />
+      {pageDescription && <meta itemprop="description" content={pageDescription} />}
       <div class="container">
-        <div class="post-header">
+        <header class="post-header">
           <span class="category">{post.data.category}</span>
-          <h1>{post.data.title}</h1>
+          <h1 itemprop="name">{post.data.title}</h1>
           <p class="post-meta">
-            {(post.data.publishDate ?? post.data.pubDate).toLocaleDateString(lang, {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-            })}
+            <time datetime={isoDate} itemprop="datePublished">
+              {publishedDate?.toLocaleDateString(lang, {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+              })}
+            </time>
           </p>
-          {post.data.newspaper && (
+          {newspaperRef && (
             <p class="newspaper-ref">
-              <a
-                href={`/${lang}/newspaper/${post.data.newspaper}`}
-                class="newspaper-link"
-              >
-                ↳ {post.data.newspaper}
+              <a href={newspaperRef.href} class="newspaper-link">
+                {newspaperRef.image && (
+                  <Picture
+                    src={newspaperRef.image}
+                    widths={[80, 160]}
+                    sizes="48px"
+                    formats={['avif', 'webp']}
+                    alt=""
+                    class="newspaper-cover"
+                  />
+                )}
+                <span class="newspaper-title">↳ {newspaperRef.title}</span>
               </a>
             </p>
           )}
-        </div>
+        </header>
         {post.data.image && (
           <div class="featured-image">
             <BlogPicture image={post.data.image} alt={post.data.title} preset="featured" loading="eager" />
           </div>
         )}
-        <div class="prose">
+        <div class="prose" itemprop="articleBody">
           <Content />
         </div>
       </div>
@@ -148,13 +179,26 @@ const pageDescription = post ? deriveDescription(post.data.description, post.bod
   .newspaper-link {
     display: inline-flex;
     align-items: center;
-    gap: 0.25em;
-    padding: 0.25rem 0.625rem;
+    gap: var(--spacing-sm);
+    padding: 0.375rem 0.75rem 0.375rem 0.375rem;
     border-radius: var(--radius-sm);
     background: var(--color-surface-elevated);
     border-left: 3px solid var(--color-warning, #ff9800);
     color: var(--color-text-primary);
     text-decoration: none;
+  }
+
+  .newspaper-link :global(.newspaper-cover) {
+    width: 36px;
+    height: 48px;
+    object-fit: cover;
+    object-position: top;
+    border-radius: var(--radius-sm);
+    flex-shrink: 0;
+  }
+
+  .newspaper-title {
+    line-height: 1.3;
   }
 
   .newspaper-link:hover {

--- a/src/pages/[lang]/positions/[...slug].astro
+++ b/src/pages/[lang]/positions/[...slug].astro
@@ -57,25 +57,30 @@ const pageDescription = entry ? deriveDescription(entry.data.description, entry.
   {...(pageDescription ? { description: pageDescription } : {})}
   lang={lang}
 >
-  <div class="section">
-    <div class="container">
-      <a href={`/${lang}/positions`} class="back-link">{backLabel}</a>
-      {entry && Content ? (
-        <article>
+  {entry && Content ? (
+    <article class="section">
+      <div class="container">
+        <a href={`/${lang}/positions`} class="back-link">{backLabel}</a>
+        <header>
           <h1>{entry.data.title}</h1>
-          <div class="content">
-            <Content />
-          </div>
-        </article>
-      ) : (
+        </header>
+        <div class="content">
+          <Content />
+        </div>
+      </div>
+    </article>
+  ) : (
+    <div class="section">
+      <div class="container">
+        <a href={`/${lang}/positions`} class="back-link">{backLabel}</a>
         <MissingTranslation
           lang={lang}
           availableLangs={availableLangs}
           relativePath={`/positions/${slug}`}
         />
-      )}
+      </div>
     </div>
-  </div>
+  )}
 </BaseLayout>
 
 <style>

--- a/src/pages/[lang]/rss.xml.ts
+++ b/src/pages/[lang]/rss.xml.ts
@@ -1,0 +1,53 @@
+import { getCollection } from 'astro:content';
+import rss from '@astrojs/rss';
+import type { APIContext } from 'astro';
+import { SUPPORTED_LANGUAGES } from '@/config/i18n';
+import { getArticleSlug } from '@/features/blog/helpers/getBlogPosts';
+import { deriveDescription } from '@/features/content/helpers/deriveDescription';
+
+/**
+ * Per-locale RSS feed exposed at `/<lang>/rss.xml`.
+ * Lists every published blog post in that locale, newest first,
+ * carrying title + the same auto-derived description used on the
+ * page (frontmatter description with first-paragraph fallback).
+ *
+ * @returns one feed per supported language.
+ */
+export const getStaticPaths = () => SUPPORTED_LANGUAGES.map((lang) => ({ params: { lang } }));
+
+const SITE_URL = 'https://comprom.org';
+
+/**
+ * Build the RSS feed for the requested locale.
+ *
+ * @param context - Astro endpoint context carrying `params.lang`.
+ * @returns RSS XML response.
+ */
+interface RssParams {
+  readonly lang?: string;
+}
+
+export const GET = async (context: APIContext) => {
+  const params: RssParams = context.params;
+  const lang = params.lang ?? 'en';
+  const posts = await getCollection(
+    'blog',
+    ({ data }) => data.published === true && data.lang === lang,
+  );
+  const items = posts
+    .map((post) => ({
+      title: post.data.title,
+      link: `/${lang}/blog/${getArticleSlug(post)}`,
+      pubDate: post.data.publishDate ?? post.data.pubDate,
+      description: deriveDescription(post.data.description, post.body),
+    }))
+    .sort((a, b) => (b.pubDate?.getTime() ?? 0) - (a.pubDate?.getTime() ?? 0));
+
+  return rss({
+    title: 'Communist Prometheus',
+    description: 'Articles from Communist Prometheus',
+    site: context.site?.toString() ?? SITE_URL,
+    items,
+    customData: `<language>${lang}</language>`,
+  });
+};


### PR DESCRIPTION
## Summary

Closes editor tickets [#11](https://github.com/communist-prometheus/tickets/issues/11), [#13](https://github.com/communist-prometheus/tickets/issues/13), and [#15](https://github.com/communist-prometheus/tickets/issues/15).

- **#11 reader-mode** — positions detail had `<article>` nested deep inside `<div class=section>`, breaking the reader-mode heuristic that ranks blog/about/manifest as readable. Restructured positions to match. Blog detail gains `<header>`, `<time datetime>`, and `schema.org/Article` microdata so Firefox/Safari reader-mode + crawlers agree on what's an article.
- **#13 newspaper link** — blog → newspaper link now resolves the newspaper issue at build time and renders the issue's real title + a 36×48 cropped cover thumbnail to the left of the title (instead of the raw slug).
- **#15 RSS + footer widgets** — adds `@astrojs/rss`, exposes `/<lang>/rss.xml` per supported language, wires `<link rel=alternate type=application/rss+xml>` in `<head>`, and adds RSS + GitHub icon links to the footer. New `e2e/footer.pw.ts` covers the link hrefs and the feed payload.

## Test plan

- [x] `bun run build` clean
- [x] `bunx playwright test e2e/footer.pw.ts` — 3/3 pass
- [ ] Manual smoke: `/en/rss.xml` loads in browser, RSS reader can subscribe
- [ ] Verify reader-mode is now offered on positions detail (was missing before)