### PR TITLE
fix(toc): include h1 in TOC + smooth-scroll anchor jumps

### DIFF
--- a/src/features/content/components/ArticleToc.astro
+++ b/src/features/content/components/ArticleToc.astro
@@ -17,8 +17,13 @@
  * the `#${slug}` hrefs land on the right section without us having to
  * rewrite the article HTML.
  *
- * h1 is the article title (rendered separately) and h≥5 is rare and
- * noisy in a TOC, so we keep h2–h4 only.
+ * h≥5 is rare and noisy in a TOC, so we keep h1–h4. Including h1
+ * matters: many editorial articles are long-form prose with no
+ * subheadings, and previously got no TOC at all. With h1 included
+ * they at least get a one-entry "back to top" affordance, and
+ * articles WITH subheadings start with the title as the anchor for
+ * "I've scrolled past everything, take me back" — matches reading
+ * rhythm better than relying on the browser's native top-of-page.
  */
 
 interface Heading {
@@ -33,7 +38,7 @@ interface Props {
 }
 
 const { headings, label = 'Contents' } = Astro.props as Props;
-const visible = headings.filter((h) => h.depth >= 2 && h.depth <= 4);
+const visible = headings.filter((h) => h.depth >= 1 && h.depth <= 4);
 ---
 
 {visible.length > 0 && (

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -130,6 +130,15 @@ html {
   background: var(--color-background);
   scrollbar-gutter: stable;
   /*
+   * Smooth-scroll TOC anchor jumps + offset the landing point past
+   * the sticky header. `--header-height` is published by Header.astro
+   * on first paint and refreshed on resize, so the offset stays in
+   * sync with the header's actual measured height. Falls back to 5rem
+   * before the script runs.
+   */
+  scroll-behavior: smooth;
+  scroll-padding-top: calc(var(--header-height, 5rem) + 0.5rem);
+  /*
    * `overflow-x: clip` instead of `hidden` keeps the page free of
    * horizontal scroll (some article media pushes the natural width
    * past the viewport on narrow screens) without making <html> its
@@ -201,6 +210,10 @@ h6 {
   *::after {
     animation-duration: 0.01ms;
     transition-duration: 0.01ms;
+  }
+
+  html {
+    scroll-behavior: auto;
   }
 }
 


### PR DESCRIPTION
## Summary
Two issues reported on the article TOC.

### 1. TOC missing on long-form prose articles
Filter was \`h.depth >= 2 && h.depth <= 4\`, so editorial pieces written as one h1 title + paragraphs (no \`## H2\` dividers) got no TOC at all. Lowered the floor to h1.

Coverage in the current content corpus (15 articles):
- Before: 9 articles got a TOC (60%)
- After: 11 articles get a TOC (73%)
- The remaining 4 have zero markdown headings — that's a content-shape issue (editor needs to add \`## H2\` section markers in the body), no code can fix it.

### 2. Anchor jumps slammed instantly + landed under the sticky header
- Added \`scroll-behavior: smooth\`
- Added \`scroll-padding-top: calc(var(--header-height, 5rem) + 0.5rem)\` so the landing point clears the sticky header (\`--header-height\` is published by \`Header.astro\` on first paint and refreshed on resize)
- \`prefers-reduced-motion: reduce\` overrides back to \`auto\` so users with motion sensitivity get the snap behaviour

Active-section highlight (the third reported request) is already working: \`ArticleToc.astro\` runs an RAF-based scroll-spy that sets \`.article-toc-link--active\` + \`aria-current=\"location\"\` on the heading the reader has just passed. It uses position-based detection (not IntersectionObserver) on purpose — the comment in the file explains why.

## Test plan
- [ ] Manual: open a long article (e.g. \`/ru/blog/about-the-manifesto\`) — TOC pill is visible bottom-left, panel opens on tap, contains 1+ entries
- [ ] Manual: click a TOC link — page scrolls smoothly to the heading; landing point sits below the sticky header, not under it
- [ ] Manual: scroll through the article — active link in the TOC updates as you pass headings
- [ ] Manual: \`prefers-reduced-motion\` toggled on — anchor jumps land instantly, no smooth animation

## Validation
\`bun run lint\` clean. \`bun run check\` (astro check) clean. \`bun run build\` builds all 170 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)