### PR TITLE
fix: make pubDate optional, align with admin save flow

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -10,7 +10,14 @@ const blogCollection = defineCollection({
       title: z.string(),
       description: z.string(),
       category: z.string(),
-      pubDate: z.date(),
+      /*
+       * `pubDate` is legacy; `publishDate` is the canonical publish
+       * timestamp set by the admin when the editor flips Published
+       * on. Both optional so an in-progress draft saves cleanly
+       * without forcing the editor to invent a date — public pages
+       * already tolerate missing dates via `?? new Date(0)` fallbacks.
+       */
+      pubDate: z.date().optional(),
       /*
        * Absent / non-true `published` means draft. The build does NOT
        * render drafts (see getBlogPosts). Editors must explicitly set

--- a/src/features/blog/helpers/getBlogPosts.ts
+++ b/src/features/blog/helpers/getBlogPosts.ts
@@ -5,7 +5,7 @@ export const getArticleSlug = (entry: CollectionEntry<'blog'>): string =>
   entry.id.split('/').at(0) ?? entry.id;
 
 const sortDate = (entry: CollectionEntry<'blog'>): number =>
-  (entry.data.publishDate ?? entry.data.pubDate).getTime();
+  (entry.data.publishDate ?? entry.data.pubDate ?? new Date(0)).getTime();
 
 export const getBlogPosts = async (lang: Language): Promise<CollectionEntry<'blog'>[]> => {
   const posts = await getCollection(


### PR DESCRIPTION
## Summary

Resolves the divergence flagged by admin-website#9. The admin's save validation (commit ceed3e2) requires title/description/category/lang but does **not** write \`pubDate\` — \`publishDate\` is the canonical publish timestamp. The public schema kept \`pubDate: z.date()\` required though, so any admin-saved article still crashed the public build.

- \`src/content.config.ts\` — \`pubDate\` now \`z.date().optional()\` for blog (positions/newspaper were already optional)
- \`getBlogPosts.ts\` — sort fallback \`?? new Date(0)\` for entries with neither field

## Test plan

- [x] \`bun run build\` clean with master content