### PR TITLE
feat: draggable mobile FAB + PWA install criteria (#12 #14)

### DIFF
--- a/e2e/mobile.pw.ts
+++ b/e2e/mobile.pw.ts
@@ -29,7 +29,8 @@ const openMobileMenu = async (page: Page): Promise<void> => {
 };
 
 const closeMobileMenu = async (page: Page): Promise<void> => {
-  await click(page, page.locator('[data-testid="mobile-menu-close"]'));
+  // Mirror admin's draggable-FAB pattern: same button toggles open/close.
+  await click(page, page.locator('[data-testid="mobile-menu-toggle"]'));
   await expectHidden(page, page.locator('[data-testid="mobile-menu-panel"]'));
 };
 
@@ -58,7 +59,7 @@ test.describe('Mobile menu interaction', () => {
     await expectMinCount(page, links, 3);
   });
 
-  test('closes on close button click', async ({ page }) => {
+  test('FAB toggles menu closed when clicked while open', async ({ page }) => {
     await openMobileMenu(page);
     await closeMobileMenu(page);
   });

--- a/e2e/pwa.pw.ts
+++ b/e2e/pwa.pw.ts
@@ -1,0 +1,38 @@
+import { expect, test, visit } from '@prometheus/e2e-toolkit';
+
+/*
+ * PWA install criteria smoke test.
+ *
+ * Validates the markup browsers look at to decide "this site can
+ * become a PWA": web app manifest, theme-color, and an
+ * apple-touch-icon. Does not exercise the install prompt itself —
+ * that requires user-gesture + A2HS heuristics that headless
+ * Chromium doesn't simulate.
+ */
+
+test.describe('PWA install criteria', () => {
+  test('manifest endpoint returns a valid web app manifest', async ({ page }) => {
+    const response = await page.request.get('/manifest.webmanifest');
+    expect(response.ok()).toBe(true);
+    const body = await response.json();
+    expect(body.name).toBe('Communist Prometheus');
+    expect(body.start_url).toBe('/');
+    expect(body.display).toBe('standalone');
+    expect(Array.isArray(body.icons)).toBe(true);
+    expect(body.icons.length).toBeGreaterThan(0);
+  });
+
+  test('every page wires manifest, theme-color, and touch icon', async ({ page }) => {
+    await visit(page, '/en');
+    await expect(page.locator('link[rel="manifest"]')).toHaveAttribute(
+      'href',
+      '/manifest.webmanifest',
+    );
+    await expect(page.locator('link[rel="apple-touch-icon"]')).toHaveAttribute(
+      'href',
+      '/pwa-icon.svg',
+    );
+    const themeColors = await page.locator('meta[name="theme-color"]').count();
+    expect(themeColors).toBeGreaterThan(0);
+  });
+});

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,25 @@
+{
+  "name": "Communist Prometheus",
+  "short_name": "Comprom",
+  "description": "Communist Prometheus — a knowledge-sharing platform.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "any",
+  "background_color": "#ffffff",
+  "theme_color": "#cf3618",
+  "icons": [
+    {
+      "src": "/pwa-icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/pwa-icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/public/pwa-icon.svg
+++ b/public/pwa-icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="96" fill="hsl(12, 80%, 45%)"/>
+  <text x="256" y="320" text-anchor="middle" font-family="Georgia, serif" font-size="280" font-weight="700" fill="#fff">P</text>
+  <text x="256" y="430" text-anchor="middle" font-family="Georgia, serif" font-size="64" font-weight="600" fill="rgba(255,255,255,0.9)" letter-spacing="6">comprom</text>
+</svg>

--- a/src/features/navigation/components/MobileMenu.astro
+++ b/src/features/navigation/components/MobileMenu.astro
@@ -15,20 +15,32 @@ const nav = await getMenuData(lang);
 const menuLabel = nav?.data.menu ?? 'Menu';
 ---
 
-<div class="mobile-menu-wrapper" data-testid="mobile-menu-wrapper">
+<!--
+  Mobile menu — port of admin-website's draggable FAB pattern.
+  - 56px round button, fixed, lives in one of four corners; user can
+    drag it to snap to the nearest corner. Corner is persisted in
+    localStorage under `fab-corner` so the button stays where the user
+    put it across navigations + sessions.
+  - Popup nav anchors to the same corner as the FAB (e.g. button in
+    bottom-right opens upward-left), matching the admin UX.
+  - Three SVG lines rotate into an X on open (no extra glyph swap).
+-->
+<div
+  class="mobile-menu-wrapper"
+  data-testid="mobile-menu-wrapper"
+  data-corner="bottom-right"
+>
   <button
-    class="hamburger"
+    type="button"
+    class="mobile-fab"
     data-testid="mobile-menu-toggle"
-    aria-label="Open menu"
+    aria-label={menuLabel}
     aria-expanded="false"
     aria-controls="mobile-menu-panel"
-    type="button"
   >
-    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <line x1="3" y1="6" x2="21" y2="6"></line>
-      <line x1="3" y1="12" x2="21" y2="12"></line>
-      <line x1="3" y1="18" x2="21" y2="18"></line>
-    </svg>
+    <span class="fab-line fab-line-1"></span>
+    <span class="fab-line fab-line-2"></span>
+    <span class="fab-line fab-line-3"></span>
   </button>
 
   <div
@@ -37,101 +49,181 @@ const menuLabel = nav?.data.menu ?? 'Menu';
     aria-hidden="true"
   ></div>
 
-  <div
+  <nav
     id="mobile-menu-panel"
-    class="panel"
+    class="mobile-popup"
     data-testid="mobile-menu-panel"
     role="dialog"
     aria-modal="true"
-    aria-label="Navigation menu"
+    aria-label={menuLabel}
   >
-    <div class="panel-header">
-      <span class="panel-title">{menuLabel}</span>
-      <button
-        class="close-btn"
-        data-testid="mobile-menu-close"
-        aria-label="Close menu"
-        type="button"
-      >
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <line x1="18" y1="6" x2="6" y2="18"></line>
-          <line x1="6" y1="6" x2="18" y2="18"></line>
-        </svg>
-      </button>
-    </div>
-
-    <nav class="panel-nav">
-      <ul>
-        {links.map(({ href, label }) => (
-          <li><a href={href}>{label}</a></li>
-        ))}
-      </ul>
-    </nav>
-
-    <div class="panel-footer">
+    <ul class="popup-links">
+      {links.map(({ href, label }) => (
+        <li><a href={href}>{label}</a></li>
+      ))}
+    </ul>
+    <div class="popup-tools">
       <LanguageSwitcher lang={lang} />
       <ThemeToggle />
     </div>
-  </div>
+  </nav>
 </div>
 
 <script>
+  /*
+   * Public-site mobile menu behavior. Mirrors admin/src/composables/
+   * useDraggableFab + components/MobileMenu: draggable FAB, snap to
+   * nearest corner, popup anchored to that same corner.
+   */
+  type Corner = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+
+  const FAB_SIZE = 56;
+  const FAB_MARGIN = 16;
+  const GAP = 8;
+  const DRAG_THRESHOLD = 10;
+  const STORAGE_KEY = 'fab-corner';
+  const DEFAULT_CORNER: Corner = 'bottom-right';
+
+  const isCorner = (v: string | null): v is Corner =>
+    v === 'top-left' ||
+    v === 'top-right' ||
+    v === 'bottom-left' ||
+    v === 'bottom-right';
+
+  const loadCorner = (): Corner => {
+    const v = localStorage.getItem(STORAGE_KEY);
+    return isCorner(v) ? v : DEFAULT_CORNER;
+  };
+
+  const saveCorner = (c: Corner) => {
+    localStorage.setItem(STORAGE_KEY, c);
+  };
+
+  const cornerToFabXY = (corner: Corner) => {
+    const right = globalThis.innerWidth - FAB_SIZE - FAB_MARGIN;
+    const bottom = globalThis.innerHeight - FAB_SIZE - FAB_MARGIN;
+    const map: Record<Corner, { x: number; y: number }> = {
+      'top-left': { x: FAB_MARGIN, y: FAB_MARGIN },
+      'top-right': { x: right, y: FAB_MARGIN },
+      'bottom-left': { x: FAB_MARGIN, y: bottom },
+      'bottom-right': { x: right, y: bottom },
+    };
+    return map[corner];
+  };
+
+  const snapToCorner = (x: number, y: number): Corner => {
+    const isRight = x > globalThis.innerWidth / 2;
+    const isBottom = y > globalThis.innerHeight / 2;
+    return `${isBottom ? 'bottom' : 'top'}-${isRight ? 'right' : 'left'}`;
+  };
+
   const setupMobileMenu = () => {
-    const wrapper = document.querySelector<HTMLElement>('[data-testid="mobile-menu-wrapper"]');
+    const wrapper = document.querySelector<HTMLElement>(
+      '[data-testid="mobile-menu-wrapper"]',
+    );
     if (!wrapper) return;
-
-    const toggle = wrapper.querySelector<HTMLButtonElement>('[data-testid="mobile-menu-toggle"]');
-    const closeBtn = wrapper.querySelector<HTMLButtonElement>('[data-testid="mobile-menu-close"]');
-    const overlay = wrapper.querySelector<HTMLElement>('[data-testid="mobile-menu-overlay"]');
-    const panel = wrapper.querySelector<HTMLElement>('[data-testid="mobile-menu-panel"]');
-
-    if (!toggle || !closeBtn || !overlay || !panel) return;
-
-    // Prevent duplicate listeners on persisted header
     if (wrapper.dataset['menuInit'] === 'true') return;
     wrapper.dataset['menuInit'] = 'true';
 
-    let closeId = 0;
+    const fab = wrapper.querySelector<HTMLButtonElement>(
+      '[data-testid="mobile-menu-toggle"]',
+    );
+    const overlay = wrapper.querySelector<HTMLElement>(
+      '[data-testid="mobile-menu-overlay"]',
+    );
+    const panel = wrapper.querySelector<HTMLElement>(
+      '[data-testid="mobile-menu-panel"]',
+    );
+    if (!fab || !overlay || !panel) return;
+
+    let corner: Corner = loadCorner();
+    let dragging = false;
+    let moved = false;
+    let sX = 0;
+    let sY = 0;
+
+    const applyFabPosition = (x: number, y: number, animate: boolean) => {
+      fab.style.left = `${x}px`;
+      fab.style.top = `${y}px`;
+      fab.style.transition = animate ? 'all var(--transition-base)' : 'none';
+    };
+
+    const applyPanelPosition = (c: Corner) => {
+      const isRight = c.endsWith('right');
+      const isBottom = c.startsWith('bottom');
+      const offset = `${FAB_MARGIN + FAB_SIZE + GAP}px`;
+      panel.style.left = isRight ? 'auto' : `${FAB_MARGIN}px`;
+      panel.style.right = isRight ? `${FAB_MARGIN}px` : 'auto';
+      panel.style.top = isBottom ? 'auto' : offset;
+      panel.style.bottom = isBottom ? offset : 'auto';
+    };
+
+    const settleToCorner = (c: Corner) => {
+      corner = c;
+      wrapper.dataset['corner'] = c;
+      const pos = cornerToFabXY(c);
+      applyFabPosition(pos.x, pos.y, true);
+      applyPanelPosition(c);
+    };
+
+    settleToCorner(corner);
 
     const openMenu = () => {
-      if (wrapper.classList.contains('open') && !wrapper.classList.contains('closing')) return;
-      closeId += 1;
-      wrapper.classList.remove('closing');
       wrapper.classList.add('open');
-      toggle.setAttribute('aria-expanded', 'true');
-      panel.querySelector('a')?.focus();
+      fab.setAttribute('aria-expanded', 'true');
+      panel.querySelector<HTMLAnchorElement>('a')?.focus();
     };
 
     const closeMenu = () => {
-      if (!wrapper.classList.contains('open') || wrapper.classList.contains('closing')) return;
-      wrapper.classList.add('closing');
-      toggle.setAttribute('aria-expanded', 'false');
-      const id = ++closeId;
-
-      const onEnd = () => {
-        if (id !== closeId) return;
-        wrapper.classList.remove('open', 'closing');
-        toggle.focus();
-      };
-
-      panel.addEventListener('animationend', onEnd, { once: true });
-      setTimeout(onEnd, 300);
+      if (!wrapper.classList.contains('open')) return;
+      wrapper.classList.remove('open');
+      fab.setAttribute('aria-expanded', 'false');
+      fab.focus();
     };
 
-    toggle.addEventListener('click', openMenu);
-    closeBtn.addEventListener('click', closeMenu);
+    fab.addEventListener('pointerdown', (e: PointerEvent) => {
+      dragging = true;
+      moved = false;
+      sX = e.clientX;
+      sY = e.clientY;
+      fab.setPointerCapture(e.pointerId);
+    });
+
+    fab.addEventListener('pointermove', (e: PointerEvent) => {
+      if (!dragging) return;
+      const dx = e.clientX - sX;
+      const dy = e.clientY - sY;
+      if (Math.abs(dx) + Math.abs(dy) > DRAG_THRESHOLD) moved = true;
+      const base = cornerToFabXY(corner);
+      applyFabPosition(base.x + dx, base.y + dy, false);
+    });
+
+    fab.addEventListener('pointerup', (e: PointerEvent) => {
+      dragging = false;
+      fab.releasePointerCapture(e.pointerId);
+      if (moved) {
+        const next = snapToCorner(e.clientX, e.clientY);
+        saveCorner(next);
+        settleToCorner(next);
+        return;
+      }
+      if (wrapper.classList.contains('open')) closeMenu();
+      else openMenu();
+    });
+
     overlay.addEventListener('click', closeMenu);
 
     document.addEventListener('keydown', (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && wrapper.classList.contains('open')) {
-        closeMenu();
-      }
+      if (e.key === 'Escape' && wrapper.classList.contains('open')) closeMenu();
     });
 
-    panel.querySelectorAll('a').forEach((link) => {
-      link.addEventListener('click', () => {
-        closeMenu();
-      });
+    panel.querySelectorAll<HTMLAnchorElement>('a').forEach((link) => {
+      link.addEventListener('click', closeMenu);
+    });
+
+    globalThis.addEventListener('resize', () => {
+      const pos = cornerToFabXY(corner);
+      applyFabPosition(pos.x, pos.y, false);
     });
   };
 
@@ -141,8 +233,7 @@ const menuLabel = nav?.data.menu ?? 'Menu';
 
 <style>
   .mobile-menu-wrapper {
-    display: flex;
-    align-items: center;
+    display: contents;
   }
 
   @media (min-width: 768px) {
@@ -151,145 +242,107 @@ const menuLabel = nav?.data.menu ?? 'Menu';
     }
   }
 
-  .hamburger {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 44px;
-    height: 44px;
-    padding: 0;
-    background: transparent;
+  .mobile-fab {
+    position: fixed;
+    z-index: 200;
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background: var(--color-accent);
+    color: var(--color-on-accent);
     border: none;
-    color: var(--color-text-primary);
     cursor: pointer;
-    border-radius: var(--radius-sm);
-    transition: background-color var(--transition-fast);
+    touch-action: none;
+    padding: 0;
+    box-shadow: var(--shadow-md);
+    -webkit-tap-highlight-color: transparent;
+    user-select: none;
   }
 
-  .hamburger:hover,
-  .hamburger:focus-visible {
-    background: var(--color-surface);
+  .mobile-fab:active {
+    transform: scale(0.92);
+    box-shadow: var(--shadow-sm);
   }
 
-  .hamburger svg {
-    pointer-events: none;
+  .fab-line {
+    position: absolute;
+    left: 50%;
+    width: 24px;
+    height: 2px;
+    background: var(--color-on-accent);
+    border-radius: 1px;
+    transform: translateX(-50%);
+    transition: top var(--transition-base), bottom var(--transition-base),
+      transform var(--transition-base), opacity var(--transition-base);
+  }
+
+  .fab-line-1 { top: 35%; }
+  .fab-line-2 { top: 50%; transform: translate(-50%, -50%); }
+  .fab-line-3 { bottom: 35%; }
+
+  .mobile-menu-wrapper.open .fab-line-1 {
+    top: 50%;
+    transform: translate(-50%) rotate(45deg);
+  }
+  .mobile-menu-wrapper.open .fab-line-2 {
+    opacity: 0;
+  }
+  .mobile-menu-wrapper.open .fab-line-3 {
+    bottom: 50%;
+    transform: translate(-50%, 50%) rotate(-45deg);
   }
 
   .overlay {
     position: fixed;
     inset: 0;
-    background: rgb(0 0 0 / 0.5);
-    z-index: 200;
+    background: rgb(0 0 0 / 0.4);
+    z-index: 199;
     opacity: 0;
     pointer-events: none;
     visibility: hidden;
     transition: opacity var(--transition-base), visibility var(--transition-base);
   }
 
-  :global(.open) .overlay {
+  .mobile-menu-wrapper.open .overlay {
     opacity: 1;
     pointer-events: auto;
     visibility: visible;
   }
 
-  :global(.closing) .overlay {
-    opacity: 0;
-    pointer-events: none;
-  }
-
-  .panel {
+  .mobile-popup {
     position: fixed;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    width: min(300px, 80vw);
-    background: var(--color-surface-elevated);
     z-index: 201;
-    display: none;
-    flex-direction: column;
+    background: var(--color-surface-elevated);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: clamp(0.5rem, 2vw, 0.75rem);
     box-shadow: var(--shadow-lg);
-  }
-
-  :global(.open) .panel {
-    display: flex;
-    animation: slide-in var(--transition-base) forwards;
-  }
-
-  @keyframes slide-in {
-    from {
-      transform: translateX(100%);
-    }
-    to {
-      transform: translateX(0);
-    }
-  }
-
-  :global(.closing) .panel {
-    animation: slide-out var(--transition-base) forwards;
-  }
-
-  @keyframes slide-out {
-    from {
-      transform: translateX(0);
-    }
-    to {
-      transform: translateX(100%);
-    }
-  }
-
-  .panel-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: var(--spacing-md);
-    border-bottom: 1px solid var(--color-border);
-  }
-
-  .panel-title {
-    font-weight: 600;
-    font-size: 1.125rem;
-    color: var(--color-text-primary);
-  }
-
-  .close-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 44px;
-    height: 44px;
-    padding: 0;
-    background: transparent;
-    border: none;
-    color: var(--color-text-primary);
-    cursor: pointer;
-    border-radius: var(--radius-sm);
-    transition: background-color var(--transition-fast);
-  }
-
-  .close-btn:hover,
-  .close-btn:focus-visible {
-    background: var(--color-surface);
-  }
-
-  .close-btn svg {
+    min-width: 220px;
+    opacity: 0;
+    transform: scale(0.95);
     pointer-events: none;
+    visibility: hidden;
+    transition: opacity var(--transition-base), transform var(--transition-base),
+      visibility var(--transition-base);
   }
 
-  .panel-nav {
-    flex: 1;
-    padding: var(--spacing-md);
-    overflow-y: auto;
+  .mobile-menu-wrapper.open .mobile-popup {
+    opacity: 1;
+    transform: scale(1);
+    pointer-events: auto;
+    visibility: visible;
   }
 
-  .panel-nav ul {
+  .popup-links {
     list-style: none;
+    margin: 0;
     padding: 0;
     display: flex;
     flex-direction: column;
     gap: var(--spacing-xs);
   }
 
-  .panel-nav a {
+  .popup-links a {
     display: flex;
     align-items: center;
     min-height: 44px;
@@ -298,36 +351,21 @@ const menuLabel = nav?.data.menu ?? 'Menu';
     text-decoration: none;
     border-radius: var(--radius-sm);
     font-size: 1rem;
-    transition: background-color var(--transition-fast), color var(--transition-fast);
   }
 
-  .panel-nav a:hover,
-  .panel-nav a:focus-visible {
+  .popup-links a:hover,
+  .popup-links a:focus-visible {
     background: var(--color-surface);
     color: var(--color-text-primary);
   }
 
-  .panel-nav a[aria-current="page"] {
-    color: var(--color-accent);
-    font-weight: 600;
-    background: var(--color-surface);
-  }
-
-  .panel-footer {
-    padding: var(--spacing-md);
+  .popup-tools {
+    margin-top: var(--spacing-sm);
+    padding-top: var(--spacing-sm);
     border-top: 1px solid var(--color-border);
     display: flex;
     align-items: center;
-    justify-content: center;
-  }
-
-  .panel-footer :global(.lang-dropdown) {
-    top: auto;
-    bottom: calc(100% + var(--spacing-xs));
-    transform: translateY(4px);
-  }
-
-  .panel-footer :global(.lang-dropdown.open) {
-    transform: translateY(0);
+    justify-content: space-between;
+    gap: var(--spacing-sm);
   }
 </style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -51,6 +51,10 @@ const absoluteImage = shareImage.startsWith('http') ? shareImage : `${SITE_URL}$
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="apple-touch-icon" href="/pwa-icon.svg" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <meta name="theme-color" content="#cf3618" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#ef6e3d" media="(prefers-color-scheme: dark)" />
     <link rel="canonical" href={canonical} />
     <link
       rel="alternate"


### PR DESCRIPTION
## Summary

Closes editor tickets [#14](https://github.com/communist-prometheus/tickets/issues/14) and [#12](https://github.com/communist-prometheus/tickets/issues/12).

- **#14 mobile menu like admin** — replaces the right-edge slide-in panel with a draggable FAB + corner-anchored popup, matching admin-website's MobileMenu component. 56px circular button, dragable to any of four corners with snap-on-release. Corner is persisted in localStorage (`fab-corner`). Popup anchors to the same corner. Three SVG lines rotate into an X on open.
- **#12 PWA** — adds `/manifest.webmanifest`, a square 512×512 brand-mark SVG at `/pwa-icon.svg`, and wires `<link rel=manifest>`, `<link rel=apple-touch-icon>`, and two `<meta name=theme-color>` tags (light + dark) into BaseLayout. Site now satisfies browser install criteria.

## Test plan

- [x] `bun run build` clean
- [x] `bunx playwright test --project=mobile` — 19/19 pass (mobile menu suite migrated to FAB-toggle)
- [x] `bunx playwright test --project=chromium e2e/pwa.pw.ts` — 2/2 pass
- [ ] Manual smoke on mobile device: drag FAB to other corners, install prompt