### PR TITLE
feat: SmartDropdown — reusable viewport-aware dropdown with tests

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
         "lint-staged": "^16.2.7",
         "playwright-lighthouse": "^4.0.0",
         "typescript": "^5.9.3",
+        "vitest": "^4.1.5",
       },
     },
   },
@@ -405,11 +406,17 @@
 
     "@sindresorhus/base62": ["@sindresorhus/base62@1.0.0", "", {}, "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
 
@@ -463,6 +470,20 @@
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
+    "@vitest/expect": ["@vitest/expect@4.1.5", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.5", "", { "dependencies": { "@vitest/spy": "4.1.5", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.5", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.5", "", { "dependencies": { "@vitest/utils": "4.1.5", "pathe": "^2.0.3" } }, "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "@vitest/utils": "4.1.5", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.5", "", {}, "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug=="],
+
     "@volar/kit": ["@volar/kit@2.4.28", "", { "dependencies": { "@volar/language-service": "2.4.28", "@volar/typescript": "2.4.28", "typesafe-path": "^0.2.2", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "typescript": "*" } }, "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg=="],
 
     "@volar/language-core": ["@volar/language-core@2.4.28", "", { "dependencies": { "@volar/source-map": "2.4.28" } }, "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ=="],
@@ -514,6 +535,8 @@
     "array-flatten": ["array-flatten@1.1.1", "", {}, "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="],
 
     "array-iterate": ["array-iterate@2.0.1", "", {}, "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
 
@@ -573,6 +596,8 @@
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
@@ -630,6 +655,8 @@
     "content-disposition": ["content-disposition@0.5.4", "", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ=="],
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
@@ -729,7 +756,7 @@
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
-    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+    "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
@@ -774,6 +801,8 @@
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "express": ["express@4.22.1", "", { "dependencies": { "accepts": "~1.3.8", "array-flatten": "1.1.1", "body-parser": "~1.20.3", "content-disposition": "~0.5.4", "content-type": "~1.0.4", "cookie": "~0.7.1", "cookie-signature": "~1.0.6", "debug": "2.6.9", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "~1.3.1", "fresh": "~0.5.2", "http-errors": "~2.0.0", "merge-descriptors": "1.0.3", "methods": "~1.1.2", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "path-to-regexp": "~0.1.12", "proxy-addr": "~2.0.7", "qs": "~6.14.0", "range-parser": "~1.2.1", "safe-buffer": "5.2.1", "send": "~0.19.0", "serve-static": "~1.16.2", "setprototypeof": "1.2.0", "statuses": "~2.0.1", "type-is": "~1.6.18", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g=="],
 
@@ -1177,6 +1206,8 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
+    "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+
     "ofetch": ["ofetch@1.5.1", "", { "dependencies": { "destr": "^2.0.5", "node-fetch-native": "^1.6.7", "ufo": "^1.6.1" } }, "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA=="],
 
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
@@ -1240,6 +1271,8 @@
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
     "path-to-regexp": ["path-to-regexp@0.1.12", "", {}, "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
@@ -1409,6 +1442,8 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
@@ -1439,7 +1474,11 @@
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
     "streamx": ["streamx@2.23.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg=="],
 
@@ -1477,9 +1516,13 @@
 
     "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
 
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
     "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "tldts-core": ["tldts-core@7.0.25", "", {}, "sha512-ZjCZK0rppSBu7rjHYDYsEaMOIbbT+nWF57hKkv4IUmZWBNrBWBOjIElc0mKRgLM8bm7x/BBlof6t2gi/Oq/Asw=="],
 
@@ -1581,6 +1624,8 @@
 
     "vitefu": ["vitefu@1.1.1", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ=="],
 
+    "vitest": ["vitest@4.1.5", "", { "dependencies": { "@vitest/expect": "4.1.5", "@vitest/mocker": "4.1.5", "@vitest/pretty-format": "4.1.5", "@vitest/runner": "4.1.5", "@vitest/snapshot": "4.1.5", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.5", "@vitest/browser-preview": "4.1.5", "@vitest/browser-webdriverio": "4.1.5", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg=="],
+
     "volar-service-css": ["volar-service-css@0.0.68", "", { "dependencies": { "vscode-css-languageservice": "^6.3.0", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-lJSMh6f3QzZ1tdLOZOzovLX0xzAadPhx8EKwraDLPxBndLCYfoTvnNuiFFV8FARrpAlW5C0WkH+TstPaCxr00Q=="],
 
     "volar-service-emmet": ["volar-service-emmet@0.0.68", "", { "dependencies": { "@emmetio/css-parser": "^0.4.1", "@emmetio/html-matcher": "^1.3.0", "@vscode/emmet-helper": "^2.9.3", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-nHvixrRQ83EzkQ4G/jFxu9Y4eSsXS/X2cltEPDM+K9qZmIv+Ey1w0tg1+6caSe8TU5Hgw4oSTwNMf/6cQb3LzQ=="],
@@ -1632,6 +1677,8 @@
     "which-module": ["which-module@2.0.1", "", {}, "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="],
 
     "which-pm-runs": ["which-pm-runs@1.1.0", "", {}, "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "widest-line": ["widest-line@5.0.0", "", { "dependencies": { "string-width": "^7.0.0" } }, "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA=="],
 
@@ -1718,6 +1765,8 @@
     "ajv-draft-04/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "astro/es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
     "astro/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 

--- a/e2e/mobile.pw.ts
+++ b/e2e/mobile.pw.ts
@@ -151,35 +151,40 @@ test.describe('Mobile menu controls', () => {
     await expectVisible(page, switcher);
   });
 
-  test('language dropdown stays inside the viewport when opened in mobile menu', async ({
-    page,
-  }) => {
-    /*
-     * The desktop dropdown opens downward; inside the FAB popup
-     * (anchored to the bottom-right corner by default) that puts
-     * the list off-screen. Mobile menu now flips the dropdown to
-     * open upward via [data-corner^=bottom-]. Asserts the dropdown
-     * box lands fully within the viewport rectangle.
-     */
-    await openMobileMenu(page);
-    const switcher = page.locator(
-      '[data-testid="mobile-menu-panel"] [data-testid="language-switcher"]',
-    );
-    await click(page, switcher.locator('.lang-trigger'));
-    const dropdown = switcher.locator('[data-testid="language-dropdown"]');
-    await expectVisible(page, dropdown);
-    const fitsViewport = await page.evaluate(() => {
-      const el = document.querySelector(
-        '[data-testid="mobile-menu-panel"] [data-testid="language-dropdown"]',
+  for (const corner of ['bottom-right', 'bottom-left', 'top-right', 'top-left'] as const) {
+    test(`language dropdown fits inside viewport when FAB is at ${corner}`, async ({ page }) => {
+      /*
+       * The FAB-corner persistence sits in localStorage. Pre-seed it
+       * before the page loads so the FAB lands in the requested
+       * corner and the popup anchors correspondingly. The dropdown
+       * is then opened and we assert its bounding box fits within
+       * the viewport rectangle. Drives every supported corner so a
+       * regression in pickPlacement fails loud.
+       */
+      await page.addInitScript((c: string) => {
+        localStorage.setItem('fab-corner', c);
+      }, corner);
+      await visit(page, BASE);
+      await openMobileMenu(page);
+      const switcher = page.locator(
+        '[data-testid="mobile-menu-panel"] [data-testid="language-switcher"]',
       );
-      if (!el) return false;
-      const r = el.getBoundingClientRect();
-      const vh = window.innerHeight;
-      const vw = window.innerWidth;
-      return r.top >= 0 && r.left >= 0 && r.bottom <= vh && r.right <= vw;
+      await click(page, switcher.locator('.lang-trigger'));
+      const dropdown = switcher.locator('[data-testid="language-dropdown"]');
+      await expectVisible(page, dropdown);
+      const fitsViewport = await page.evaluate(() => {
+        const el = document.querySelector(
+          '[data-testid="mobile-menu-panel"] [data-testid="language-dropdown"]',
+        );
+        if (!el) return false;
+        const r = el.getBoundingClientRect();
+        const vh = globalThis.innerHeight;
+        const vw = globalThis.innerWidth;
+        return r.top >= 0 && r.left >= 0 && r.bottom <= vh && r.right <= vw;
+      });
+      expect(fitsViewport).toBe(true);
     });
-    expect(fitsViewport).toBe(true);
-  });
+  }
 
   test('language switcher navigates to another language from mobile menu', async ({ page }) => {
     await openMobileMenu(page);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "format": "biome format --write .",
     "format:check": "biome format .",
     "prepare": "husky",
+    "test:unit": "vitest run",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui"
   },
@@ -39,7 +40,8 @@
     "lighthouse": "^13.0.3",
     "lint-staged": "^16.2.7",
     "playwright-lighthouse": "^4.0.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.5"
   },
   "lint-staged": {
     "*": [

--- a/src/features/navigation/components/LanguageSwitcher.astro
+++ b/src/features/navigation/components/LanguageSwitcher.astro
@@ -1,6 +1,7 @@
 ---
 import type { Language } from '@/config/i18n';
 import { LANGUAGE_LABELS, SUPPORTED_LANGUAGES } from '@/config/i18n';
+import SmartDropdown from '@/features/ui/SmartDropdown/SmartDropdown.astro';
 
 interface Props {
   lang: Language;
@@ -16,8 +17,9 @@ const rest = Astro.url.pathname.replace(/^\/[a-z]{2}(?=\/|$)/, '');
 const hrefFor = (code: string) => (rest === '' ? `/${code}` : `/${code}${rest}`);
 ---
 
-<div class="lang-switcher" data-testid="language-switcher">
+<SmartDropdown ariaLabel="Select language" testid="language-switcher">
   <button
+    slot="trigger"
     class="lang-trigger"
     type="button"
     aria-expanded="false"
@@ -25,11 +27,23 @@ const hrefFor = (code: string) => (rest === '' ? `/${code}` : `/${code}${rest}`)
     aria-label="Select language"
   >
     <span class="lang-current">{lang.toUpperCase()}</span>
-    <svg class="lang-chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <svg
+      class="lang-chevron"
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
       <polyline points="3 5 6 8 9 5"></polyline>
     </svg>
   </button>
   <ul
+    slot="dropdown"
     class="lang-dropdown"
     role="listbox"
     aria-label="Available languages"
@@ -48,98 +62,46 @@ const hrefFor = (code: string) => (rest === '' ? `/${code}` : `/${code}${rest}`)
       </li>
     ))}
   </ul>
-</div>
+</SmartDropdown>
 
 <script>
-  const initSwitcher = (switcher: HTMLElement) => {
-    const trigger = switcher.querySelector<HTMLButtonElement>('.lang-trigger');
-    const dropdown = switcher.querySelector<HTMLElement>('.lang-dropdown');
-    const currentLabel = switcher.querySelector<HTMLElement>('.lang-current');
+  /*
+   * SmartDropdown handles open/close/positioning. This script keeps
+   * the in-place "current language" label + per-page hrefs in sync
+   * across SPA navigations.
+   */
+  const updateAllSwitchers = () => {
+    document
+      .querySelectorAll<HTMLElement>('[data-testid="language-switcher"]')
+      .forEach(updateSwitcher);
+  };
 
-    if (!trigger || !dropdown || !currentLabel) return;
+  const updateSwitcher = (switcher: HTMLElement) => {
+    const path = globalThis.location.pathname;
+    const langMatch = path.match(/^\/([a-z]{2})/);
+    const activeLang = langMatch?.[1] ?? 'en';
+    const rest = path.replace(/^\/[a-z]{2}(?=\/|$)/, '');
 
-    if (switcher.dataset['switcherInit'] === 'true') {
-      updateCurrentLang();
-      return;
-    }
-    switcher.dataset['switcherInit'] = 'true';
+    const label = switcher.querySelector<HTMLElement>('.lang-current');
+    if (label) label.textContent = activeLang.toUpperCase();
 
-    const open = () => {
-      trigger.setAttribute('aria-expanded', 'true');
-      dropdown.classList.add('open');
-    };
-
-    const close = () => {
-      trigger.setAttribute('aria-expanded', 'false');
-      dropdown.classList.remove('open');
-    };
-
-    const toggle = () => {
-      const isOpen = trigger.getAttribute('aria-expanded') === 'true';
-      if (isOpen) close();
-      else open();
-    };
-
-    trigger.addEventListener('click', toggle);
-
-    document.addEventListener('click', (e: MouseEvent) => {
-      if (!switcher.contains(e.target instanceof Node ? e.target : null)) {
-        close();
-      }
-    });
-
-    document.addEventListener('keydown', (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && trigger.getAttribute('aria-expanded') === 'true') {
-        close();
-        trigger.focus();
-      }
-    });
-
-    // The anchor href is server-rendered with the correct per-page
-    // path, so native navigation handles every flavour of click
-    // (left / middle / Ctrl / keyboard). We do NOT attach a click
-    // listener here: calling `close()` flips `visibility: hidden`
-    // on the dropdown mid-click, which can abort the left-click's
-    // default navigation on some browsers. The dropdown naturally
-    // disappears once the whole document swaps under us.
-
-    updateCurrentLang();
-
-    function updateCurrentLang() {
-      const path = globalThis.location.pathname;
-      const langMatch = path.match(/^\/([a-z]{2})/);
-      const activeLang = langMatch?.[1] ?? 'en';
-
-      // Rest of the path after the lang prefix. Keep the trailing
-      // slash that Astro uses so the anchor href matches the
-      // canonical static URL exactly (no extra 307 hop).
-      const rest = path.replace(/^\/[a-z]{2}(?=\/|$)/, '');
-
-      const label = switcher.querySelector<HTMLElement>('.lang-current');
-      if (label) label.textContent = activeLang.toUpperCase();
-
-      switcher.querySelectorAll<HTMLAnchorElement>('.lang-option').forEach((option) => {
-        const optionLang = option.dataset['lang'];
-        if (optionLang) option.href = rest === '' ? `/${optionLang}` : `/${optionLang}${rest}`;
-        option.classList.toggle('active', optionLang === activeLang);
-        option.closest('li')?.setAttribute('aria-selected', String(optionLang === activeLang));
+    switcher
+      .querySelectorAll<HTMLAnchorElement>('.lang-option')
+      .forEach((option) => {
+        const code = option.dataset['lang'];
+        if (code) option.href = rest === '' ? `/${code}` : `/${code}${rest}`;
+        option.classList.toggle('active', code === activeLang);
+        option
+          .closest('li')
+          ?.setAttribute('aria-selected', String(code === activeLang));
       });
-    }
   };
 
-  const setupAllSwitchers = () => {
-    document.querySelectorAll<HTMLElement>('[data-testid="language-switcher"]').forEach(initSwitcher);
-  };
-
-  setupAllSwitchers();
-  document.addEventListener('astro:after-swap', setupAllSwitchers);
+  updateAllSwitchers();
+  document.addEventListener('astro:after-swap', updateAllSwitchers);
 </script>
 
 <style>
-  .lang-switcher {
-    position: relative;
-  }
-
   .lang-trigger {
     display: inline-flex;
     align-items: center;
@@ -153,7 +115,9 @@ const hrefFor = (code: string) => (rest === '' ? `/${code}` : `/${code}${rest}`)
     font-size: 0.875rem;
     font-weight: 500;
     cursor: pointer;
-    transition: background-color var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
+    transition: background-color var(--transition-fast),
+      color var(--transition-fast),
+      border-color var(--transition-fast);
   }
 
   .lang-trigger:hover,
@@ -173,9 +137,6 @@ const hrefFor = (code: string) => (rest === '' ? `/${code}` : `/${code}${rest}`)
   }
 
   .lang-dropdown {
-    position: absolute;
-    top: calc(100% + var(--spacing-xs));
-    right: 0;
     min-width: 140px;
     padding: var(--spacing-xs);
     margin: 0;
@@ -184,17 +145,6 @@ const hrefFor = (code: string) => (rest === '' ? `/${code}` : `/${code}${rest}`)
     border: 1px solid var(--color-border);
     border-radius: var(--radius-sm);
     box-shadow: var(--shadow-md);
-    opacity: 0;
-    visibility: hidden;
-    transform: translateY(-4px);
-    transition: opacity var(--transition-fast), visibility var(--transition-fast), transform var(--transition-fast);
-    z-index: 300;
-  }
-
-  .lang-dropdown.open {
-    opacity: 1;
-    visibility: visible;
-    transform: translateY(0);
   }
 
   .lang-option {
@@ -206,7 +156,8 @@ const hrefFor = (code: string) => (rest === '' ? `/${code}` : `/${code}${rest}`)
     text-decoration: none;
     border-radius: var(--radius-sm);
     font-size: 0.875rem;
-    transition: background-color var(--transition-fast), color var(--transition-fast);
+    transition: background-color var(--transition-fast),
+      color var(--transition-fast);
   }
 
   .lang-option:hover,

--- a/src/features/navigation/components/MobileMenu.astro
+++ b/src/features/navigation/components/MobileMenu.astro
@@ -368,37 +368,4 @@ const menuLabel = nav?.data.menu ?? 'Menu';
     justify-content: space-between;
     gap: var(--spacing-sm);
   }
-
-  /*
-   * The desktop LanguageSwitcher renders its dropdown anchored
-   * downward + right-aligned. Inside the FAB popup that lands
-   * off-screen for any FAB corner. Remap the dropdown's anchor
-   * relative to the popup's data-corner so the list always opens
-   * INTO the popup area instead of beyond the viewport edge:
-   *
-   * - bottom-* corner → popup grows upward, dropdown opens upward
-   * - top-*    corner → popup grows downward, dropdown opens downward
-   * - *-right  corner → popup right-aligned, dropdown right-aligned
-   * - *-left   corner → popup left-aligned, dropdown left-aligned
-   */
-  .mobile-menu-wrapper[data-corner^='bottom-']
-    .popup-tools
-    :global(.lang-dropdown) {
-    top: auto;
-    bottom: calc(100% + var(--spacing-xs));
-    transform: translateY(4px);
-  }
-
-  .mobile-menu-wrapper[data-corner^='bottom-']
-    .popup-tools
-    :global(.lang-dropdown.open) {
-    transform: translateY(0);
-  }
-
-  .mobile-menu-wrapper[data-corner$='-left']
-    .popup-tools
-    :global(.lang-dropdown) {
-    right: auto;
-    left: 0;
-  }
 </style>

--- a/src/features/ui/SmartDropdown/SmartDropdown.astro
+++ b/src/features/ui/SmartDropdown/SmartDropdown.astro
@@ -1,0 +1,174 @@
+---
+/*
+ * Reusable, accessible dropdown that picks its open direction at
+ * runtime so the panel always lands inside the viewport.
+ *
+ * Usage:
+ *   <SmartDropdown ariaLabel="Select language" testid="…">
+ *     <button slot="trigger" class="my-trigger">…</button>
+ *     <div slot="dropdown" role="listbox" class="my-dropdown">…</div>
+ *   </SmartDropdown>
+ *
+ * Contract for slotted children:
+ * - The trigger MUST be a single focusable element (button/anchor)
+ *   carrying `aria-haspopup` and the initial `aria-expanded="false"`.
+ * - The dropdown MUST carry the appropriate role (listbox/menu) and
+ *   should not include its own positioning style — this component
+ *   sets `position: absolute` + top/bottom/left/right at open time.
+ *
+ * Behavior:
+ * - First click on trigger → measure trigger + dropdown, compute
+ *   placement via `pickPlacement`, anchor accordingly, animate in.
+ * - Click outside, ESC, or click the trigger again → close.
+ * - The component does not steal focus or trap it; downstream
+ *   listbox keyboard logic stays in the caller.
+ */
+
+interface Props {
+  readonly ariaLabel: string;
+  readonly testid?: string | undefined;
+}
+
+const { ariaLabel, testid } = Astro.props;
+---
+
+<div
+  class="smart-dropdown"
+  data-smart-dropdown
+  data-testid={testid}
+  aria-label={ariaLabel}
+>
+  <slot name="trigger" />
+  <div class="smart-dropdown-panel" data-smart-dropdown-panel>
+    <slot name="dropdown" />
+  </div>
+</div>
+
+<script>
+  import {
+    pickPlacement,
+    PLACEMENT_GAP,
+  } from '@/features/ui/SmartDropdown/pick-placement';
+
+  const setupSmartDropdown = (root: HTMLElement) => {
+    if (root.dataset['ddInit'] === 'true') return;
+    root.dataset['ddInit'] = 'true';
+
+    const trigger = root.querySelector<HTMLElement>(
+      ':scope > button, :scope > a',
+    );
+    const panel = root.querySelector<HTMLElement>(
+      '[data-smart-dropdown-panel]',
+    );
+    if (!trigger || !panel) return;
+
+    const close = () => {
+      root.classList.remove('open');
+      trigger.setAttribute('aria-expanded', 'false');
+    };
+
+    const apply = () => {
+      const tRect = trigger.getBoundingClientRect();
+      const pRect = panel.getBoundingClientRect();
+      const v = { width: globalThis.innerWidth, height: globalThis.innerHeight };
+      const placement = pickPlacement(tRect, pRect, v);
+      panel.style.top = placement.vertical === 'down'
+        ? `${tRect.height + PLACEMENT_GAP}px`
+        : 'auto';
+      panel.style.bottom = placement.vertical === 'up'
+        ? `${tRect.height + PLACEMENT_GAP}px`
+        : 'auto';
+      panel.style.left = placement.horizontal === 'left' ? '0' : 'auto';
+      panel.style.right = placement.horizontal === 'right' ? '0' : 'auto';
+      root.dataset['placement'] =
+        `${placement.vertical}-${placement.horizontal}`;
+    };
+
+    const open = () => {
+      // Render the panel hidden first so getBoundingClientRect()
+      // returns the intrinsic size; only THEN we anchor it.
+      root.classList.add('measuring');
+      apply();
+      root.classList.remove('measuring');
+      root.classList.add('open');
+      trigger.setAttribute('aria-expanded', 'true');
+    };
+
+    const toggle = () => {
+      if (root.classList.contains('open')) close();
+      else open();
+    };
+
+    trigger.addEventListener('click', toggle);
+
+    document.addEventListener('click', (e: MouseEvent) => {
+      if (!(e.target instanceof Node) || !root.contains(e.target)) close();
+    });
+
+    document.addEventListener('keydown', (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && root.classList.contains('open')) {
+        close();
+        trigger.focus();
+      }
+    });
+
+    globalThis.addEventListener('resize', () => {
+      if (root.classList.contains('open')) apply();
+    });
+  };
+
+  const setupAll = () => {
+    document
+      .querySelectorAll<HTMLElement>('[data-smart-dropdown]')
+      .forEach(setupSmartDropdown);
+  };
+
+  setupAll();
+  document.addEventListener('astro:after-swap', setupAll);
+</script>
+
+<style>
+  .smart-dropdown {
+    position: relative;
+    display: inline-block;
+  }
+
+  .smart-dropdown-panel {
+    /*
+     * Pre-staged hidden; the script flips visibility once it has
+     * computed the right anchoring corner. While `measuring` we
+     * render off-screen but laid out so getBoundingClientRect()
+     * returns the intrinsic size.
+     */
+    position: absolute;
+    z-index: 300;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transform: translateY(-4px);
+    transition: opacity var(--transition-fast),
+      visibility var(--transition-fast),
+      transform var(--transition-fast);
+  }
+
+  .smart-dropdown.measuring .smart-dropdown-panel {
+    /* Visible to layout but invisible to the user during measurement. */
+    visibility: hidden;
+    opacity: 0;
+  }
+
+  .smart-dropdown.open .smart-dropdown-panel {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  .smart-dropdown[data-placement^='up-'] .smart-dropdown-panel {
+    transform: translateY(4px);
+  }
+
+  .smart-dropdown.open[data-placement^='up-'] .smart-dropdown-panel {
+    transform: translateY(0);
+  }
+</style>

--- a/src/features/ui/SmartDropdown/index.ts
+++ b/src/features/ui/SmartDropdown/index.ts
@@ -1,0 +1,8 @@
+export {
+  PLACEMENT_GAP,
+  type Placement,
+  pickPlacement,
+  type RectLike,
+  type Viewport,
+} from './pick-placement';
+export { default as SmartDropdown } from './SmartDropdown.astro';

--- a/src/features/ui/SmartDropdown/pick-placement.test.ts
+++ b/src/features/ui/SmartDropdown/pick-placement.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { pickPlacement, type RectLike, type Viewport } from './pick-placement';
+
+const rect = (top: number, left: number, width: number, height: number): RectLike => ({
+  top,
+  left,
+  right: left + width,
+  bottom: top + height,
+  width,
+  height,
+});
+
+const viewport = (width: number, height: number): Viewport => ({ width, height });
+
+describe('pickPlacement — vertical axis', () => {
+  it('opens down when there is enough room below the trigger', () => {
+    const trigger = rect(40, 100, 60, 32);
+    const dropdown = rect(0, 0, 140, 200);
+    const p = pickPlacement(trigger, dropdown, viewport(800, 600));
+    expect(p.vertical).toBe('down');
+  });
+
+  it('flips up when below would overflow the viewport', () => {
+    // Trigger near the bottom edge — dropdown 200px tall does not fit.
+    const trigger = rect(550, 100, 60, 32);
+    const dropdown = rect(0, 0, 140, 200);
+    const p = pickPlacement(trigger, dropdown, viewport(800, 600));
+    expect(p.vertical).toBe('up');
+  });
+
+  it('falls back to the side with more space when neither fits', () => {
+    /*
+     * Tiny viewport — dropdown taller than the available space on
+     * either side. Trigger sits 80% down the viewport, so above wins.
+     */
+    const trigger = rect(200, 100, 60, 32);
+    const dropdown = rect(0, 0, 140, 500);
+    const p = pickPlacement(trigger, dropdown, viewport(800, 250));
+    expect(p.vertical).toBe('up');
+  });
+
+  it('prefers down when below has more space and neither fits', () => {
+    const trigger = rect(20, 100, 60, 32);
+    const dropdown = rect(0, 0, 140, 500);
+    const p = pickPlacement(trigger, dropdown, viewport(800, 250));
+    expect(p.vertical).toBe('down');
+  });
+});
+
+describe('pickPlacement — horizontal axis', () => {
+  it('right-aligns when the dropdown fits to the left of the trigger right edge', () => {
+    const trigger = rect(40, 600, 60, 32);
+    const dropdown = rect(0, 0, 200, 100);
+    const p = pickPlacement(trigger, dropdown, viewport(800, 600));
+    expect(p.horizontal).toBe('right');
+  });
+
+  it('flips to left-aligned when right-alignment would overflow the left viewport edge', () => {
+    /*
+     * Trigger near the left edge — right-aligning a 200px dropdown
+     * would put its left edge at -130, off-screen.
+     */
+    const trigger = rect(40, 70, 60, 32);
+    const dropdown = rect(0, 0, 200, 100);
+    const p = pickPlacement(trigger, dropdown, viewport(800, 600));
+    expect(p.horizontal).toBe('left');
+  });
+
+  it('picks the side with more space when neither alignment fits', () => {
+    /*
+     * Pathological: dropdown wider than viewport. Trigger at 30% from
+     * the left, so left-aligned reaches further than right-aligned.
+     */
+    const trigger = rect(40, 240, 60, 32);
+    const dropdown = rect(0, 0, 900, 100);
+    const p = pickPlacement(trigger, dropdown, viewport(800, 600));
+    expect(p.horizontal).toBe('left');
+  });
+});
+
+describe('pickPlacement — combined corners', () => {
+  it('bottom-right corner trigger → up + right', () => {
+    const trigger = rect(540, 720, 56, 32);
+    const dropdown = rect(0, 0, 200, 220);
+    const p = pickPlacement(trigger, dropdown, viewport(800, 600));
+    expect(p).toEqual({ vertical: 'up', horizontal: 'right' });
+  });
+
+  it('top-left corner trigger → down + left', () => {
+    const trigger = rect(16, 16, 56, 32);
+    const dropdown = rect(0, 0, 200, 220);
+    const p = pickPlacement(trigger, dropdown, viewport(800, 600));
+    expect(p).toEqual({ vertical: 'down', horizontal: 'left' });
+  });
+
+  it('top-right corner trigger → down + right', () => {
+    const trigger = rect(16, 720, 56, 32);
+    const dropdown = rect(0, 0, 200, 220);
+    const p = pickPlacement(trigger, dropdown, viewport(800, 600));
+    expect(p).toEqual({ vertical: 'down', horizontal: 'right' });
+  });
+
+  it('bottom-left corner trigger → up + left', () => {
+    const trigger = rect(540, 16, 56, 32);
+    const dropdown = rect(0, 0, 200, 220);
+    const p = pickPlacement(trigger, dropdown, viewport(800, 600));
+    expect(p).toEqual({ vertical: 'up', horizontal: 'left' });
+  });
+});

--- a/src/features/ui/SmartDropdown/pick-placement.ts
+++ b/src/features/ui/SmartDropdown/pick-placement.ts
@@ -1,0 +1,82 @@
+/*
+ * Pure helper that picks dropdown placement relative to a trigger
+ * given the viewport box. The component renders the dropdown
+ * hidden, measures its intrinsic size, then calls this function to
+ * decide which side of the trigger to anchor to.
+ *
+ * Decision rules:
+ * - vertical: prefer below the trigger when there is enough room.
+ *   When neither side has enough room, pick the one with more space
+ *   so we degrade gracefully on tiny viewports.
+ * - horizontal: prefer right-edge alignment with the trigger
+ *   (matches the "menu opens from the trigger corner" mental model).
+ *   Flip to left-aligned when right-aligning would overflow the
+ *   left edge of the viewport.
+ */
+
+/** Subset of DOMRect we actually use — keeps the helper testable. */
+export interface RectLike {
+  readonly top: number;
+  readonly left: number;
+  readonly right: number;
+  readonly bottom: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+/** Viewport width + height. */
+export interface Viewport {
+  readonly width: number;
+  readonly height: number;
+}
+
+/** Resolved placement direction along each axis. */
+export interface Placement {
+  readonly vertical: 'down' | 'up';
+  readonly horizontal: 'left' | 'right';
+}
+
+/** Gap (px) between trigger and dropdown along the chosen axis. */
+export const PLACEMENT_GAP = 4;
+
+/**
+ * Compute the placement for a dropdown.
+ *
+ * @param trigger The trigger button's bounding rect.
+ * @param dropdown The dropdown's intrinsic bounding rect.
+ * @param viewport Current viewport size.
+ * @returns Direction to open along each axis.
+ */
+export const pickPlacement = (
+  trigger: RectLike,
+  dropdown: RectLike,
+  viewport: Viewport,
+): Placement => ({
+  vertical: pickVertical(trigger, dropdown, viewport),
+  horizontal: pickHorizontal(trigger, dropdown, viewport),
+});
+
+const pickVertical = (
+  trigger: RectLike,
+  dropdown: RectLike,
+  viewport: Viewport,
+): Placement['vertical'] => {
+  const spaceBelow = viewport.height - trigger.bottom;
+  const spaceAbove = trigger.top;
+  const needed = dropdown.height + PLACEMENT_GAP;
+  if (spaceBelow >= needed) return 'down';
+  if (spaceAbove >= needed) return 'up';
+  return spaceBelow >= spaceAbove ? 'down' : 'up';
+};
+
+const pickHorizontal = (
+  trigger: RectLike,
+  dropdown: RectLike,
+  viewport: Viewport,
+): Placement['horizontal'] => {
+  const rightAlignedLeftEdge = trigger.right - dropdown.width;
+  if (rightAlignedLeftEdge >= 0) return 'right';
+  const leftAlignedRightEdge = trigger.left + dropdown.width;
+  if (leftAlignedRightEdge <= viewport.width) return 'left';
+  return rightAlignedLeftEdge >= viewport.width - leftAlignedRightEdge ? 'right' : 'left';
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': '/src',
+    },
+  },
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary

Replaces the \`data-corner\` CSS hack from #70 with a real reusable component that picks its open direction at runtime based on available space. Also covers the **top-*** corners that #70 had no override for.

## What landed

- **\`pick-placement.ts\`** — pure helper resolving (vertical, horizontal) from trigger/dropdown/viewport rects. Prefers below + right-aligned; flips to up or left-aligned when the preferred direction would overflow. Falls back to the side with more space when neither fits.
- **\`pick-placement.test.ts\`** — 11 unit tests (vertical axis, horizontal axis, 4-corner combinations).
- **\`SmartDropdown.astro\`** — slot-based component (\`trigger\` + \`dropdown\` slots). Measures hidden, calls \`pickPlacement\`, anchors. Handles click-outside, ESC, resize, aria-expanded, SPA navigation.
- **LanguageSwitcher** — refactored to use SmartDropdown. Removed bespoke open/close + absolute positioning.
- **MobileMenu** — dropped the \`data-corner\` override block (now unnecessary).
- **vitest** added as devDep with \`test:unit\` script.

## Test plan

- [x] \`bunx vitest run\` — 11/11 pass
- [x] \`bunx playwright test --project=mobile\` — 22/22 pass, including 4 new specs that pre-seed \`localStorage.fab-corner\` for each corner and assert the dropdown's bounding box fits inside the viewport