### PR TITLE
content: fix(i18n): localised date format on public site

### DIFF
--- a/src/features/i18n/format-date.test.ts
+++ b/src/features/i18n/format-date.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { formatArticleDate } from './format-date';
+
+const SAMPLE = new Date(Date.UTC(2026, 4, 5, 12, 0, 0));
+
+describe('formatArticleDate', () => {
+  it('formats English in long form', () => {
+    expect(formatArticleDate(SAMPLE, 'en')).toBe('May 5, 2026');
+  });
+
+  it('formats Russian with Cyrillic month', () => {
+    const out = formatArticleDate(SAMPLE, 'ru');
+    expect(out).toContain('мая');
+    expect(out).toContain('2026');
+  });
+
+  it('formats Italian with localised month', () => {
+    const out = formatArticleDate(SAMPLE, 'it');
+    expect(out.toLowerCase()).toContain('maggio');
+    expect(out).toContain('2026');
+  });
+
+  it('formats Spanish with localised month', () => {
+    const out = formatArticleDate(SAMPLE, 'es');
+    expect(out.toLowerCase()).toContain('mayo');
+    expect(out).toContain('2026');
+  });
+
+  it('maps `bl` to Bulgarian (bg-BG)', () => {
+    const viaAlias = formatArticleDate(SAMPLE, 'bl');
+    const viaBcp47 = new Intl.DateTimeFormat('bg-BG', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    }).format(SAMPLE);
+    expect(viaAlias).toBe(viaBcp47);
+    expect(viaAlias.toLowerCase()).toContain('май');
+  });
+
+  it('formats Polish with localised month', () => {
+    const out = formatArticleDate(SAMPLE, 'pl');
+    expect(out.toLowerCase()).toContain('maja');
+    expect(out).toContain('2026');
+  });
+
+  it('formats Ukrainian with localised month', () => {
+    const out = formatArticleDate(SAMPLE, 'uk');
+    expect(out.toLowerCase()).toContain('травня');
+    expect(out).toContain('2026');
+  });
+
+  it('falls back to English for unknown language codes', () => {
+    expect(formatArticleDate(SAMPLE, 'zz')).toBe('May 5, 2026');
+  });
+});

--- a/src/features/i18n/format-date.ts
+++ b/src/features/i18n/format-date.ts
@@ -1,0 +1,47 @@
+/*
+ * Locale-aware article date formatting.
+ *
+ * Site language codes (see `content/settings/languages.json`) are not
+ * always valid BCP-47 tags — `bl` is an internal alias for Bulgarian
+ * and `Intl.DateTimeFormat` will silently fall back to English when
+ * given an unknown subtag. The mapping below is the single place that
+ * translates our internal codes to the proper BCP-47 locales used by
+ * the platform `Intl` APIs.
+ *
+ * Keep this in sync with `SUPPORTED_LANGUAGES`.
+ */
+
+import type { Language } from '@/config/i18n';
+
+const FALLBACK_LOCALE = 'en-US';
+
+const LOCALE_BY_LANGUAGE: Readonly<Record<string, string>> = {
+  en: FALLBACK_LOCALE,
+  ru: 'ru-RU',
+  it: 'it-IT',
+  es: 'es-ES',
+  bl: 'bg-BG',
+  pl: 'pl-PL',
+  uk: 'uk-UA',
+};
+
+const FORMAT_OPTIONS: Readonly<Intl.DateTimeFormatOptions> = {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+};
+
+/**
+ * Format a publication date for the given site language. Maps internal
+ * language codes (e.g. `bl`) to BCP-47 locales (e.g. `bg-BG`) so the
+ * `Intl` runtime returns the localised string instead of falling back
+ * to English.
+ *
+ * @param date Publication date (typically from frontmatter).
+ * @param lang Active page language code.
+ * @returns Localised long-form date, e.g. `5 мая 2026 г.`.
+ */
+export const formatArticleDate = (date: Date, lang: Language): string => {
+  const locale = LOCALE_BY_LANGUAGE[lang] ?? FALLBACK_LOCALE;
+  return new Intl.DateTimeFormat(locale, FORMAT_OPTIONS).format(date);
+};

--- a/src/pages/[lang]/blog/[...slug].astro
+++ b/src/pages/[lang]/blog/[...slug].astro
@@ -8,6 +8,7 @@ import { getArticleSlug } from '@/features/blog/helpers/getBlogPosts';
 import ArticleToc from '@/features/content/components/ArticleToc.astro';
 import SuggestChangesLink from '@/features/content/components/SuggestChangesLink.astro';
 import { deriveDescription } from '@/features/content/helpers/deriveDescription';
+import { formatArticleDate } from '@/features/i18n/format-date';
 import MissingTranslation from '@/features/i18n/MissingTranslation.astro';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
@@ -98,11 +99,7 @@ const newspaperRef = await (async () => {
           <h1 itemprop="name">{post.data.title}</h1>
           <p class="post-meta">
             <time datetime={isoDate} itemprop="datePublished">
-              {publishedDate?.toLocaleDateString(lang, {
-                year: 'numeric',
-                month: 'long',
-                day: 'numeric',
-              })}
+              {publishedDate && formatArticleDate(publishedDate, lang)}
             </time>
           </p>
           {newspaperRef && (


### PR DESCRIPTION
## Summary
- `Intl.DateTimeFormat` was being called with our internal language codes (e.g. `bl`, `ru`), which silently fell back to English for unknown / non-BCP-47 subtags. As a result the article publish date on `/ru/blog/*` rendered as `May 5, 2026` instead of `5 мая 2026 г.`.
- Added `src/features/i18n/format-date.ts` with `formatArticleDate(date, lang)` mapping internal codes to BCP-47 locales (`bl` -> `bg-BG`, `uk` -> `uk-UA`, etc.) and a `vitest` covering all 7 supported languages plus an explicit Bulgarian assertion.
- Switched `src/pages/[lang]/blog/[...slug].astro` to use the helper.

## Test plan
- [x] `bunx vitest run src/features/i18n/format-date.test.ts` — 8/8 green
- [x] `bun run check` (astro check) — 0 errors
- [x] `bun run lint` (biome + eslint) — clean
- [x] `bun run build` — succeeds (170 pages)

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)