### PR TITLE
feat(layout): port admin's sticky-with-reveal header to mobile (clean rebase of #80)

### DIFF
--- a/e2e/sticky-header.pw.ts
+++ b/e2e/sticky-header.pw.ts
@@ -1,0 +1,133 @@
+import { expect, type Page, test, visit } from '@prometheus/e2e-toolkit';
+
+/*
+ * Sticky-with-reveal header — mirrors the admin AppHeader pattern.
+ *
+ * Asserts:
+ * - Header is sticky at top:0 (engaged once user scrolls past the
+ *   header line). Pre-existing bug was that body { overflow-x: hidden }
+ *   computed `overflow-y: auto`, making body the sticky scope while
+ *   actual scroll happened on html — so sticky never engaged. Theme
+ *   stylesheet now uses `overflow-x: clip` to keep scroll on html.
+ * - Scrolling down past the header retracts it (translateY -height).
+ * - Scrolling back up reveals it (translateY 0).
+ * - `--header-height` and `--header-offset` CSS variables are
+ *   published so other components can lay out around the header.
+ * - On mobile, the MobileMenu FAB is rendered as a body sibling and
+ *   is unaffected by the header's transform.
+ */
+
+const ARTICLE = '/en/blog/astro-framework';
+
+const readState = (page: Page) =>
+  page.evaluate(() => ({
+    y: window.scrollY,
+    transform: document.querySelector('header')?.style.transform ?? '',
+    bboxTop: document.querySelector('header')?.getBoundingClientRect().top ?? 0,
+    height: getComputedStyle(document.documentElement).getPropertyValue('--header-height'),
+    offset: getComputedStyle(document.documentElement).getPropertyValue('--header-offset'),
+  }));
+
+const scrollAndSettle = async (page: Page, y: number): Promise<void> => {
+  /*
+   * Scroll, then poll until the rAF-throttled scroll handler in
+   * Header.astro publishes a `--header-offset` value matching the
+   * new scroll direction. Polling beats waiting on a fixed number
+   * of rAF callbacks because the handler can land in either of the
+   * next two frames depending on browser scheduling.
+   */
+  await page.evaluate(
+    (target) =>
+      new Promise<void>((resolve) => {
+        const before = window.scrollY;
+        window.scrollTo(0, target);
+        const goingDown = target > before;
+        const goingUp = target < before;
+        const start = performance.now();
+        const tick = () => {
+          const offset = parseFloat(
+            getComputedStyle(document.documentElement).getPropertyValue('--header-offset') || '0',
+          );
+          const settled =
+            (goingDown && offset < 0) || (goingUp && offset === 0) || (!goingDown && !goingUp);
+          if (settled || performance.now() - start > 1000) {
+            resolve();
+            return;
+          }
+          requestAnimationFrame(tick);
+        };
+        requestAnimationFrame(tick);
+      }),
+    y,
+  );
+};
+
+test.describe('Sticky header — desktop', () => {
+  test.use({ viewport: { width: 1400, height: 900 } });
+
+  test('engages position:sticky so header stays near the viewport top', async ({ page }) => {
+    await visit(page, ARTICLE);
+    await scrollAndSettle(page, 500);
+    const s = await readState(page);
+    /*
+     * 500px scroll. If `position: sticky` is engaging, the header's
+     * viewport-relative top is between -height (fully retracted by
+     * the scroll-reveal transform) and 0 (still pinned). Without
+     * sticky we'd see ≈ -500.
+     */
+    expect(s.y).toBe(500);
+    expect(s.bboxTop).toBeGreaterThan(-200);
+  });
+
+  test('publishes --header-height and --header-offset', async ({ page }) => {
+    await visit(page, ARTICLE);
+    const initial = await readState(page);
+    expect(initial.height).toMatch(/\d+px/);
+    expect(parseFloat(initial.height)).toBeGreaterThan(40);
+    await scrollAndSettle(page, 500);
+    const scrolled = await readState(page);
+    expect(parseFloat(scrolled.offset)).toBeLessThan(0);
+  });
+
+  test('reveals on scroll-up', async ({ page }) => {
+    await visit(page, ARTICLE);
+    await scrollAndSettle(page, 800);
+    const hidden = await readState(page);
+    expect(hidden.transform).toMatch(/translateY\(-\d/);
+    await scrollAndSettle(page, 600);
+    const revealed = await readState(page);
+    expect(revealed.transform).toBe('translateY(0px)');
+  });
+});
+
+test.describe('Sticky header — mobile (MobileMenu lives outside header)', () => {
+  test.use({ viewport: { width: 420, height: 800 } });
+
+  test('FAB is a body sibling, not nested in <header>', async ({ page }) => {
+    await visit(page, ARTICLE);
+    const parentTag = await page.evaluate(() => {
+      const w = document.querySelector('[data-testid="mobile-menu-wrapper"]');
+      return w?.parentElement?.tagName ?? null;
+    });
+    expect(parentTag).toBe('BODY');
+  });
+
+  test('FAB stays anchored to viewport when header retracts', async ({ page }) => {
+    await visit(page, ARTICLE);
+    await scrollAndSettle(page, 1000);
+    const result = await page.evaluate(() => {
+      const fab = document.querySelector(
+        '[data-testid="mobile-menu-toggle"]',
+      ) as HTMLElement | null;
+      const header = document.querySelector('header') as HTMLElement | null;
+      return {
+        fabBottom: fab?.getBoundingClientRect().bottom ?? 0,
+        headerTransform: header?.style.transform ?? '',
+      };
+    });
+    /* Header retracted, FAB still anchored near viewport bottom (≤ 800). */
+    expect(result.headerTransform).toMatch(/translateY\(-\d/);
+    expect(result.fabBottom).toBeLessThanOrEqual(800);
+    expect(result.fabBottom).toBeGreaterThan(700);
+  });
+});

--- a/src/features/navigation/components/Header.astro
+++ b/src/features/navigation/components/Header.astro
@@ -2,7 +2,6 @@
 import type { Language } from '@/config/i18n';
 import ThemeToggle from '@/features/theme/components/ThemeToggle.astro';
 import LanguageSwitcher from './LanguageSwitcher.astro';
-import MobileMenu from './MobileMenu.astro';
 import Nav from './Nav.astro';
 
 interface Props {
@@ -29,7 +28,6 @@ const { lang } = Astro.props;
         <div class="desktop-only">
           <ThemeToggle />
         </div>
-        <MobileMenu lang={lang} />
       </div>
     </div>
   </div>
@@ -37,35 +35,41 @@ const { lang } = Astro.props;
 
 <script is:inline>
   /*
-   * Sticky-with-reveal header — desktop only. On mobile the header
-   * contains the MobileMenu hamburger AND the panel/overlay, and a
-   * `transform` on `<header>` would make the header the containing
-   * block for those `position: fixed` panel elements (CSS spec).
-   * The panel + overlay then float over the article instead of the
-   * viewport — which is exactly what broke the mobile UX after the
-   * scroll-reveal first shipped. So gate the script to desktop.
+   * Sticky-with-reveal header — mirrors admin's AppHeader. Active on
+   * every viewport including mobile. Mobile is safe now because the
+   * MobileMenu lives outside <header> (rendered as a sibling in the
+   * BaseLayout) so its `position: fixed` panel + overlay no longer
+   * use the header as their containing block when the header
+   * transforms on scroll.
+   *
+   * The translateY offset is also published as `--header-offset` on
+   * <html> so any sibling component can react (e.g. a TOC pinned
+   * below the header line could subtract this offset to follow the
+   * reveal). Header height is published as `--header-height`.
    */
   (function () {
     var header = document.querySelector('[data-scroll-header]');
     if (!header) return;
-    var DESKTOP_QUERY = '(min-width: 768px)';
     var lastY = window.scrollY;
     var offset = 0;
     var ticking = false;
-    function isDesktop() {
-      return window.matchMedia(DESKTOP_QUERY).matches;
+
+    function publishHeight() {
+      var h = header.getBoundingClientRect().height || 60;
+      document.documentElement.style.setProperty(
+        '--header-height',
+        h + 'px'
+      );
     }
     function applyOffset(o) {
-      header.style.transform = isDesktop() ? 'translateY(' + o + 'px)' : '';
+      header.style.transform = 'translateY(' + o + 'px)';
+      document.documentElement.style.setProperty(
+        '--header-offset',
+        o + 'px'
+      );
     }
     function handleScroll() {
       ticking = false;
-      if (!isDesktop()) {
-        offset = 0;
-        applyOffset(0);
-        lastY = window.scrollY;
-        return;
-      }
       var height = header.getBoundingClientRect().height || 60;
       var y = window.scrollY;
       var dy = y - lastY;
@@ -77,26 +81,21 @@ const { lang } = Astro.props;
       }
       applyOffset(offset);
     }
+
+    publishHeight();
+    applyOffset(0);
     window.addEventListener('scroll', function () {
       if (ticking) return;
       ticking = true;
       window.requestAnimationFrame(handleScroll);
     }, { passive: true });
-    /*
-     * Resize / orientation changes can flip the breakpoint. Reset
-     * inline transform when we leave desktop so mobile gets the
-     * untransformed header back, even if a previous scroll left
-     * a non-zero offset behind.
-     */
-    window.matchMedia(DESKTOP_QUERY).addEventListener('change', function () {
-      offset = 0;
-      applyOffset(0);
-    });
+    window.addEventListener('resize', publishHeight);
     document.addEventListener('astro:before-swap', function () {
       offset = 0;
       lastY = 0;
       applyOffset(0);
     });
+    document.addEventListener('astro:after-swap', publishHeight);
   })();
 </script>
 
@@ -107,22 +106,20 @@ const { lang } = Astro.props;
     background: var(--color-surface-elevated);
     border-bottom: 1px solid var(--color-border);
     z-index: 100;
+    transition: transform var(--transition-fast);
+    will-change: transform;
   }
 
   /*
-   * The scroll-hide reveal lives on desktop only — the JS guards
-   * its `transform` mutations behind a matchMedia gate. The
-   * transition + will-change live in the SAME media query so they
-   * never apply on mobile; otherwise either property would make
-   * `<header>` a containing block for `position: fixed` descendants
-   * (CSS spec) and trap the MobileMenu panel inside the header
-   * box, which is exactly what broke the menu on prod.
+   * Blur stays desktop-only — on mobile it's pure overhead. Header
+   * transform is now safe on every viewport because MobileMenu is
+   * rendered as a BaseLayout sibling, not inside <header>, so a
+   * transformed header is no longer the containing block for the
+   * menu's fixed FAB / panel / overlay.
    */
   @media (min-width: 768px) {
     header {
       backdrop-filter: blur(10px);
-      transition: transform var(--transition-fast);
-      will-change: transform;
     }
   }
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -3,6 +3,7 @@ import { ClientRouter } from 'astro:transitions';
 import type { Language } from '@/config/i18n';
 import Footer from '@/features/navigation/components/Footer.astro';
 import Header from '@/features/navigation/components/Header.astro';
+import MobileMenu from '@/features/navigation/components/MobileMenu.astro';
 import '@/styles/theme.css';
 import '@/styles/utilities.css';
 
@@ -98,6 +99,14 @@ const absoluteImage = shareImage.startsWith('http') ? shareImage : `${SITE_URL}$
       <slot />
     </main>
     <Footer lang={lang} />
+    {/*
+      MobileMenu sits as a body-level sibling of <header> so the
+      header's scroll-reveal transform never makes it the containing
+      block for the menu's fixed FAB / panel / overlay. On desktop
+      the wrapper hides itself (>=768px), so this only paints on
+      mobile.
+    */}
+    <MobileMenu lang={lang} />
     <script is:inline>
       if ('serviceWorker' in navigator && location.hostname !== 'localhost') {
         navigator.serviceWorker.register('/sw.js');

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -129,7 +129,16 @@ html {
   color: var(--color-text-primary);
   background: var(--color-background);
   scrollbar-gutter: stable;
-  overflow-x: hidden;
+  /*
+   * `overflow-x: clip` instead of `hidden` keeps the page free of
+   * horizontal scroll (some article media pushes the natural width
+   * past the viewport on narrow screens) without making <html> its
+   * own scroll container. `hidden` quietly forces `overflow-y: auto`
+   * on the same element — that broke `position: sticky` for the
+   * header because body became the sticky scope but actual scroll
+   * still happens on html.
+   */
+  overflow-x: clip;
   /*
    * Mobile Safari / Android Chrome paint a translucent grey square
    * over every tappable element on tap. Override globally to
@@ -142,7 +151,8 @@ html {
 body {
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
-  overflow-x: hidden;
+  /* See html — clip avoids the implicit `overflow-y: auto`. */
+  overflow-x: clip;
 }
 
 img,


### PR DESCRIPTION
Clean rebase of #80 onto latest master after #78/#79/#81 merged. Same content, no merge conflicts. Header gets sticky-reveal on mobile, MobileMenu moved to body sibling, --header-height/--header-offset CSS vars exposed.