### PR TITLE
feat: skip empty sections — no nav link, no listing route (#1)

### DIFF
--- a/src/config/section-availability.ts
+++ b/src/config/section-availability.ts
@@ -1,0 +1,61 @@
+import { getCollection } from 'astro:content';
+import type { Language } from './i18n';
+
+/**
+ * Per-section content presence check used by the nav builder so we
+ * don't link to sections that would render empty for the active
+ * language. Each predicate runs in parallel during the static build
+ * and is memoised within a single getStaticPaths invocation by
+ * Astro's collection caching.
+ */
+type AvailableMap = Readonly<Record<string, boolean>>;
+
+const blogHas = async (lang: Language): Promise<boolean> => {
+  const items = await getCollection(
+    'blog',
+    ({ data }) => data.lang === lang && data.published === true,
+  );
+  return items.length > 0;
+};
+
+const positionsHas = async (lang: Language): Promise<boolean> => {
+  const items = await getCollection(
+    'positions',
+    ({ data }) => data.lang === lang && data.published === true,
+  );
+  return items.length > 0;
+};
+
+const newspaperHas = async (lang: Language): Promise<boolean> => {
+  const items = await getCollection(
+    'newspaper',
+    ({ data }) => data.lang === lang && data.published === true,
+  );
+  return items.length > 0;
+};
+
+const pageHas = async (slug: string, lang: Language): Promise<boolean> => {
+  const items = await getCollection('pages', ({ data, id }) => {
+    return data.lang === lang && id.startsWith(`${slug}/`);
+  });
+  return items.length > 0;
+};
+
+/**
+ * Resolve which top-level sections actually have published content
+ * for the given language. The home link is always present; every
+ * other key is true only if at least one item exists.
+ *
+ * @param lang Current page language.
+ * @returns A boolean per nav slot.
+ */
+export const getSectionAvailability = async (lang: Language): Promise<AvailableMap> => {
+  const [blog, positions, newspaper, manifest, about] = await Promise.all([
+    blogHas(lang),
+    positionsHas(lang),
+    newspaperHas(lang),
+    pageHas('manifest', lang),
+    pageHas('about', lang),
+  ]);
+  return { home: true, blog, positions, newspaper, manifest, about };
+};

--- a/src/config/translations.ts
+++ b/src/config/translations.ts
@@ -69,15 +69,19 @@ export const getNavLinks = async (
 ): Promise<ReadonlyArray<{ readonly href: string; readonly label: string }>> => {
   const menu = await getMenuData(lang);
   if (!menu) return [];
+  const { getSectionAvailability } = await import('./section-availability');
+  const has = await getSectionAvailability(lang);
   const candidates = [
-    { href: `/${lang}`, label: menu.data.home },
-    { href: `/${lang}/blog`, label: menu.data.blog },
-    { href: `/${lang}/positions`, label: menu.data.positions },
-    { href: `/${lang}/manifest`, label: menu.data.manifest },
-    { href: `/${lang}/newspaper`, label: menu.data.newspaper },
-    { href: `/${lang}/about`, label: menu.data.about },
+    { key: 'home', href: `/${lang}`, label: menu.data.home },
+    { key: 'blog', href: `/${lang}/blog`, label: menu.data.blog },
+    { key: 'positions', href: `/${lang}/positions`, label: menu.data.positions },
+    { key: 'manifest', href: `/${lang}/manifest`, label: menu.data.manifest },
+    { key: 'newspaper', href: `/${lang}/newspaper`, label: menu.data.newspaper },
+    { key: 'about', href: `/${lang}/about`, label: menu.data.about },
   ] as const;
   return candidates.flatMap((c) =>
-    typeof c.label === 'string' && c.label.length > 0 ? [{ href: c.href, label: c.label }] : [],
+    typeof c.label === 'string' && c.label.length > 0 && has[c.key] === true
+      ? [{ href: c.href, label: c.label }]
+      : [],
   );
 };

--- a/src/pages/[lang]/about.astro
+++ b/src/pages/[lang]/about.astro
@@ -1,14 +1,25 @@
 ---
-import { DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES } from '@/config/i18n';
+import { SUPPORTED_LANGUAGES } from '@/config/i18n';
 import { getPageData } from '@/config/translations';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
-export const getStaticPaths = () => SUPPORTED_LANGUAGES.map((lang) => ({ params: { lang } }));
+/* Skip languages without an about page (no fallback hop). */
+export const getStaticPaths = async () => {
+  const filled = await Promise.all(
+    SUPPORTED_LANGUAGES.map(async (lang) => ({
+      lang,
+      has: (await getPageData('about', lang)) !== undefined,
+    })),
+  );
+  return filled.filter(({ has }) => has).map(({ lang }) => ({ params: { lang } }));
+};
 
 const { lang } = Astro.params;
 
-const page = (await getPageData('about', lang)) ?? (await getPageData('about', DEFAULT_LANGUAGE));
-if (!page) return Astro.redirect(`/${DEFAULT_LANGUAGE}`);
+const page = await getPageData('about', lang);
+// Unreachable in practice — getStaticPaths excludes empty langs —
+// but Astro requires `page` to be narrowed for the render below.
+if (!page) throw new Error(`about page missing for ${lang}`);
 
 const { Content } = await page.render();
 ---

--- a/src/pages/[lang]/blog/index.astro
+++ b/src/pages/[lang]/blog/index.astro
@@ -11,7 +11,23 @@ import {
 import { deriveDescription } from '@/features/content/helpers/deriveDescription';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
-export const getStaticPaths = () => SUPPORTED_LANGUAGES.map((lang) => ({ params: { lang } }));
+/*
+ * Only emit the listing route for languages that have at least one
+ * published blog post. The nav drops the link when the section is
+ * empty (see getSectionAvailability); skipping the route here means
+ * the URL itself 404s rather than serving an empty list.
+ */
+export const getStaticPaths = async () => {
+  const langsWithPosts = await Promise.all(
+    SUPPORTED_LANGUAGES.map(async (lang) => ({
+      lang,
+      hasPosts: (await getBlogPosts(lang)).length > 0,
+    })),
+  );
+  return langsWithPosts
+    .filter(({ hasPosts }) => hasPosts)
+    .map(({ lang }) => ({ params: { lang } }));
+};
 
 const { lang } = Astro.params;
 

--- a/src/pages/[lang]/manifest.astro
+++ b/src/pages/[lang]/manifest.astro
@@ -1,19 +1,30 @@
 ---
 import { getCollection } from 'astro:content';
-import { DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES } from '@/config/i18n';
+import { SUPPORTED_LANGUAGES } from '@/config/i18n';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
-export const getStaticPaths = () => SUPPORTED_LANGUAGES.map((lang) => ({ params: { lang } }));
+/* Skip languages without a manifest page (no fallback hop). */
+export const getStaticPaths = async () => {
+  const findManifest = async (l: string) => {
+    const pages = await getCollection('pages', ({ data }) => data.lang === l);
+    return pages.find((p) => p.id.startsWith('manifest/'));
+  };
+  const filled = await Promise.all(
+    SUPPORTED_LANGUAGES.map(async (lang) => ({
+      lang,
+      has: (await findManifest(lang)) !== undefined,
+    })),
+  );
+  return filled.filter(({ has }) => has).map(({ lang }) => ({ params: { lang } }));
+};
 
 const { lang } = Astro.params;
 
-const manifestIn = async (l: string) => {
-  const pages = await getCollection('pages', ({ data }) => data.lang === l);
-  return pages.find((p) => p.id.startsWith('manifest/'));
-};
-const page = (await manifestIn(lang)) ?? (await manifestIn(DEFAULT_LANGUAGE));
+const pages = await getCollection('pages', ({ data }) => data.lang === lang);
+const page = pages.find((p) => p.id.startsWith('manifest/'));
 
-if (!page) return Astro.redirect(`/${DEFAULT_LANGUAGE}`);
+// Unreachable — getStaticPaths excludes empty langs.
+if (!page) throw new Error(`manifest page missing for ${lang}`);
 
 const { Content } = await page.render();
 ---

--- a/src/pages/[lang]/newspaper/index.astro
+++ b/src/pages/[lang]/newspaper/index.astro
@@ -5,7 +5,16 @@ import NewspaperCard from '@/features/newspaper/components/NewspaperCard.astro';
 import { getNewspaperItems } from '@/features/newspaper/helpers/getNewspaperItems';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
-export const getStaticPaths = () => SUPPORTED_LANGUAGES.map((lang) => ({ params: { lang } }));
+/* Skip languages with no published newspaper issues. */
+export const getStaticPaths = async () => {
+  const filled = await Promise.all(
+    SUPPORTED_LANGUAGES.map(async (lang) => ({
+      lang,
+      has: (await getNewspaperItems(lang)).length > 0,
+    })),
+  );
+  return filled.filter(({ has }) => has).map(({ lang }) => ({ params: { lang } }));
+};
 
 const { lang } = Astro.params;
 

--- a/src/pages/[lang]/positions/index.astro
+++ b/src/pages/[lang]/positions/index.astro
@@ -5,7 +5,16 @@ import PositionCard from '@/features/positions/components/PositionCard.astro';
 import { getPositions } from '@/features/positions/helpers/getPositions';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
-export const getStaticPaths = () => SUPPORTED_LANGUAGES.map((lang) => ({ params: { lang } }));
+/* Skip languages with no published positions — see blog/index.astro. */
+export const getStaticPaths = async () => {
+  const filled = await Promise.all(
+    SUPPORTED_LANGUAGES.map(async (lang) => ({
+      lang,
+      has: (await getPositions(lang)).length > 0,
+    })),
+  );
+  return filled.filter(({ has }) => has).map(({ lang }) => ({ params: { lang } }));
+};
 
 const { lang } = Astro.params;
 


### PR DESCRIPTION
## Summary

Closes editor [ticket #1](https://github.com/communist-prometheus/tickets/issues/1).

Languages with no published blog/positions/newspaper/manifest/about content used to:
- still emit the listing route as an empty page,
- still show the nav link.

Now the build:
1. Drops the listing-page route via \`getStaticPaths\` filtering — the URL 404s.
2. Drops the corresponding nav link via \`getSectionAvailability\`.

Build delta on the develop content corpus: **185 → 170 pages**.

## Test plan

- [x] \`bun run build\` clean (170 pages)
- [ ] CI master build will reflect the master content corpus