### PR TITLE
fix(infra): remove stale subtree hooks that broke local builds

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,3 +1,0 @@
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
-# Run subtree sync in background to avoid blocking on network issues
-(git fetch content "$BRANCH" 2>/dev/null && git subtree pull --prefix=src/content content "$BRANCH" --squash -m "content: sync after checkout" 2>/dev/null) &

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,3 +1,0 @@
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
-# Run subtree sync in background to avoid blocking on network issues
-(git fetch content "$BRANCH" 2>/dev/null && git subtree pull --prefix=src/content content "$BRANCH" --squash -m "content: sync after pull" 2>/dev/null) &


### PR DESCRIPTION
## Summary
`.husky/post-checkout` and `.husky/post-merge` were leftovers from when content lived inside this repo as a `src/content/` subtree. They ran:

```sh
git subtree pull --prefix=src/content content \"\$BRANCH\" --squash \
  -m \"content: sync after checkout\"
```

…in the background after every \`git checkout\` / \`git pull\`. Two problems with that on the current setup:

1. \`scripts/fetch-content.ts\` already clones \`public-website-content\` into \`src/content/\` at \`predev\`/\`prebuild\` time, and \`src/content/\` is gitignored. The repo has no subtree metadata at \`src/content/\` any more.
2. Without subtree metadata, \`git subtree pull --prefix=src/content --squash\` silently falls back to a plain merge of the content repo's tree (rooted at \`blog/\`, \`common/\`, \`pages/\`, \`settings/\`) directly into the working tree — dumping those directories at the repo **root** and leaving the working tree with \`Unmerged paths\` and \`MERGE_MSG=content: sync after checkout\`.

What that looked like in practice: a routine \`git checkout\` mid-task corrupted the working tree, and the next \`bun run build\` blew up because Astro started seeing root-level \`pages/\`, \`common/\` collections instead of finding them under \`src/content/\`. Reproduced + diagnosed today.

The hooks are obsolete since the \`fetch-content.ts\` switch (per the comment block in that script: \"Content is no longer committed into the code repo\"). \`predev\`/\`prebuild\` already pull content fresh every cycle, so the hooks have nothing to do besides break things. Drop them.

## Test plan
- [x] \`bun run build\` from a clean working tree → 170 pages built, no errors.
- [x] Verified the failure mode beforehand: aborted merge had \`MERGE_MSG=content: sync after checkout\` (literal hook message) and root-level \`blog/\`, \`pages/\`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)