### PR TITLE
fix(blog): uniform tile heights + clamp overflow text

### DIFF
--- a/e2e/blog-tile-uniform.pw.ts
+++ b/e2e/blog-tile-uniform.pw.ts
@@ -1,0 +1,89 @@
+import { expect, expectMinCount, type Page, test, visit } from '@prometheus/e2e-toolkit';
+
+/**
+ * Blog tile uniformity E2E.
+ *
+ * Verifies that the listing renders every blog card at the same height
+ * (within 1px tolerance) and that each card's inner text content is
+ * fully contained inside the card box (no overflow). The fix is pure
+ * CSS — `grid-auto-rows: 1fr` on the grid plus line-clamp on the title
+ * and summary inside `.post-card`.
+ */
+
+const BLOG = '/ru/blog';
+const TOLERANCE_PX = 1;
+const CARD = '.post-card';
+
+interface CardMetrics {
+  readonly height: number;
+  readonly bottom: number;
+}
+
+interface ChildExtents {
+  readonly maxBottom: number;
+  readonly maxRight: number;
+}
+
+const cardMetrics = async (page: Page): Promise<readonly CardMetrics[]> =>
+  page.locator(CARD).evaluateAll((els) =>
+    els.map((el) => {
+      const rect = el.getBoundingClientRect();
+      return { height: rect.height, bottom: rect.bottom };
+    }),
+  );
+
+const childExtents = async (page: Page): Promise<readonly (ChildExtents & CardMetrics)[]> =>
+  page.locator(CARD).evaluateAll((els) =>
+    els.map((el) => {
+      const rect = el.getBoundingClientRect();
+      const descendants = Array.from(el.querySelectorAll('*'));
+      const maxBottom = descendants.reduce((acc, child) => {
+        const r = child.getBoundingClientRect();
+        return r.bottom > acc ? r.bottom : acc;
+      }, rect.top);
+      const maxRight = descendants.reduce((acc, child) => {
+        const r = child.getBoundingClientRect();
+        return r.right > acc ? r.right : acc;
+      }, rect.left);
+      return {
+        height: rect.height,
+        bottom: rect.bottom,
+        maxBottom,
+        maxRight,
+      };
+    }),
+  );
+
+test.describe('Blog tile uniformity', () => {
+  test.beforeEach(async ({ page }) => {
+    await visit(page, BLOG);
+  });
+
+  test('every card has the same height within 1px', async ({ page }) => {
+    const cards = page.locator(CARD);
+    await expectMinCount(page, cards, 2);
+
+    const metrics = await cardMetrics(page);
+    const first = metrics[0];
+    if (!first) throw new Error('no cards measured');
+    for (const m of metrics) {
+      expect(Math.abs(m.height - first.height)).toBeLessThanOrEqual(TOLERANCE_PX);
+    }
+  });
+
+  test('inner content does not overflow the card box', async ({ page }) => {
+    const cards = page.locator(CARD);
+    await expectMinCount(page, cards, 2);
+
+    const measurements = await childExtents(page);
+    for (const m of measurements) {
+      expect(m.maxBottom).toBeLessThanOrEqual(m.bottom + TOLERANCE_PX);
+    }
+  });
+
+  test('listing screenshot at 1280px viewport', async ({ page }) => {
+    const cards = page.locator(CARD);
+    await expectMinCount(page, cards, 2);
+    await page.locator('.grid').first().screenshot({ path: 'screenshots/blog-tiles-1280.png' });
+  });
+});

--- a/src/features/blog/components/PostCard.astro
+++ b/src/features/blog/components/PostCard.astro
@@ -31,8 +31,8 @@ const {
   {image && <div class="post-image"><BlogPicture image={image} alt={title} preset="thumbnail" /></div>}
   <div class="post-content">
     <span class="category">{category}</span>
-    {headingLevel === 2 ? <h2>{title}</h2> : <h3>{title}</h3>}
-    <p class="text-secondary">{description}</p>
+    {headingLevel === 2 ? <h2 class="post-title">{title}</h2> : <h3 class="post-title">{title}</h3>}
+    <p class="post-summary text-secondary">{description}</p>
     <a href={`/${lang}/blog/${slug}`} class="read-more">
       {readMoreLabel} <span aria-hidden="true">→</span>
     </a>
@@ -44,6 +44,7 @@ const {
     display: flex;
     flex-direction: column;
     height: 100%;
+    width: 100%;
     overflow: hidden;
     padding: 0;
   }
@@ -54,6 +55,7 @@ const {
     height: clamp(120px, 30vw, 200px);
     overflow: hidden;
     border-radius: var(--radius-md);
+    flex-shrink: 0;
   }
 
   .post-image :global(img) {
@@ -69,6 +71,7 @@ const {
     padding: clamp(var(--spacing-sm), 3vw, var(--spacing-lg));
     flex: 1;
     min-width: 0;
+    min-height: 0;
   }
 
   .category {
@@ -82,30 +85,45 @@ const {
     width: fit-content;
     text-transform: uppercase;
     letter-spacing: 0.05em;
+    flex-shrink: 0;
   }
 
-  h2, h3 {
+  .post-title {
     font-size: clamp(1rem, 3vw, 1.25rem);
     line-height: 1.4;
     overflow-wrap: break-word;
     word-break: break-word;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    flex-shrink: 0;
   }
 
-  p {
+  .post-summary {
     flex: 1;
+    margin: 0;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    min-height: 0;
   }
 
   .read-more {
     display: inline-flex;
     align-items: center;
     gap: var(--spacing-xs);
-    margin-top: var(--spacing-sm);
+    margin-top: auto;
     padding: var(--spacing-sm) var(--spacing-md);
     border-radius: var(--radius-sm);
     color: var(--color-text-primary);
     text-decoration: none;
     width: fit-content;
     min-height: 44px;
+    flex-shrink: 0;
   }
 
   .read-more:hover {

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -17,6 +17,7 @@
 .grid {
   display: grid;
   gap: var(--spacing-lg);
+  grid-auto-rows: 1fr;
 }
 
 .grid-2 {
@@ -25,6 +26,21 @@
 
 .grid-3 {
   grid-template-columns: repeat(auto-fill, minmax(min(100%, 240px), 1fr));
+}
+
+/*
+ * Wrappers that the CategoryFilter toggles via [data-category] need to
+ * stretch to the row track, otherwise the inner card's height: 100%
+ * collapses against an auto-sized div.
+ */
+.grid > [data-category] {
+  height: 100%;
+  display: flex;
+}
+
+.grid > [data-category] > * {
+  flex: 1;
+  min-height: 0;
 }
 
 .flex {


### PR DESCRIPTION
## Summary
PostCard.astro now uses a flex chain where the description clamps to 3 lines and the title clamps to 2 lines. The read-more pin sticks to the bottom via `margin-top: auto`. Combined with the `grid-auto-rows: 1fr` override on the listing grid utility, every tile renders at the same height regardless of content length.

## Test plan
- [ ] Manual: open `/ru/blog` at 1280px → all tiles visually equal height
- [ ] Manual: tiles with 2-line vs 1-line titles still align
- [ ] Manual: long descriptions truncate with ellipsis (no overflow into siblings)
- [ ] E2E: `e2e/blog-tile-uniform.pw.ts` asserts equal heights + no overflow

Closes #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)