### PR TITLE
feat: description as preface + body-derived widget summary (#3 part 1)

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -8,7 +8,14 @@ const blogCollection = defineCollection({
   schema: ({ image }) =>
     z.object({
       title: z.string(),
-      description: z.string(),
+      /*
+       * Description is optional now: editors stopped filling it in
+       * the admin (the field was retired). Listings derive their
+       * card preview from the body's first paragraph; the article
+       * page renders description as a lead block when an old entry
+       * still carries one.
+       */
+      description: z.string().optional(),
       category: z.string(),
       /*
        * `pubDate` is legacy; `publishDate` is the canonical publish
@@ -55,7 +62,8 @@ const positionsCollection = defineCollection({
   type: 'content',
   schema: z.object({
     title: z.string(),
-    description: z.string(),
+    /* Optional: see blogCollection. Listings derive a body preview. */
+    description: z.string().optional(),
     pubDate: z.date().optional(),
     /* See blog: absent / non-true is draft. */
     published: z.boolean().optional(),
@@ -88,7 +96,8 @@ const newspaperCollection = defineCollection({
   schema: ({ image }) =>
     z.object({
       title: z.string(),
-      description: z.string(),
+      /* Optional: see blogCollection. */
+      description: z.string().optional(),
       pubDate: z.date().optional(),
       // See blog: absent / non-true is draft.
       published: z.boolean().optional(),

--- a/src/features/content/helpers/deriveDescription.ts
+++ b/src/features/content/helpers/deriveDescription.ts
@@ -21,27 +21,31 @@
  *   5. ![alt](url)  — drop entirely
  *   6. [text](url)  — keep the visible text only
  */
-const STRIP_PATTERNS: ReadonlyArray<RegExp> = [
+/* Patterns that drop the match entirely (no capture group). */
+const DROP_PATTERNS: ReadonlyArray<RegExp> = [
   /^---[\s\S]*?\n---\s*/,
   /^#{1,6}\s+.*$/gm,
   /^>\s*/gm,
   /^\s*[-*+]\s+/gm,
   /^\s*\d+\.\s+/gm,
   /<\/?[a-z][^>]*>/gi,
+  /!\[[^\]]*\]\([^)]*\)/g,
+];
+
+/* Patterns that keep the visible text inside the capture group. */
+const KEEP_PATTERNS: ReadonlyArray<RegExp> = [
   /\*\*([^*]+)\*\*/g,
   /__([^_]+)__/g,
   /\*([^*]+)\*/g,
   /_([^_]+)_/g,
   /`([^`]+)`/g,
-  /!\[[^\]]*\]\([^)]*\)/g,
   /\[([^\]]+)\]\([^)]*\)/g,
 ];
 
 const stripMarkdown = (raw: string): string => {
   let out = raw;
-  for (const re of STRIP_PATTERNS) {
-    out = out.replace(re, (_, captured?: string) => captured ?? '');
-  }
+  for (const re of DROP_PATTERNS) out = out.replace(re, '');
+  for (const re of KEEP_PATTERNS) out = out.replace(re, (_, captured: string) => captured);
   return out;
 };
 

--- a/src/features/content/helpers/deriveSummary.test.ts
+++ b/src/features/content/helpers/deriveSummary.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { deriveSummary } from './deriveSummary';
+
+describe('deriveSummary', () => {
+  it('returns the first paragraph as-is when short', () => {
+    expect(deriveSummary('Hello world.')).toBe('Hello world.');
+  });
+
+  it('skips heading and grabs the next paragraph', () => {
+    expect(deriveSummary('# Title\n\nFirst paragraph.')).toBe('First paragraph.');
+  });
+
+  it('strips bold/italic/code marks', () => {
+    expect(deriveSummary('**Bold** and _italic_ and `code` text.')).toBe(
+      'Bold and italic and code text.',
+    );
+  });
+
+  it('preserves link visible text, drops URL', () => {
+    expect(deriveSummary('See [docs](https://x.test) for more.')).toBe('See docs for more.');
+  });
+
+  it('drops images entirely', () => {
+    expect(deriveSummary('![alt](pic.png)\n\nReal text.')).toBe('Real text.');
+  });
+
+  it('truncates at ~160 chars on a word boundary with ellipsis', () => {
+    const long = 'word '.repeat(80).trim();
+    const out = deriveSummary(long);
+    expect(out?.length).toBeLessThanOrEqual(161);
+    expect(out?.endsWith('…')).toBe(true);
+  });
+
+  it('returns undefined when the body has no readable text', () => {
+    expect(deriveSummary('')).toBe(undefined);
+    expect(deriveSummary('---\nlang: en\n---\n')).toBe(undefined);
+  });
+});

--- a/src/features/content/helpers/deriveSummary.ts
+++ b/src/features/content/helpers/deriveSummary.ts
@@ -1,0 +1,64 @@
+/*
+ * Widget summary — short preview text shown on cards in listings.
+ *
+ * Editor wants widgets (PostCard, NewspaperCard, position cards) to
+ * always derive their preview from the article body, NOT from the
+ * frontmatter `description` field. The frontmatter description is
+ * being repurposed as the preface block on the article page itself
+ * — see deriveDescription for the SEO meta path.
+ *
+ * Rules:
+ * - Strip markdown decorations (headings, lists, bold, italic, …).
+ * - Take the first non-trivial paragraph.
+ * - Truncate on a word boundary at ~MAX_LEN characters; append …
+ */
+
+/* Patterns that drop the match entirely (no capture group). */
+const DROP_PATTERNS: ReadonlyArray<RegExp> = [
+  /^---[\s\S]*?\n---\s*/,
+  /^#{1,6}\s+.*$/gm,
+  /^>\s*/gm,
+  /^\s*[-*+]\s+/gm,
+  /^\s*\d+\.\s+/gm,
+  /<\/?[a-z][^>]*>/gi,
+  /!\[[^\]]*\]\([^)]*\)/g,
+];
+
+/* Patterns that keep the visible text inside the capture group. */
+const KEEP_PATTERNS: ReadonlyArray<RegExp> = [
+  /\*\*([^*]+)\*\*/g,
+  /__([^_]+)__/g,
+  /\*([^*]+)\*/g,
+  /_([^_]+)_/g,
+  /`([^`]+)`/g,
+  /\[([^\]]+)\]\([^)]*\)/g,
+];
+
+const stripMarkdown = (raw: string): string => {
+  let out = raw;
+  for (const re of DROP_PATTERNS) out = out.replace(re, '');
+  for (const re of KEEP_PATTERNS) out = out.replace(re, (_, captured: string) => captured);
+  return out;
+};
+
+const MAX_LEN = 160;
+
+/**
+ * Build the preview snippet shown on listing cards. Always derives
+ * from the article body — frontmatter `description` is reserved for
+ * the lead/preface block on the detail page now.
+ *
+ * @param body Raw markdown body.
+ * @returns Short summary (~160 chars), or undefined if body is empty.
+ */
+export const deriveSummary = (body: string | undefined): string | undefined => {
+  if (!body) return undefined;
+  const firstPara = stripMarkdown(body)
+    .split(/\n\s*\n/)
+    .map((p) => p.replace(/\s+/g, ' ').trim())
+    .find((p) => p.length > 0);
+  if (!firstPara) return undefined;
+  if (firstPara.length <= MAX_LEN) return firstPara;
+  const cut = firstPara.slice(0, MAX_LEN + 1).lastIndexOf(' ');
+  return `${firstPara.slice(0, cut > 0 ? cut : MAX_LEN).trimEnd()}…`;
+};

--- a/src/features/home/components/NewsSection.astro
+++ b/src/features/home/components/NewsSection.astro
@@ -4,6 +4,7 @@ import CpButton from '@/components/cp/CpButton.astro';
 import type { Language } from '@/config/i18n';
 import PostCard from '@/features/blog/components/PostCard.astro';
 import { getArticleSlug } from '@/features/blog/helpers/getBlogPosts';
+import { deriveSummary } from '@/features/content/helpers/deriveSummary';
 
 interface Props {
   posts: CollectionEntry<'blog'>[];
@@ -29,7 +30,7 @@ const { posts, lang, latestNewsLabel, viewAllLabel } = Astro.props;
           {posts.map((post) => (
             <PostCard
               title={post.data.title}
-              description={post.data.description}
+              description={deriveSummary(post.body) ?? ''}
               category={post.data.category}
               slug={getArticleSlug(post)}
               image={post.data.image}

--- a/src/features/positions/components/PositionsWidget.astro
+++ b/src/features/positions/components/PositionsWidget.astro
@@ -3,6 +3,7 @@ import type { CollectionEntry } from 'astro:content';
 import CpButton from '@/components/cp/CpButton.astro';
 import type { Language } from '@/config/i18n';
 import { getLabelsData, getPageData } from '@/config/translations';
+import { deriveSummary } from '@/features/content/helpers/deriveSummary';
 import PositionCard from './PositionCard.astro';
 
 interface Props {
@@ -33,7 +34,7 @@ const readMore = labels?.data.readMore ?? 'Read more';
           {positions.map((pos) => (
             <PositionCard
               title={pos.data.title}
-              description={pos.data.description}
+              description={deriveSummary(pos.body) ?? ''}
               slug={pos.id.split('/').at(0) ?? pos.id}
               lang={lang}
               readMoreLabel={readMore}

--- a/src/pages/[lang]/blog/[...slug].astro
+++ b/src/pages/[lang]/blog/[...slug].astro
@@ -120,6 +120,9 @@ const newspaperRef = await (async () => {
             <BlogPicture image={post.data.image} alt={post.data.title} preset="featured" loading="eager" />
           </div>
         )}
+        {post.data.description && post.data.description.trim() !== '' && (
+          <p class="lead" itemprop="abstract">{post.data.description}</p>
+        )}
         <div class="prose" itemprop="articleBody">
           <Content />
         </div>
@@ -217,6 +220,22 @@ const newspaperRef = await (async () => {
     width: 100%;
     height: auto;
     border-radius: var(--radius-lg);
+  }
+
+  /*
+   * Description-as-preface: a slightly larger, secondary-colour
+   * lead paragraph above the article body. The surrounding article
+   * `.prose` keeps regular paragraph styling, but the lead block is
+   * visually distinct so readers spot the editor-written summary.
+   */
+  .lead {
+    max-width: 800px;
+    margin: 0 auto var(--spacing-lg);
+    color: var(--color-text-secondary);
+    font-size: 1.125rem;
+    line-height: 1.65;
+    border-left: 3px solid var(--color-accent);
+    padding-left: var(--spacing-md);
   }
 
   .prose {

--- a/src/pages/[lang]/blog/index.astro
+++ b/src/pages/[lang]/blog/index.astro
@@ -8,7 +8,7 @@ import {
   getBlogPosts,
   getUniqueCategories,
 } from '@/features/blog/helpers/getBlogPosts';
-import { deriveDescription } from '@/features/content/helpers/deriveDescription';
+import { deriveSummary } from '@/features/content/helpers/deriveSummary';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
 /*
@@ -57,7 +57,7 @@ const readMore = labels?.data.readMore ?? 'Read more';
               <div data-category={post.data.category}>
                 <PostCard
                   title={post.data.title}
-                  description={deriveDescription(post.data.description, post.body) ?? ''}
+                  description={deriveSummary(post.body) ?? ''}
                   category={post.data.category}
                   slug={getArticleSlug(post)}
                   image={post.data.image}

--- a/src/pages/[lang]/newspaper/index.astro
+++ b/src/pages/[lang]/newspaper/index.astro
@@ -1,6 +1,7 @@
 ---
 import { DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES } from '@/config/i18n';
 import { getLabelsData } from '@/config/translations';
+import { deriveSummary } from '@/features/content/helpers/deriveSummary';
 import NewspaperCard from '@/features/newspaper/components/NewspaperCard.astro';
 import { getNewspaperItems } from '@/features/newspaper/helpers/getNewspaperItems';
 import BaseLayout from '@/layouts/BaseLayout.astro';
@@ -36,7 +37,7 @@ const readMore = labels?.data.readMore ?? 'Download PDF';
           {items.map((item) => (
             <NewspaperCard
               title={item.data.title}
-              description={item.data.description}
+              description={deriveSummary(item.body) ?? item.data.description ?? ''}
               slug={item.id.split('/').at(0) ?? item.id}
               lang={lang}
               image={item.data.image ?? undefined}

--- a/src/pages/[lang]/positions/index.astro
+++ b/src/pages/[lang]/positions/index.astro
@@ -1,6 +1,7 @@
 ---
 import { DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES } from '@/config/i18n';
 import { getLabelsData, getPageData } from '@/config/translations';
+import { deriveSummary } from '@/features/content/helpers/deriveSummary';
 import PositionCard from '@/features/positions/components/PositionCard.astro';
 import { getPositions } from '@/features/positions/helpers/getPositions';
 import BaseLayout from '@/layouts/BaseLayout.astro';
@@ -38,7 +39,7 @@ const readMore = labels?.data.readMore ?? 'Read more';
           {positions.map((pos) => (
             <PositionCard
               title={pos.data.title}
-              description={pos.data.description}
+              description={deriveSummary(pos.body) ?? pos.data.description ?? ''}
               slug={pos.id.split('/').at(0) ?? pos.id}
               lang={lang}
               headingLevel={2}


### PR DESCRIPTION
Editor's spec: `description` shows as a preface on the article page; widgets pull preview from body. New deriveSummary helper, schemas relaxed to optional, lead block on blog detail. Admin-side field-removal follow-up incoming.