### PR TITLE
fix(toc): always render + add to about/manifest + content headings

### DIFF
--- a/src/features/content/components/ArticleToc.astro
+++ b/src/features/content/components/ArticleToc.astro
@@ -12,21 +12,27 @@
  * edge with the same heading list. Tapping a link or pressing Escape
  * dismisses the panel.
  *
- * Headings are sourced from `await entry.render()`'s `.headings` —
- * Astro auto-generates anchor `id`s on headings via github-slugger so
- * the `#${slug}` hrefs land on the right section without us having to
- * rewrite the article HTML.
+ * Headings come from `await entry.render()`'s `.headings`. Astro
+ * auto-generates anchor ids on every heading via github-slugger so
+ * the `#${slug}` hrefs land on the right section without us having
+ * to rewrite the article HTML.
  *
- * The TOC always renders — for articles with no markdown headings we
- * fall back to a single synthetic "back to top" entry that points at
- * the `#article-top` anchor (the host page sets it on its `<article>`
- * wrapper). Editors should still mark up real headings; the
- * synthetic case is a guard rail, not a substitute.
+ * The TOC always opens with the article *title*, anchored to
+ * `#article-top` — the host page sets that id on the title header.
+ * That gives readers a stable "back to top" entry on every article,
+ * regardless of whether the markdown body has its own headings, and
+ * matches reading rhythm: on long pieces the cursor naturally drifts
+ * away from the navigation chrome and the title pin reels it back.
  *
- * h≥5 is rare and noisy in a TOC, so we keep h1–h4 only. Including
- * h1 lets articles WITH subheadings start with the title as a
- * "scrolled past everything, take me back" anchor — matches reading
- * rhythm better than relying on the browser's native top-of-page.
+ * Body h1s are dropped from the heading list. They almost always
+ * duplicate the article title, and showing both creates an
+ * "Article Title / Article Title" doublet at the top of the TOC.
+ * h2-h4 are kept; h≥5 is rare and noisy.
+ *
+ * Smooth scroll on click is implemented in JS rather than relying
+ * on `scroll-behavior: smooth` alone, because Astro's ClientRouter
+ * sometimes intercepts the click before the browser's default
+ * anchor jump fires, killing the smooth easing.
  */
 
 interface Heading {
@@ -38,15 +44,17 @@ interface Heading {
 interface Props {
   readonly headings: readonly Heading[];
   readonly label?: string;
-  /** Title rendered as the synthetic entry when no headings exist. */
-  readonly fallbackTitle: string;
+  /** Article title — always rendered as the top TOC entry. */
+  readonly articleTitle: string;
 }
 
-const { headings, label = 'Contents', fallbackTitle } = Astro.props as Props;
-const real = headings.filter((h) => h.depth >= 1 && h.depth <= 4);
-const FALLBACK_SLUG = 'article-top';
-const visible: readonly Heading[] =
-  real.length > 0 ? real : [{ depth: 1, slug: FALLBACK_SLUG, text: fallbackTitle }];
+const { headings, label = 'Contents', articleTitle } = Astro.props as Props;
+const TOP_SLUG = 'article-top';
+const subHeadings = headings.filter((h) => h.depth >= 2 && h.depth <= 4);
+const visible: readonly Heading[] = [
+  { depth: 1, slug: TOP_SLUG, text: articleTitle },
+  ...subHeadings,
+];
 ---
 
 <aside class="article-toc" data-testid="article-toc">
@@ -121,7 +129,31 @@ const visible: readonly Heading[] =
       toggle.setAttribute('aria-expanded', String(next));
     });
     root.querySelectorAll('a').forEach((a) => {
-      a.addEventListener('click', close);
+      a.addEventListener('click', (e) => {
+        const href = a.getAttribute('href') ?? '';
+        if (href.startsWith('#')) {
+          /*
+           * Bypass Astro's ClientRouter and any other interceptor:
+           * resolve the target id, scroll smoothly, and update the
+           * URL hash explicitly. `scroll-behavior: smooth` on <html>
+           * isn't always enough — when overflow rules push the
+           * scroll container down to <body> the html-level rule
+           * doesn't apply, and view-transition setups sometimes
+           * eat the click before the native anchor jump fires.
+           */
+          e.preventDefault();
+          const id = decodeURIComponent(href.slice(1));
+          const target = document.getElementById(id);
+          if (target) {
+            target.scrollIntoView({
+              behavior: 'smooth',
+              block: 'start',
+            });
+            history.pushState(null, '', href);
+          }
+        }
+        close();
+      });
     });
     root
       .querySelector<HTMLButtonElement>(

--- a/src/features/content/components/ArticleToc.astro
+++ b/src/features/content/components/ArticleToc.astro
@@ -17,8 +17,16 @@
  * the `#${slug}` hrefs land on the right section without us having to
  * rewrite the article HTML.
  *
- * h1 is the article title (rendered separately) and h≥5 is rare and
- * noisy in a TOC, so we keep h2–h4 only.
+ * The TOC always renders — for articles with no markdown headings we
+ * fall back to a single synthetic "back to top" entry that points at
+ * the `#article-top` anchor (the host page sets it on its `<article>`
+ * wrapper). Editors should still mark up real headings; the
+ * synthetic case is a guard rail, not a substitute.
+ *
+ * h≥5 is rare and noisy in a TOC, so we keep h1–h4 only. Including
+ * h1 lets articles WITH subheadings start with the title as a
+ * "scrolled past everything, take me back" anchor — matches reading
+ * rhythm better than relying on the browser's native top-of-page.
  */
 
 interface Heading {
@@ -30,55 +38,58 @@ interface Heading {
 interface Props {
   readonly headings: readonly Heading[];
   readonly label?: string;
+  /** Title rendered as the synthetic entry when no headings exist. */
+  readonly fallbackTitle: string;
 }
 
-const { headings, label = 'Contents' } = Astro.props as Props;
-const visible = headings.filter((h) => h.depth >= 2 && h.depth <= 4);
+const { headings, label = 'Contents', fallbackTitle } = Astro.props as Props;
+const real = headings.filter((h) => h.depth >= 1 && h.depth <= 4);
+const FALLBACK_SLUG = 'article-top';
+const visible: readonly Heading[] =
+  real.length > 0 ? real : [{ depth: 1, slug: FALLBACK_SLUG, text: fallbackTitle }];
 ---
 
-{visible.length > 0 && (
-  <aside class="article-toc" data-testid="article-toc">
-    <button
-      type="button"
-      class="article-toc-toggle"
-      aria-expanded="false"
-      aria-controls="article-toc-nav"
-      data-testid="article-toc-toggle"
+<aside class="article-toc" data-testid="article-toc">
+  <button
+    type="button"
+    class="article-toc-toggle"
+    aria-expanded="false"
+    aria-controls="article-toc-nav"
+    data-testid="article-toc-toggle"
+  >
+    <svg
+      class="article-toc-icon"
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      aria-hidden="true"
+      focusable="false"
     >
-      <svg
-        class="article-toc-icon"
-        width="16"
-        height="16"
-        viewBox="0 0 16 16"
-        aria-hidden="true"
-        focusable="false"
-      >
-        <path
-          fill="currentColor"
-          d="M2 3h12v2H2zM2 7h12v2H2zM2 11h8v2H2z"
-        />
-      </svg>
-      <span>{label}</span>
-    </button>
-    <button
-      type="button"
-      class="article-toc-backdrop"
-      aria-label="Close contents"
-      data-testid="article-toc-backdrop"
-      tabindex="-1"
-    ></button>
-    <nav id="article-toc-nav" class="article-toc-nav" aria-label={label}>
-      <span class="article-toc-heading">{label}</span>
-      <ol class="article-toc-list">
-        {visible.map((h) => (
-          <li class={`article-toc-item article-toc-item--depth-${h.depth}`}>
-            <a href={`#${h.slug}`} class="article-toc-link">{h.text}</a>
-          </li>
-        ))}
-      </ol>
-    </nav>
-  </aside>
-)}
+      <path
+        fill="currentColor"
+        d="M2 3h12v2H2zM2 7h12v2H2zM2 11h8v2H2z"
+      />
+    </svg>
+    <span>{label}</span>
+  </button>
+  <button
+    type="button"
+    class="article-toc-backdrop"
+    aria-label="Close contents"
+    data-testid="article-toc-backdrop"
+    tabindex="-1"
+  ></button>
+  <nav id="article-toc-nav" class="article-toc-nav" aria-label={label}>
+    <span class="article-toc-heading">{label}</span>
+    <ol class="article-toc-list">
+      {visible.map((h) => (
+        <li class={`article-toc-item article-toc-item--depth-${h.depth}`}>
+          <a href={`#${h.slug}`} class="article-toc-link">{h.text}</a>
+        </li>
+      ))}
+    </ol>
+  </nav>
+</aside>
 
 <script>
   /*

--- a/src/pages/[lang]/about.astro
+++ b/src/pages/[lang]/about.astro
@@ -1,6 +1,7 @@
 ---
-import { SUPPORTED_LANGUAGES } from '@/config/i18n';
-import { getPageData } from '@/config/translations';
+import { DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES } from '@/config/i18n';
+import { getLabelsData, getPageData } from '@/config/translations';
+import ArticleToc from '@/features/content/components/ArticleToc.astro';
 import SuggestChangesLink from '@/features/content/components/SuggestChangesLink.astro';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
@@ -22,13 +23,18 @@ const page = await getPageData('about', lang);
 // but Astro requires `page` to be narrowed for the render below.
 if (!page) throw new Error(`about page missing for ${lang}`);
 
-const { Content } = await page.render();
+const rendered = await page.render();
+const Content = rendered.Content;
+const headings = rendered.headings ?? [];
+const labels = (await getLabelsData(lang)) ?? (await getLabelsData(DEFAULT_LANGUAGE));
+const tocLabel = labels?.data.tableOfContents ?? 'Contents';
 ---
 
 <BaseLayout title={`${page.data.title} - Prometheus`} {...(page.data.description ? { description: page.data.description } : {})} lang={lang}>
   <article class="section">
+    <ArticleToc headings={headings} label={tocLabel} fallbackTitle={page.data.title} />
     <div class="container">
-      <div class="about-header">
+      <div class="about-header" id="article-top">
         <h1>{page.data.title}</h1>
         {page.data.subtitle ? <p class="lead">{page.data.subtitle}</p> : null}
       </div>

--- a/src/pages/[lang]/about.astro
+++ b/src/pages/[lang]/about.astro
@@ -32,7 +32,7 @@ const tocLabel = labels?.data.tableOfContents ?? 'Contents';
 
 <BaseLayout title={`${page.data.title} - Prometheus`} {...(page.data.description ? { description: page.data.description } : {})} lang={lang}>
   <article class="section">
-    <ArticleToc headings={headings} label={tocLabel} fallbackTitle={page.data.title} />
+    <ArticleToc headings={headings} label={tocLabel} articleTitle={page.data.title} />
     <div class="container">
       <div class="about-header" id="article-top">
         <h1>{page.data.title}</h1>

--- a/src/pages/[lang]/blog/[...slug].astro
+++ b/src/pages/[lang]/blog/[...slug].astro
@@ -91,9 +91,9 @@ const newspaperRef = await (async () => {
     <article class="section" itemscope itemtype="https://schema.org/Article">
       <meta itemprop="headline" content={post.data.title} />
       {pageDescription && <meta itemprop="description" content={pageDescription} />}
-      <ArticleToc headings={headings} label={tocLabel} />
+      <ArticleToc headings={headings} label={tocLabel} fallbackTitle={post.data.title} />
       <div class="container">
-        <header class="post-header">
+        <header class="post-header" id="article-top">
           <span class="category">{post.data.category}</span>
           <h1 itemprop="name">{post.data.title}</h1>
           <p class="post-meta">

--- a/src/pages/[lang]/blog/[...slug].astro
+++ b/src/pages/[lang]/blog/[...slug].astro
@@ -91,7 +91,7 @@ const newspaperRef = await (async () => {
     <article class="section" itemscope itemtype="https://schema.org/Article">
       <meta itemprop="headline" content={post.data.title} />
       {pageDescription && <meta itemprop="description" content={pageDescription} />}
-      <ArticleToc headings={headings} label={tocLabel} fallbackTitle={post.data.title} />
+      <ArticleToc headings={headings} label={tocLabel} articleTitle={post.data.title} />
       <div class="container">
         <header class="post-header" id="article-top">
           <span class="category">{post.data.category}</span>

--- a/src/pages/[lang]/manifest.astro
+++ b/src/pages/[lang]/manifest.astro
@@ -1,6 +1,8 @@
 ---
 import { getCollection } from 'astro:content';
-import { SUPPORTED_LANGUAGES } from '@/config/i18n';
+import { DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES } from '@/config/i18n';
+import { getLabelsData } from '@/config/translations';
+import ArticleToc from '@/features/content/components/ArticleToc.astro';
 import SuggestChangesLink from '@/features/content/components/SuggestChangesLink.astro';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
@@ -27,13 +29,18 @@ const page = pages.find((p) => p.id.startsWith('manifest/'));
 // Unreachable — getStaticPaths excludes empty langs.
 if (!page) throw new Error(`manifest page missing for ${lang}`);
 
-const { Content } = await page.render();
+const rendered = await page.render();
+const Content = rendered.Content;
+const headings = rendered.headings ?? [];
+const labels = (await getLabelsData(lang)) ?? (await getLabelsData(DEFAULT_LANGUAGE));
+const tocLabel = labels?.data.tableOfContents ?? 'Contents';
 ---
 
 <BaseLayout title={`${page.data.title} - Prometheus`} {...(page.data.description ? { description: page.data.description } : {})} lang={lang}>
   <article class="section">
+    <ArticleToc headings={headings} label={tocLabel} fallbackTitle={page.data.title} />
     <div class="container">
-      <div class="manifest-header">
+      <div class="manifest-header" id="article-top">
         <h1>{page.data.title}</h1>
       </div>
       <div class="prose">

--- a/src/pages/[lang]/manifest.astro
+++ b/src/pages/[lang]/manifest.astro
@@ -38,7 +38,7 @@ const tocLabel = labels?.data.tableOfContents ?? 'Contents';
 
 <BaseLayout title={`${page.data.title} - Prometheus`} {...(page.data.description ? { description: page.data.description } : {})} lang={lang}>
   <article class="section">
-    <ArticleToc headings={headings} label={tocLabel} fallbackTitle={page.data.title} />
+    <ArticleToc headings={headings} label={tocLabel} articleTitle={page.data.title} />
     <div class="container">
       <div class="manifest-header" id="article-top">
         <h1>{page.data.title}</h1>

--- a/src/pages/[lang]/positions/[...slug].astro
+++ b/src/pages/[lang]/positions/[...slug].astro
@@ -64,7 +64,7 @@ const pageDescription = entry ? deriveDescription(entry.data.description, entry.
 >
   {entry && Content ? (
     <article class="section">
-      <ArticleToc headings={headings} label={tocLabel} fallbackTitle={entry.data.title} />
+      <ArticleToc headings={headings} label={tocLabel} articleTitle={entry.data.title} />
       <div class="container">
         <a href={`/${lang}/positions`} class="back-link">{backLabel}</a>
         <header id="article-top">

--- a/src/pages/[lang]/positions/[...slug].astro
+++ b/src/pages/[lang]/positions/[...slug].astro
@@ -64,10 +64,10 @@ const pageDescription = entry ? deriveDescription(entry.data.description, entry.
 >
   {entry && Content ? (
     <article class="section">
-      <ArticleToc headings={headings} label={tocLabel} />
+      <ArticleToc headings={headings} label={tocLabel} fallbackTitle={entry.data.title} />
       <div class="container">
         <a href={`/${lang}/positions`} class="back-link">{backLabel}</a>
-        <header>
+        <header id="article-top">
           <h1>{entry.data.title}</h1>
         </header>
         <div class="content">

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -130,6 +130,15 @@ html {
   background: var(--color-background);
   scrollbar-gutter: stable;
   /*
+   * Smooth-scroll TOC anchor jumps + offset the landing point past
+   * the sticky header. `--header-height` is published by Header.astro
+   * on first paint and refreshed on resize, so the offset stays in
+   * sync with the header's actual measured height. Falls back to 5rem
+   * before the script runs.
+   */
+  scroll-behavior: smooth;
+  scroll-padding-top: calc(var(--header-height, 5rem) + 0.5rem);
+  /*
    * `overflow-x: clip` instead of `hidden` keeps the page free of
    * horizontal scroll (some article media pushes the natural width
    * past the viewport on narrow screens) without making <html> its
@@ -201,6 +210,10 @@ h6 {
   *::after {
     animation-duration: 0.01ms;
     transition-duration: 0.01ms;
+  }
+
+  html {
+    scroll-behavior: auto;
   }
 }
 


### PR DESCRIPTION
**Supersedes #83** — same smooth-scroll changes plus the always-render + content fixes the user asked for.

## Summary
The TOC must show **everywhere**, regardless of whether the article's markdown body has headings.

### Code
- **ArticleToc.astro** — render unconditionally. When there are no h1-h4 headings, fall back to a single synthetic "back to top" entry pointing at `#article-top`.
- **TOC added to `about.astro` + `manifest.astro`** — these long-form pages had no TOC at all.
- **`id="article-top"` on the title header element** of every consumer page so the synthetic anchor lands at the right spot.
- **Smooth scroll**: `scroll-behavior: smooth` + `scroll-padding-top: calc(var(--header-height, 5rem) + 0.5rem)`. `prefers-reduced-motion: reduce` overrides back to auto.

Active-section highlight already worked via the existing RAF scroll-spy.

### Content fixes (pushed to `public-website-content@ede8b86`)
Articles + pages where editors had used bold pseudo-headers or plain inline section labels now use proper `## H2`:

- **last-battle-en**: 2 bold → h2 (matches RU)
- **from-manchester-it**: added h1 + 4 bold → h2 (matches RU)
- **cyber-tool-ru**: opening h2 + mid-article divider → h2
- **manifest in {EN, ES, PL, BG}**: every Roman-numeral section → `## H2`; "Spread of Marxism" sub-periods → `### H3`. Added article-title h1 to every variant. EN was previously inline prose — section labels were folded into the preceding paragraph and invisible.
- **about in {EN, ES, BG, PL, UK}**: added article-title h1 to match RU/IT.

## Validation
`bun run lint` clean. `astro check` clean. `bun run build` green (170 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)