### PR TITLE
fix(listing): emit /lang/<section> route for every language

### DIFF
--- a/e2e/language-coverage.pw.ts
+++ b/e2e/language-coverage.pw.ts
@@ -47,14 +47,24 @@ test.describe('Language coverage — every code in settings must work', () => {
   for (const { code, label } of languages) {
     test.describe(`${label} (${code})`, () => {
       /*
-       * After PR #74 (empty-section gating) sections without
-       * published content for this lang 404 by design — that's the
-       * editor's contract. Skip those tuples; the existing-section
-       * tuples still assert the lang attr + h1 is rendered.
+       * The listing routes (`/blog`, `/positions`, `/newspaper`)
+       * must serve a 200 for EVERY supported language even when no
+       * issues are published in that lang yet — the listing page
+       * shows an empty-state instead of 404. Pre-fix the user hit
+       * `/en/newspaper` (no English issues yet) and got the
+       * site-wide "This page does not exist" 404; the deploy gate
+       * had no failing test because the suite skipped empty langs
+       * by design.
+       *
+       * `manifest` is the exception: it renders the article body
+       * directly (no empty-state branch), so the route only exists
+       * for langs that have a manifest translation. Skip those.
        */
       for (const p of pages) {
         const section = sectionByPath[p] ?? 'home';
-        const exists = hasSection(availability, code, section);
+        const isListingOrHome =
+          p === '' || p === '/blog' || p === '/positions' || p === '/newspaper';
+        const exists = isListingOrHome || hasSection(availability, code, section);
         const variant = exists ? test : test.skip;
         variant(`/${code}${p} renders with lang="${code}"`, async ({ page }) => {
           const res = await visit(page, `/${code}${p}`);

--- a/src/pages/[lang]/blog/index.astro
+++ b/src/pages/[lang]/blog/index.astro
@@ -12,22 +12,13 @@ import { deriveSummary } from '@/features/content/helpers/deriveSummary';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
 /*
- * Only emit the listing route for languages that have at least one
- * published blog post. The nav drops the link when the section is
- * empty (see getSectionAvailability); skipping the route here means
- * the URL itself 404s rather than serving an empty list.
+ * Generate the listing for every supported language. The nav drops
+ * the link when the section is empty (see getSectionAvailability),
+ * but a user who reaches the URL directly (RSS / external link /
+ * shared URL / manual) must still get the empty-state page rather
+ * than a 404.
  */
-export const getStaticPaths = async () => {
-  const langsWithPosts = await Promise.all(
-    SUPPORTED_LANGUAGES.map(async (lang) => ({
-      lang,
-      hasPosts: (await getBlogPosts(lang)).length > 0,
-    })),
-  );
-  return langsWithPosts
-    .filter(({ hasPosts }) => hasPosts)
-    .map(({ lang }) => ({ params: { lang } }));
-};
+export const getStaticPaths = async () => SUPPORTED_LANGUAGES.map((lang) => ({ params: { lang } }));
 
 const { lang } = Astro.params;
 

--- a/src/pages/[lang]/newspaper/index.astro
+++ b/src/pages/[lang]/newspaper/index.astro
@@ -6,16 +6,15 @@ import NewspaperCard from '@/features/newspaper/components/NewspaperCard.astro';
 import { getNewspaperItems } from '@/features/newspaper/helpers/getNewspaperItems';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
-/* Skip languages with no published newspaper issues. */
-export const getStaticPaths = async () => {
-  const filled = await Promise.all(
-    SUPPORTED_LANGUAGES.map(async (lang) => ({
-      lang,
-      has: (await getNewspaperItems(lang)).length > 0,
-    })),
-  );
-  return filled.filter(({ has }) => has).map(({ lang }) => ({ params: { lang } }));
-};
+/*
+ * Generate the listing for every supported language, even when no
+ * issues are published in that language yet — the empty state below
+ * shows "No newspaper editions yet" instead of a 404. The previous
+ * "skip empty langs" filter meant `/en/newspaper` 404'd on master
+ * because only the Russian edition had been published, even though
+ * the EN nav linked to it.
+ */
+export const getStaticPaths = async () => SUPPORTED_LANGUAGES.map((lang) => ({ params: { lang } }));
 
 const { lang } = Astro.params;
 

--- a/src/pages/[lang]/positions/index.astro
+++ b/src/pages/[lang]/positions/index.astro
@@ -6,16 +6,8 @@ import PositionCard from '@/features/positions/components/PositionCard.astro';
 import { getPositions } from '@/features/positions/helpers/getPositions';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
-/* Skip languages with no published positions — see blog/index.astro. */
-export const getStaticPaths = async () => {
-  const filled = await Promise.all(
-    SUPPORTED_LANGUAGES.map(async (lang) => ({
-      lang,
-      has: (await getPositions(lang)).length > 0,
-    })),
-  );
-  return filled.filter(({ has }) => has).map(({ lang }) => ({ params: { lang } }));
-};
+/* Generate every supported language — see blog/index.astro. */
+export const getStaticPaths = async () => SUPPORTED_LANGUAGES.map((lang) => ({ params: { lang } }));
 
 const { lang } = Astro.params;
 


### PR DESCRIPTION
## Why
User reported that the public site stayed broken after the IT magazine was published — \`/en/newspaper\`, \`/it/newspaper\` etc. all 404'd. Root causes (two stacked):

1. **Content repo** had a stale \`code: ukr\` settings entry that mismatched the surviving \`*.uk.md\` files — the build crashed before any page rendered. Fixed in [content #12](https://github.com/communist-prometheus/public-website-content/pull/12) + [#13](https://github.com/communist-prometheus/public-website-content/pull/13). Prod deploy is now green.
2. **This repo** explicitly skipped lang routes for sections with no items via \`getStaticPaths\` — \`/en/newspaper\` 404'd whenever EN had no published issues, even though the empty-state branch was already in the template. Same gating in blog/positions.

## What
- Drop the \`filter(({ has }) => has)\` from blog / positions / newspaper listings; emit a route for every supported language. The pre-existing empty-state UI handles "no items yet".
- \`manifest\` not changed — its template needs content to render; the right fix there is fallback to \`DEFAULT_LANGUAGE\` content (separate concern).
- Update \`language-coverage.pw.ts\` to NOT skip empty-section tuples for listing routes. Pre-fix the deploy gate happily passed while the user got a 404 on prod, because the suite skipped the broken paths by design.

## Test plan
- [x] \`bun run lint\`, \`bun run check\` — green.
- [ ] e2e in CI hits \`/{en,ru,it,es,bl,pl,uk}/newspaper\` for every code and asserts 200 + h1.