### PR TITLE
fix: mobile lang switcher — flat chips replace dropdown to stop off-screen overflow

### DIFF
--- a/e2e/mobile.pw.ts
+++ b/e2e/mobile.pw.ts
@@ -151,13 +151,22 @@ test.describe('Mobile menu controls', () => {
     await expectVisible(page, switcher);
   });
 
-  test('language switcher opens dropdown in mobile menu', async ({ page }) => {
+  test('all language chips are visible in mobile menu (flat list, no dropdown)', async ({
+    page,
+  }) => {
+    /*
+     * The mobile FAB popup renders languages as a flat row of chips
+     * — no toggle, no overlay. The desktop header keeps the
+     * dropdown variant. This test guards against regressions where
+     * the dropdown variant slips back into the popup and chips
+     * fall off-screen.
+     */
     await openMobileMenu(page);
     const switcher = page.locator(
       '[data-testid="mobile-menu-panel"] [data-testid="language-switcher"]',
     );
-    await click(page, switcher.locator('.lang-trigger'));
-    await expectVisible(page, switcher.locator('[data-testid="language-dropdown"]'));
+    await expectVisible(page, switcher.locator('[data-testid="lang-option-en"]'));
+    await expectVisible(page, switcher.locator('[data-testid="lang-option-ru"]'));
   });
 
   test('language switcher navigates to another language from mobile menu', async ({ page }) => {
@@ -165,7 +174,6 @@ test.describe('Mobile menu controls', () => {
     const switcher = page.locator(
       '[data-testid="mobile-menu-panel"] [data-testid="language-switcher"]',
     );
-    await click(page, switcher.locator('.lang-trigger'));
     const ruOption = switcher.locator('[data-testid="lang-option-ru"]');
     await expectVisible(page, ruOption);
     await click(page, ruOption);

--- a/src/features/navigation/components/MobileMenu.astro
+++ b/src/features/navigation/components/MobileMenu.astro
@@ -1,8 +1,8 @@
 ---
 import type { Language } from '@/config/i18n';
+import { LANGUAGE_LABELS, SUPPORTED_LANGUAGES } from '@/config/i18n';
 import { getMenuData, getNavLinks } from '@/config/translations';
 import ThemeToggle from '@/features/theme/components/ThemeToggle.astro';
-import LanguageSwitcher from './LanguageSwitcher.astro';
 
 interface Props {
   lang: Language;
@@ -13,6 +13,20 @@ const { lang } = Astro.props;
 const links = await getNavLinks(lang);
 const nav = await getMenuData(lang);
 const menuLabel = nav?.data.menu ?? 'Menu';
+
+/*
+ * On mobile we render languages as a flat row of chips — the same
+ * dropdown-style switcher the desktop header uses overflows the FAB
+ * popup (the dropdown opens downward and lands off-screen when the
+ * popup is already at the viewport edge). A flat row fits in one
+ * line for our 4–7 languages and is always reachable without a
+ * second click.
+ */
+const restPath = (() => {
+  const path = Astro.url.pathname.replace(/^\/[a-z]{2}(?=\/|$)/, '');
+  return path === '' ? '' : path;
+})();
+const langHref = (code: string) => (restPath === '' ? `/${code}` : `/${code}${restPath}`);
 ---
 
 <!--
@@ -62,8 +76,25 @@ const menuLabel = nav?.data.menu ?? 'Menu';
         <li><a href={href}>{label}</a></li>
       ))}
     </ul>
+    <div
+      class="popup-langs"
+      role="group"
+      aria-label="Select language"
+      data-testid="language-switcher"
+    >
+      {SUPPORTED_LANGUAGES.map((code) => (
+        <a
+          href={langHref(code)}
+          data-testid={`lang-option-${code}`}
+          aria-current={code === lang ? 'page' : undefined}
+          class:list={['popup-lang', { active: code === lang }]}
+          title={LANGUAGE_LABELS[code]}
+        >
+          {code.toUpperCase()}
+        </a>
+      ))}
+    </div>
     <div class="popup-tools">
-      <LanguageSwitcher lang={lang} />
       <ThemeToggle />
     </div>
   </nav>
@@ -359,13 +390,55 @@ const menuLabel = nav?.data.menu ?? 'Menu';
     color: var(--color-text-primary);
   }
 
+  .popup-langs {
+    margin-top: var(--spacing-sm);
+    padding-top: var(--spacing-sm);
+    border-top: 1px solid var(--color-border);
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-xs);
+  }
+
+  .popup-lang {
+    flex: 1 1 calc(33% - var(--spacing-xs));
+    min-width: 48px;
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--spacing-xs);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    color: var(--color-text-secondary);
+    text-decoration: none;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    transition:
+      background-color var(--transition-fast),
+      color var(--transition-fast),
+      border-color var(--transition-fast);
+  }
+
+  .popup-lang:hover,
+  .popup-lang:focus-visible {
+    background: var(--color-surface);
+    color: var(--color-text-primary);
+    border-color: var(--color-text-secondary);
+  }
+
+  .popup-lang.active {
+    background: var(--color-accent);
+    color: var(--color-on-accent);
+    border-color: var(--color-accent);
+  }
+
   .popup-tools {
     margin-top: var(--spacing-sm);
     padding-top: var(--spacing-sm);
     border-top: 1px solid var(--color-border);
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    gap: var(--spacing-sm);
+    justify-content: center;
   }
 </style>


### PR DESCRIPTION
## Summary

Fixes a regression that the editor flagged as urgent after the mobile FAB redesign (#67):

- The desktop \`LanguageSwitcher.astro\` renders an absolute-positioned dropdown that opens **downward** (\`top: calc(100% + xs); right: 0\`). 
- The mobile FAB popup is itself at the viewport edge.
- So the dropdown spilled below the popup and the language list landed **off-screen / unreachable**.

Solution — render languages flat inside the FAB popup. Row of one-tap chips (one per supported language), always visible, fits in one line for 4–7 locales without an overlay. The desktop header keeps the dropdown variant where there's room and a non-edge anchor.

## Test plan

- [x] \`bun run build\` clean
- [x] \`bunx playwright test --project=mobile\` — 19/19 pass
- [x] Test contract preserved: \`[data-testid=language-switcher]\` and \`[data-testid=lang-option-<code>]\`. Removed \`language-dropdown\` assertion (no dropdown to expand). Added a chip-visibility regression test.