### PR TITLE
feat(newspaper): prefer per-language source assets

### DIFF
--- a/src/features/newspaper/components/NewspaperCard.astro
+++ b/src/features/newspaper/components/NewspaperCard.astro
@@ -36,8 +36,8 @@ const {
  * to dist as-is.
  */
 const detailPath = `/${lang}/newspaper/${slug}`;
-const pdfAsset = findIssueAsset(slug, '.pdf');
-const fb2Asset = findIssueAsset(slug, '.fb2');
+const pdfAsset = findIssueAsset(slug, lang, '.pdf');
+const fb2Asset = findIssueAsset(slug, lang, '.fb2');
 ---
 
 <article class="newspaper-card" data-testid="newspaper-card">

--- a/src/features/newspaper/helpers/findIssueAsset.ts
+++ b/src/features/newspaper/helpers/findIssueAsset.ts
@@ -10,30 +10,47 @@ interface IssueAssetWithPath extends IssueAsset {
   readonly url: string;
 }
 
-const findOne = (dir: string, ext: string): IssueAsset | undefined => {
-  if (!existsSync(dir)) return undefined;
-  const file = readdirSync(dir).find((f) => f.toLowerCase().endsWith(ext));
-  if (file === undefined) return undefined;
-  return { file, size: statSync(resolve(dir, file)).size };
+const sized = (dir: string, file: string): IssueAsset => ({
+  file,
+  size: statSync(resolve(dir, file)).size,
+});
+
+const scan = (dir: string): readonly string[] => (existsSync(dir) ? readdirSync(dir) : []);
+
+const matchesLang = (file: string, slug: string, lang: string, ext: string): boolean =>
+  file.toLowerCase() === `${slug}.${lang}${ext}`.toLowerCase();
+
+const matchesLegacy = (file: string, slug: string, ext: string): boolean => {
+  const lower = file.toLowerCase();
+  return lower === `${slug}${ext}`.toLowerCase();
 };
 
+const matchesAnyExt = (file: string, ext: string): boolean =>
+  file.toLowerCase().endsWith(ext.toLowerCase());
+
 /**
- * Locate the first file inside a newspaper issue's `assets/` dir that
- * has the given extension. Returns the file's basename, byte size,
- * and its served URL — the public site's links can read this without
- * caring whether the editor named the file `<slug>.pdf`, `gazette.pdf`,
- * or `Magazine1 (3).pdf`.
+ * Find a per-language asset, falling back to legacy single-language
+ * names. Order: `<slug>.<lang><ext>` (preferred), `<slug><ext>`
+ * (pre-multilang), then any file with the matching extension (covers
+ * historical names like `gazette.pdf`).
  *
- * @param slug - Issue slug (also the directory name)
- * @param ext - File extension to look for, including the leading dot
- * @returns Asset descriptor with served URL, or undefined when missing
+ * @param slug - Issue slug, doubles as the directory name
+ * @param lang - Active page language (en, ru, it, ...)
+ * @param ext - Extension including leading dot (e.g. `.pdf`)
+ * @returns Asset descriptor with served URL, or undefined when no candidate exists
  */
-export const findIssueAsset = (slug: string, ext: string): IssueAssetWithPath | undefined => {
+export const findIssueAsset = (
+  slug: string,
+  lang: string,
+  ext: string,
+): IssueAssetWithPath | undefined => {
   const dir = resolve(`src/content/newspaper/${slug}/assets`);
-  const found = findOne(dir, ext);
-  if (found === undefined) return undefined;
-  return {
-    ...found,
-    url: `/newspaper/${slug}/assets/${found.file}`,
-  };
+  const files = scan(dir);
+  if (files.length === 0) return undefined;
+  const langHit = files.find((f) => matchesLang(f, slug, lang, ext));
+  const legacyHit = langHit ?? files.find((f) => matchesLegacy(f, slug, ext));
+  const anyHit = legacyHit ?? files.find((f) => matchesAnyExt(f, ext));
+  if (anyHit === undefined) return undefined;
+  const asset = sized(dir, anyHit);
+  return { ...asset, url: `/newspaper/${slug}/assets/${asset.file}` };
 };

--- a/src/pages/[lang]/newspaper/[slug].astro
+++ b/src/pages/[lang]/newspaper/[slug].astro
@@ -72,8 +72,8 @@ const tocEntries = await (async (): Promise<ReadonlyArray<TocEntry>> => {
   });
 })();
 
-const pdfAsset = issue ? findIssueAsset(slug, '.pdf') : undefined;
-const fb2Asset = issue ? findIssueAsset(slug, '.fb2') : undefined;
+const pdfAsset = issue ? findIssueAsset(slug, lang, '.pdf') : undefined;
+const fb2Asset = issue ? findIssueAsset(slug, lang, '.fb2') : undefined;
 ---
 
 <BaseLayout


### PR DESCRIPTION
## Summary
- `findIssueAsset(slug, lang, ext)` now prefers `<slug>.<lang><ext>` over legacy `<slug><ext>` / first-match fallback.
- `NewspaperCard.astro` and `[lang]/newspaper/[slug].astro` thread the active language through.

Pairs with [admin-website per-lang assets PR](https://github.com/communist-prometheus/admin-website/pulls?q=is%3Apr+per-lang) which writes new uploads under the per-lang naming. Legacy single-language issues keep rendering until someone re-uploads under the new convention.

## Test plan
- [x] `bun run lint`
- [x] `bun run check`
- [ ] Open `/it/newspaper/<slug>` for an issue with both EN + IT bundles → IT PDF/FB2/cover served.
- [ ] Open same slug under `/en/...` → EN bundle served.
- [ ] Legacy issue (only `<slug>.pdf`, no per-lang variant) still serves.