### PR TITLE
feat(newspaper): auto-discover assets, format-badge UI, force fb2 download

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,19 @@
+# Cloudflare Pages / Workers static-assets header rules.
+# https://developers.cloudflare.com/pages/configuration/headers/
+
+# Force .fb2 (FictionBook) downloads instead of inline XML preview.
+# Without these, CF infers `application/xml` for the unknown
+# extension; the browser then opens the XML viewer and "Save as"
+# proposes `.xml` because it trusts the response Content-Type
+# over the URL/`download` attribute. Setting an explicit MIME +
+# Content-Disposition: attachment fixes both.
+/newspaper/*/assets/*.fb2
+  Content-Type: application/x-fictionbook+xml
+  Content-Disposition: attachment
+
+# Same for any incidentally-served *.docx (the editor never
+# persists docx, but be defensive — saves a "broken file" support
+# ticket if one ever leaks through).
+/newspaper/*/assets/*.docx
+  Content-Type: application/vnd.openxmlformats-officedocument.wordprocessingml.document
+  Content-Disposition: attachment

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -86,6 +86,14 @@ const commonCollection = defineCollection({
     menu: z.string().optional(),
     copyright: z.string().optional(),
     readMore: z.string().optional(),
+    /*
+     * Newspaper-issue download labels. Distinct keys so editors can
+     * localise PDF and FB2 buttons separately and so the layout no
+     * longer reuses `readMore` (which was visually wrong: a "Read
+     * more" button that actually downloads a binary).
+     */
+    downloadPdf: z.string().optional(),
+    downloadFb2: z.string().optional(),
     viewAll: z.string().optional(),
     backToList: z.string().optional(),
     tableOfContents: z.string().optional(),

--- a/src/features/newspaper/components/DownloadLink.astro
+++ b/src/features/newspaper/components/DownloadLink.astro
@@ -1,0 +1,88 @@
+---
+import { formatBytes } from '../helpers/formatBytes';
+
+interface Props {
+  readonly url: string;
+  readonly label: string;
+  readonly format: 'pdf' | 'fb2';
+  readonly size: number;
+  readonly testId?: string;
+}
+
+const { url, label, format, size, testId } = Astro.props;
+---
+
+<a
+  href={url}
+  download
+  class={`download-link format-${format}`}
+  {...(testId ? { 'data-testid': testId } : {})}
+>
+  <span class="format-badge" aria-hidden="true">{format.toUpperCase()}</span>
+  <span class="download-text">
+    <span class="download-label">{label}</span>
+    <span class="download-size">{formatBytes(size)}</span>
+  </span>
+</a>
+
+<style>
+  .download-link {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    padding: var(--spacing-xs) var(--spacing-md);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface-elevated);
+    color: var(--color-text-primary);
+    text-decoration: none;
+    min-height: 44px;
+    transition: border-color var(--transition-fast),
+      background var(--transition-fast);
+  }
+
+  .download-link:hover {
+    border-color: var(--color-accent);
+    background: var(--color-surface);
+  }
+
+  .format-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 38px;
+    height: 28px;
+    border-radius: var(--radius-sm);
+    color: #fff;
+    font-weight: 700;
+    font-size: 0.75rem;
+    letter-spacing: 0.02em;
+    flex-shrink: 0;
+  }
+
+  .format-pdf .format-badge {
+    background: #d83b3b;
+  }
+
+  .format-fb2 .format-badge {
+    background: #2f7d32;
+  }
+
+  .download-text {
+    display: flex;
+    flex-direction: column;
+    line-height: 1.2;
+    min-width: 0;
+  }
+
+  .download-label {
+    font-weight: 500;
+    font-size: 0.9375rem;
+  }
+
+  .download-size {
+    color: var(--color-text-secondary);
+    font-size: 0.8125rem;
+    font-variant-numeric: tabular-nums;
+  }
+</style>

--- a/src/features/newspaper/components/NewspaperCard.astro
+++ b/src/features/newspaper/components/NewspaperCard.astro
@@ -1,8 +1,8 @@
 ---
 import { Picture } from 'astro:assets';
-import { existsSync, readdirSync } from 'node:fs';
-import { resolve } from 'node:path';
 import type { ImageMetadata } from 'astro';
+import { findIssueAsset } from '../helpers/findIssueAsset';
+import DownloadLink from './DownloadLink.astro';
 
 interface Props {
   readonly title: string;
@@ -11,7 +11,8 @@ interface Props {
   readonly lang: string;
   readonly image?: ImageMetadata | undefined;
   readonly headingLevel?: 2 | 3;
-  readonly downloadLabel?: string;
+  readonly pdfLabel?: string;
+  readonly fb2Label?: string;
 }
 
 const {
@@ -21,26 +22,22 @@ const {
   lang,
   image,
   headingLevel = 3,
-  downloadLabel = 'Download PDF',
+  pdfLabel = 'Download PDF',
+  fb2Label = 'Download FB2',
 } = Astro.props;
 
 /*
- * The card title now leads to the newspaper detail page (cover, TOC,
- * download). Direct PDF download stays as a side action so editors
- * who only want the file can still grab it from the listing. The
- * FB2 link is only emitted when the editor uploaded a fb2 (either
- * directly via Fb2Upload or via DocxUpload's client-side conversion)
- * — newspaper-fb2 build integration copies it through to dist.
+ * The card title leads to the detail page; format buttons are
+ * side-actions so editors who only want the file can grab it from
+ * the listing. PDF/FB2 paths are auto-discovered from the issue's
+ * `assets/` dir — they ship under whatever name the editor chose
+ * (slug-based, gazette.pdf for legacy issues, etc.). The
+ * newspaper-pdfs/newspaper-fb2 build integrations copy them through
+ * to dist as-is.
  */
 const detailPath = `/${lang}/newspaper/${slug}`;
-const pdfPath = `/newspaper/${slug}/assets/gazette.pdf`;
-const fb2Path = `/newspaper/${slug}/assets/gazette.fb2`;
-
-const hasFb2 = (() => {
-  const dir = resolve(`src/content/newspaper/${slug}/assets`);
-  if (!existsSync(dir)) return false;
-  return readdirSync(dir).some((f) => f.toLowerCase().endsWith('.fb2'));
-})();
+const pdfAsset = findIssueAsset(slug, '.pdf');
+const fb2Asset = findIssueAsset(slug, '.fb2');
 ---
 
 <article class="newspaper-card" data-testid="newspaper-card">
@@ -57,13 +54,23 @@ const hasFb2 = (() => {
     <a href={detailPath} class="open-link">
       Open <span aria-hidden="true">→</span>
     </a>
-    <a href={pdfPath} download class="read-more">
-      {downloadLabel} <span aria-hidden="true">↓</span>
-    </a>
-    {hasFb2 && (
-      <a href={fb2Path} download class="read-more" data-testid="newspaper-fb2">
-        FB2 <span aria-hidden="true">↓</span>
-      </a>
+    {pdfAsset && (
+      <DownloadLink
+        url={pdfAsset.url}
+        label={pdfLabel}
+        format="pdf"
+        size={pdfAsset.size}
+        testId="newspaper-pdf"
+      />
+    )}
+    {fb2Asset && (
+      <DownloadLink
+        url={fb2Asset.url}
+        label={fb2Label}
+        format="fb2"
+        size={fb2Asset.size}
+        testId="newspaper-fb2"
+      />
     )}
   </div>
 </article>
@@ -123,28 +130,19 @@ const hasFb2 = (() => {
     gap: var(--spacing-sm);
   }
 
-  .open-link,
-  .read-more {
+  .open-link {
     display: inline-flex;
     align-items: center;
     gap: var(--spacing-xs);
     padding: var(--spacing-sm) var(--spacing-md);
     border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
+    background: var(--color-accent);
+    color: var(--color-on-accent);
     min-height: 44px;
     text-decoration: none;
   }
 
-  .open-link {
-    background: var(--color-accent);
-    color: var(--color-on-accent);
-  }
-
   .open-link:hover {
     background: var(--color-accent-hover);
-  }
-
-  .read-more:hover {
-    background: var(--color-surface);
   }
 </style>

--- a/src/features/newspaper/helpers/findIssueAsset.ts
+++ b/src/features/newspaper/helpers/findIssueAsset.ts
@@ -1,0 +1,39 @@
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+interface IssueAsset {
+  readonly file: string;
+  readonly size: number;
+}
+
+interface IssueAssetWithPath extends IssueAsset {
+  readonly url: string;
+}
+
+const findOne = (dir: string, ext: string): IssueAsset | undefined => {
+  if (!existsSync(dir)) return undefined;
+  const file = readdirSync(dir).find((f) => f.toLowerCase().endsWith(ext));
+  if (file === undefined) return undefined;
+  return { file, size: statSync(resolve(dir, file)).size };
+};
+
+/**
+ * Locate the first file inside a newspaper issue's `assets/` dir that
+ * has the given extension. Returns the file's basename, byte size,
+ * and its served URL — the public site's links can read this without
+ * caring whether the editor named the file `<slug>.pdf`, `gazette.pdf`,
+ * or `Magazine1 (3).pdf`.
+ *
+ * @param slug - Issue slug (also the directory name)
+ * @param ext - File extension to look for, including the leading dot
+ * @returns Asset descriptor with served URL, or undefined when missing
+ */
+export const findIssueAsset = (slug: string, ext: string): IssueAssetWithPath | undefined => {
+  const dir = resolve(`src/content/newspaper/${slug}/assets`);
+  const found = findOne(dir, ext);
+  if (found === undefined) return undefined;
+  return {
+    ...found,
+    url: `/newspaper/${slug}/assets/${found.file}`,
+  };
+};

--- a/src/features/newspaper/helpers/formatBytes.ts
+++ b/src/features/newspaper/helpers/formatBytes.ts
@@ -1,0 +1,20 @@
+const KB = 1024;
+const MB = KB * 1024;
+
+const fmt = (v: number, frac: number, unit: string): string => `${v.toFixed(frac)} ${unit}`;
+
+/**
+ * Format a byte count for human-readable file size next to a
+ * download button (e.g. "2.0 MB", "118 KB", "612 B"). Single
+ * decimal for MB, integer for KB and bytes — keeps the label
+ * compact without lying about precision.
+ *
+ * @param bytes - Raw byte size from `fs.statSync`
+ * @returns Compact human-readable size string
+ */
+export const formatBytes = (bytes: number): string =>
+  bytes >= MB
+    ? fmt(bytes / MB, 1, 'MB')
+    : bytes >= KB
+      ? fmt(bytes / KB, 0, 'KB')
+      : fmt(bytes, 0, 'B');

--- a/src/pages/[lang]/newspaper/[slug].astro
+++ b/src/pages/[lang]/newspaper/[slug].astro
@@ -5,6 +5,8 @@ import { getLabelsData } from '@/config/translations';
 import { getArticleSlug } from '@/features/blog/helpers/getBlogPosts';
 import SuggestChangesLink from '@/features/content/components/SuggestChangesLink.astro';
 import MissingTranslation from '@/features/i18n/MissingTranslation.astro';
+import DownloadLink from '@/features/newspaper/components/DownloadLink.astro';
+import { findIssueAsset } from '@/features/newspaper/helpers/findIssueAsset';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
 /*
@@ -47,7 +49,8 @@ const { lang, slug } = Astro.params;
 
 const labels = (await getLabelsData(lang)) ?? (await getLabelsData('en'));
 const backLabel = labels?.data.backToList ?? '← Back';
-const downloadLabel = labels?.data.readMore ?? 'Download PDF';
+const pdfLabel = labels?.data.downloadPdf ?? 'Download PDF';
+const fb2Label = labels?.data.downloadFb2 ?? 'Download FB2';
 
 interface TocEntry {
   readonly slug: string;
@@ -69,7 +72,8 @@ const tocEntries = await (async (): Promise<ReadonlyArray<TocEntry>> => {
   });
 })();
 
-const pdfPath = issue ? `/newspaper/${slug}/assets/gazette.pdf` : undefined;
+const pdfAsset = issue ? findIssueAsset(slug, '.pdf') : undefined;
+const fb2Asset = issue ? findIssueAsset(slug, '.fb2') : undefined;
 ---
 
 <BaseLayout
@@ -89,11 +93,26 @@ const pdfPath = issue ? `/newspaper/${slug}/assets/gazette.pdf` : undefined;
           <header class="issue-header">
             <h1>{issue.data.title}</h1>
             <p class="issue-description">{issue.data.description}</p>
-            {pdfPath && (
-              <a href={pdfPath} download class="download-cta">
-                {downloadLabel} <span aria-hidden="true">↓</span>
-              </a>
-            )}
+            <div class="downloads">
+              {pdfAsset && (
+                <DownloadLink
+                  url={pdfAsset.url}
+                  label={pdfLabel}
+                  format="pdf"
+                  size={pdfAsset.size}
+                  testId="newspaper-pdf"
+                />
+              )}
+              {fb2Asset && (
+                <DownloadLink
+                  url={fb2Asset.url}
+                  label={fb2Label}
+                  format="fb2"
+                  size={fb2Asset.size}
+                  testId="newspaper-fb2"
+                />
+              )}
+            </div>
           </header>
           {tocEntries.length > 0 && (
             <section class="toc" aria-label="Issue contents">
@@ -160,21 +179,12 @@ const pdfPath = issue ? `/newspaper/${slug}/assets/gazette.pdf` : undefined;
     margin-bottom: var(--spacing-lg);
   }
 
-  .download-cta {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--spacing-xs);
-    padding: var(--spacing-sm) var(--spacing-lg);
-    background: var(--color-accent);
-    color: var(--color-on-accent);
-    border-radius: var(--radius-sm);
-    text-decoration: none;
-    font-weight: 500;
-    min-height: 44px;
-  }
-
-  .download-cta:hover {
-    background: var(--color-accent-hover);
+  .downloads {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: var(--spacing-sm);
+    margin-top: var(--spacing-md);
   }
 
   .toc {

--- a/src/pages/[lang]/newspaper/index.astro
+++ b/src/pages/[lang]/newspaper/index.astro
@@ -21,7 +21,8 @@ const { lang } = Astro.params;
 
 const items = await getNewspaperItems(lang);
 const labels = (await getLabelsData(lang)) ?? (await getLabelsData(DEFAULT_LANGUAGE));
-const readMore = labels?.data.readMore ?? 'Download PDF';
+const pdfLabel = labels?.data.downloadPdf ?? 'Download PDF';
+const fb2Label = labels?.data.downloadFb2 ?? 'Download FB2';
 ---
 
 <BaseLayout
@@ -42,7 +43,8 @@ const readMore = labels?.data.readMore ?? 'Download PDF';
               lang={lang}
               image={item.data.image ?? undefined}
               headingLevel={2}
-              downloadLabel={readMore}
+              pdfLabel={pdfLabel}
+              fb2Label={fb2Label}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary
Three related fixes batched into one PR — all touch NewspaperCard.astro / [slug].astro.

### 1. Auto-discover PDF/FB2 by extension
Drops hardcoded \`gazette.{pdf,fb2}\` URL. \`findIssueAsset(slug, ext)\` lists \`src/content/newspaper/<slug>/assets\` and returns the first matching file + its byte size. Works for legacy issues with \`gazette.pdf\` and new issues with slug-named assets without migration.

### 2. Proper download UI
Replaces the generic \"readMore\"-labelled link (which literally said \"Read more\" on a PDF download button) with \`DownloadLink.astro\`:
- colored format badge (PDF red, FB2 green)
- localised label (new i18n keys \`downloadPdf\`, \`downloadFb2\`)
- file size

### 3. Force .fb2 to download
Adds \`public/_headers\` so Cloudflare returns \`Content-Type: application/x-fictionbook+xml\` and \`Content-Disposition: attachment\` for \`/newspaper/*/assets/*.fb2\`. Without it CF inferred \`application/xml\`, the browser opened the FictionBook inline, and \"Save as\" proposed \`.xml\` — exactly the \"why is my fb2 turning into xml\" bug.

## Companion PRs
- Content: \`public-website-content#feat/newspaper-download-labels-2\` — adds \`downloadPdf\` / \`downloadFb2\` to all four label files (en/ru/it/es).
- Admin: \`admin-website#225\` — drops the matching hardcoded \`gazette.fb2\` rename in the upload widgets.

## Test plan
- [x] \`CONTENT_KEEP=1 bun run build\` — green (validate + astro build)
- [ ] After merge: visit \`/<lang>/newspaper\` and \`/<lang>/newspaper/<slug>\`, verify the format badges + sizes render and the FB2 download saves with \`.fb2\` extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)