### PR TITLE
feat: "Suggest changes" link under each article (#2)

### DIFF
--- a/src/features/content/components/SuggestChangesLink.astro
+++ b/src/features/content/components/SuggestChangesLink.astro
@@ -1,0 +1,92 @@
+---
+/*
+ * "Suggest changes" affordance on every article-like page.
+ *
+ * Clicking the link opens GitHub's web editor at the file's source
+ * path. If the visitor doesn't have write access (the common case
+ * for content contributors), GitHub auto-forks the content repo
+ * into their account and lands them on the editor in their fork.
+ * Saving the edit opens a PR back to the upstream master branch.
+ *
+ * Pre-req on the content repo: PRs from forks must be enabled
+ * (the default for public repos). The token-bearing admin keeps
+ * direct push access; this flow is for outside contributors.
+ */
+
+interface Props {
+  /**
+   * Collection directory inside the content repo
+   * (e.g. `blog`, `positions`, `newspaper`, `pages`).
+   */
+  readonly collection: string;
+  /**
+   * Path inside the collection directory — usually the Astro
+   * content entry id, e.g. `about-the-manifesto/index.ru.md`.
+   */
+  readonly entryId: string;
+  /**
+   * Visible label. Defaults to the English string; pass a
+   * translated label when the surrounding page has one available.
+   */
+  readonly label?: string;
+}
+
+const { collection, entryId, label = 'Suggest changes' } = Astro.props;
+
+const REPO = 'communist-prometheus/public-website-content';
+const BRANCH = 'master';
+
+const editUrl = `https://github.com/${REPO}/edit/${BRANCH}/${collection}/${entryId}`;
+---
+
+<p class="suggest-changes">
+  <a
+    href={editUrl}
+    target="_blank"
+    rel="noopener noreferrer"
+    class="suggest-changes-link"
+    data-testid="suggest-changes"
+  >
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path
+        d="M11.013 1.427a1.75 1.75 0 0 1 2.474 0l1.086 1.086a1.75 1.75 0 0 1 0 2.474l-8.61 8.61c-.21.21-.47.364-.756.445l-3.251.93a.75.75 0 0 1-.927-.928l.929-3.25c.082-.286.235-.547.445-.758l8.61-8.61Zm.176 4.823L9.75 4.81l-6.286 6.287a.253.253 0 0 0-.064.108l-.558 1.953 1.953-.558a.253.253 0 0 0 .108-.064Zm1.238-3.763a.25.25 0 0 0-.354 0L10.811 3.75l1.439 1.44 1.263-1.263a.25.25 0 0 0 0-.354Z"
+      />
+    </svg>
+    {label}
+    <span aria-hidden="true">↗</span>
+  </a>
+</p>
+
+<style>
+  .suggest-changes {
+    margin-top: var(--spacing-xl);
+    padding-top: var(--spacing-md);
+    border-top: 1px solid var(--color-border);
+    text-align: center;
+  }
+
+  .suggest-changes-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4em;
+    color: var(--color-text-secondary);
+    text-decoration: none;
+    font-size: 0.875rem;
+    padding: var(--spacing-xs) var(--spacing-sm);
+    border-radius: var(--radius-sm);
+    transition: color var(--transition-fast), background-color var(--transition-fast);
+  }
+
+  .suggest-changes-link:hover,
+  .suggest-changes-link:focus-visible {
+    color: var(--color-accent);
+    background: var(--color-surface);
+  }
+</style>

--- a/src/pages/[lang]/about.astro
+++ b/src/pages/[lang]/about.astro
@@ -1,6 +1,7 @@
 ---
 import { SUPPORTED_LANGUAGES } from '@/config/i18n';
 import { getPageData } from '@/config/translations';
+import SuggestChangesLink from '@/features/content/components/SuggestChangesLink.astro';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
 /* Skip languages without an about page (no fallback hop). */
@@ -34,6 +35,7 @@ const { Content } = await page.render();
       <div class="prose">
         <Content />
       </div>
+      <SuggestChangesLink collection="pages" entryId={page.id} />
     </div>
   </article>
 </BaseLayout>

--- a/src/pages/[lang]/blog/[...slug].astro
+++ b/src/pages/[lang]/blog/[...slug].astro
@@ -4,6 +4,7 @@ import { type CollectionEntry, getCollection } from 'astro:content';
 import { DEFAULT_LANGUAGE, type Language, SUPPORTED_LANGUAGES } from '@/config/i18n';
 import BlogPicture from '@/features/blog/components/BlogPicture.astro';
 import { getArticleSlug } from '@/features/blog/helpers/getBlogPosts';
+import SuggestChangesLink from '@/features/content/components/SuggestChangesLink.astro';
 import { deriveDescription } from '@/features/content/helpers/deriveDescription';
 import MissingTranslation from '@/features/i18n/MissingTranslation.astro';
 import BaseLayout from '@/layouts/BaseLayout.astro';
@@ -123,6 +124,7 @@ const newspaperRef = await (async () => {
         <div class="prose" itemprop="articleBody">
           <Content />
         </div>
+        <SuggestChangesLink collection="blog" entryId={post.id} />
       </div>
     </article>
   ) : (

--- a/src/pages/[lang]/manifest.astro
+++ b/src/pages/[lang]/manifest.astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import { SUPPORTED_LANGUAGES } from '@/config/i18n';
+import SuggestChangesLink from '@/features/content/components/SuggestChangesLink.astro';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
 /* Skip languages without a manifest page (no fallback hop). */
@@ -38,6 +39,7 @@ const { Content } = await page.render();
       <div class="prose">
         <Content />
       </div>
+      <SuggestChangesLink collection="pages" entryId={page.id} />
     </div>
   </article>
 </BaseLayout>

--- a/src/pages/[lang]/newspaper/[slug].astro
+++ b/src/pages/[lang]/newspaper/[slug].astro
@@ -3,6 +3,7 @@ import { type CollectionEntry, getCollection } from 'astro:content';
 import { type Language, SUPPORTED_LANGUAGES } from '@/config/i18n';
 import { getLabelsData } from '@/config/translations';
 import { getArticleSlug } from '@/features/blog/helpers/getBlogPosts';
+import SuggestChangesLink from '@/features/content/components/SuggestChangesLink.astro';
 import MissingTranslation from '@/features/i18n/MissingTranslation.astro';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
@@ -109,6 +110,7 @@ const pdfPath = issue ? `/newspaper/${slug}/assets/gazette.pdf` : undefined;
               </ol>
             </section>
           )}
+          <SuggestChangesLink collection="newspaper" entryId={issue.id} />
         </article>
       ) : (
         <MissingTranslation

--- a/src/pages/[lang]/positions/[...slug].astro
+++ b/src/pages/[lang]/positions/[...slug].astro
@@ -2,6 +2,7 @@
 import { type CollectionEntry, getCollection } from 'astro:content';
 import { DEFAULT_LANGUAGE, type Language, SUPPORTED_LANGUAGES } from '@/config/i18n';
 import { getLabelsData } from '@/config/translations';
+import SuggestChangesLink from '@/features/content/components/SuggestChangesLink.astro';
 import { deriveDescription } from '@/features/content/helpers/deriveDescription';
 import MissingTranslation from '@/features/i18n/MissingTranslation.astro';
 import BaseLayout from '@/layouts/BaseLayout.astro';
@@ -67,6 +68,7 @@ const pageDescription = entry ? deriveDescription(entry.data.description, entry.
         <div class="content">
           <Content />
         </div>
+        <SuggestChangesLink collection="positions" entryId={entry.id} />
       </div>
     </article>
   ) : (


### PR DESCRIPTION
Closes editor ticket #2. Adds a footer link under each article that opens GitHub's web editor at the file's source path. Visitors without write access get auto-forked + PR-flow handled by GitHub. Pre-req: content repo allows PRs from forks (default for public repos).