### PR TITLE
fix(toc, sticky): unbreak the 6 skipped chromium e2e

### DIFF
--- a/e2e/article-toc.pw.ts
+++ b/e2e/article-toc.pw.ts
@@ -45,7 +45,23 @@ const TOC_MOBILE = '[data-testid="article-toc"]';
 const TOGGLE = '[data-testid="article-toc-toggle"]';
 const BACKDROP = '[data-testid="article-toc-backdrop"]';
 
+/*
+ * `ArticleTocOverlay.astro` stamps `data-toc-ready="true"` on its
+ * root once the FAB / backdrop / Escape listeners are attached.
+ * Wait on that signal before driving the FAB so the test never
+ * races the hoisted module script (which historically did an
+ * early sweep and silently dropped the toggle listener when the
+ * inner button hadn't been parsed yet).
+ */
+const waitForOverlayReady = async (page: Page): Promise<void> => {
+  await page.locator(`${TOC_MOBILE}[data-toc-ready="true"]`).waitFor({
+    state: 'attached',
+    timeout: 5000,
+  });
+};
+
 const openMobilePanel = async (page: Page): Promise<void> => {
+  await waitForOverlayReady(page);
   await click(page, page.locator(TOGGLE));
   await expectAttribute(page, page.locator(TOGGLE), 'aria-expanded', 'true');
 };
@@ -143,29 +159,13 @@ test.describe('Article TOC — mobile slide-in', () => {
     await expectAttribute(page, page.locator(TOGGLE), 'aria-expanded', 'false');
   });
 
-  /*
-   * TODO(#__): the four panel-open scenarios below race the
-   * overlay's init() script — playwright's `click()` lands before
-   * the module script has attached the toggle's listener, so the
-   * test observes the FAB visible but no `aria-expanded='true'` ever
-   * fires. The contract under test is real (FAB tap → panel opens,
-   * backdrop/Escape/link tap → close) but the harness needs a
-   * better wait. Options:
-   *  - have ArticleTocOverlay.astro stamp a `data-toc-ready` on the
-   *    root once init() runs and have the test wait on that;
-   *  - move the listener out of an Astro-hoisted module script;
-   *  - convert these to a `page.waitForFunction` that checks
-   *    `_articleTocClose` is set, then dispatch a synthetic click.
-   * Skipping until then so the deploy gate stays meaningful for
-   * everything else.
-   */
-  test.skip('tapping FAB opens the panel', async ({ page }) => {
+  test('tapping FAB opens the panel', async ({ page }) => {
     await visit(page, ARTICLE);
     await openMobilePanel(page);
     await expectVisible(page, page.locator('#article-toc-overlay-nav'));
   });
 
-  test.skip('backdrop click dismisses the panel', async ({ page }) => {
+  test('backdrop click dismisses the panel', async ({ page }) => {
     await visit(page, ARTICLE);
     await openMobilePanel(page);
     /*
@@ -180,14 +180,14 @@ test.describe('Article TOC — mobile slide-in', () => {
     await expectAttribute(page, page.locator(TOGGLE), 'aria-expanded', 'false');
   });
 
-  test.skip('Escape dismisses the panel', async ({ page }) => {
+  test('Escape dismisses the panel', async ({ page }) => {
     await visit(page, ARTICLE);
     await openMobilePanel(page);
     await pressKey(page, 'Escape');
     await expectAttribute(page, page.locator(TOGGLE), 'aria-expanded', 'false');
   });
 
-  test.skip('tapping a link dismisses the panel and updates hash', async ({ page }) => {
+  test('tapping a link dismisses the panel and updates hash', async ({ page }) => {
     await visit(page, ARTICLE);
     await openMobilePanel(page);
     const firstLink = page.locator(`${TOC_MOBILE} .article-toc-link`).first();

--- a/e2e/sticky-header.pw.ts
+++ b/e2e/sticky-header.pw.ts
@@ -39,17 +39,21 @@ const readState = (page: Page) =>
 
 const scrollAndSettle = async (page: Page, y: number): Promise<void> => {
   /*
-   * Scroll, then poll until the rAF-throttled scroll handler in
-   * Header.astro publishes a `--header-offset` value matching the
-   * new scroll direction. Polling beats waiting on a fixed number
-   * of rAF callbacks because the handler can land in either of the
-   * next two frames depending on browser scheduling.
+   * `html { scroll-behavior: smooth }` is applied globally for human
+   * UX, but a smooth scroll inside `page.evaluate()` runs for
+   * 100-200 ms BEFORE the rAF tick observes the new scrollY — and in
+   * headless chromium it occasionally fails to start at all when
+   * the same task scheduled the scroll. Force an instant scroll so
+   * the `--header-offset` observation begins from the new position
+   * immediately, then poll until the rAF-throttled handler in
+   * `Header.astro` publishes a `--header-offset` matching the new
+   * direction.
    */
   await page.evaluate(
     (target) =>
       new Promise<void>((resolve) => {
         const before = window.scrollY;
-        window.scrollTo(0, target);
+        window.scrollTo({ top: target, behavior: 'instant' as ScrollBehavior });
         const goingDown = target > before;
         const goingUp = target < before;
         const start = performance.now();
@@ -74,20 +78,7 @@ const scrollAndSettle = async (page: Page, y: number): Promise<void> => {
 test.describe('Sticky header — desktop', () => {
   test.use({ viewport: { width: 1400, height: 900 } });
 
-  /*
-   * TODO(#__): these three scenarios all assume the article page is
-   * scrollable past 500-800 px in the chromium headless viewport.
-   * Locally `window.scrollTo(0, 500)` is a no-op on the new target
-   * article — `window.scrollY` stays 0 — so the scroll-driven
-   * header retract/reveal handler never publishes the values the
-   * assertions check. The behaviour under test is real (sticky +
-   * reveal works in a real browser) but the harness needs a tall-
-   * enough page or a synthetic-scroll injection. Skipping until
-   * either the test fixture is replaced with a guaranteed-tall page
-   * or the scroll helper switches to driving `--header-offset`
-   * directly via JS.
-   */
-  test.skip('engages position:sticky so header stays near the viewport top', async ({ page }) => {
+  test('engages position:sticky so header stays near the viewport top', async ({ page }) => {
     await visit(page, ARTICLE);
     await scrollAndSettle(page, 500);
     const s = await readState(page);
@@ -105,7 +96,7 @@ test.describe('Sticky header — desktop', () => {
     expect(parseFloat(scrolled.offset)).toBeLessThan(0);
   });
 
-  test.skip('reveals on scroll-up', async ({ page }) => {
+  test('reveals on scroll-up', async ({ page }) => {
     await visit(page, ARTICLE);
     await scrollAndSettle(page, 800);
     const hidden = await readState(page);

--- a/src/features/content/components/ArticleTocOverlay.astro
+++ b/src/features/content/components/ArticleTocOverlay.astro
@@ -96,41 +96,71 @@ const visible: readonly Heading[] =
    * Smooth-scroll click + scroll-spy live in ArticleTocSidebar.astro
    * (Astro hoists + dedupes scripts across components, so importing
    * either component bootstraps the shared TOC behaviour).
+   *
+   * Astro hoists this module into a separate file with `defer`/module
+   * semantics; on the first page load that file can execute against a
+   * server-rendered overlay whose subtree is still being inserted
+   * piece-by-piece. The historical race was: `init()` runs, finds the
+   * `<div.article-toc-overlay>`, but `root.querySelector('[data-
+   * testid="article-toc-toggle"]')` returns null because the inner
+   * button hasn't been parsed yet — so `_articleTocClose` is set on
+   * the root, the test sees "init has run", but the click listener
+   * was never attached. `astro:page-load` fires later (with view
+   * transitions enabled) and `init()` re-runs successfully, but
+   * e2e tests beat that event.
+   *
+   * Two changes make init reliable:
+   *  - If `init()` doesn't find the toggle, re-arm via `MutationObserver`
+   *    so the listener attaches the moment the toggle appears.
+   *  - On success, stamp `data-toc-ready="true"` on the root so tests
+   *    have a deterministic signal to wait on instead of guessing
+   *    that "the script must have run by now".
    */
-  const init = (): void => {
-    const root = document.querySelector<HTMLElement>(
-      '.article-toc-overlay',
-    );
-    if (!root) return;
+  type Wired = HTMLElement & { _articleTocInit?: true; _articleTocClose?: () => void };
+  const READY = 'data-toc-ready';
+
+  const wire = (root: Wired): void => {
+    if (root._articleTocInit) return;
     const toggle = root.querySelector<HTMLButtonElement>(
       '[data-testid="article-toc-toggle"]',
     );
     const backdrop = root.querySelector<HTMLButtonElement>(
       '[data-testid="article-toc-backdrop"]',
     );
+    if (!toggle) return; // wait — caller will retry via MutationObserver
     const close = (): void => {
       root.classList.remove('is-open');
-      toggle?.setAttribute('aria-expanded', 'false');
+      toggle.setAttribute('aria-expanded', 'false');
     };
-    /*
-     * Expose the close hook on the root so the shared link-click
-     * handler in ArticleTocSidebar.astro can dismiss the panel after
-     * a tap without knowing overlay-specific markup.
-     */
-    (root as HTMLElement & { _articleTocClose?: () => void })
-      ._articleTocClose = close;
-
-    toggle?.addEventListener('click', () => {
+    root._articleTocClose = close;
+    toggle.addEventListener('click', () => {
       const next = !root.classList.contains('is-open');
       root.classList.toggle('is-open', next);
       toggle.setAttribute('aria-expanded', String(next));
     });
     backdrop?.addEventListener('click', close);
     document.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape' && root.classList.contains('is-open')) {
-        close();
-      }
+      if (e.key === 'Escape' && root.classList.contains('is-open')) close();
     });
+    root._articleTocInit = true;
+    root.setAttribute(READY, 'true');
+  };
+
+  const init = (): void => {
+    const root = document.querySelector<Wired>('.article-toc-overlay');
+    if (!root) return;
+    wire(root);
+    if (root._articleTocInit) return;
+    /*
+     * Toggle wasn't in DOM at first sweep — observe the root until it
+     * arrives. Disconnect on success so we don't leak observers
+     * across view transitions.
+     */
+    const observer = new MutationObserver(() => {
+      wire(root);
+      if (root._articleTocInit) observer.disconnect();
+    });
+    observer.observe(root, { childList: true, subtree: true });
   };
 
   init();


### PR DESCRIPTION
## Summary
Follow-up to #98, which kept the deploy gate green by skipping 6 chromium scenarios. Both classes of failure are now fixed at the source.

### `ArticleTocOverlay` (4 tests)
The hoisted `<script type=\"module\">` ran an early sweep that found \`.article-toc-overlay\` but `root.querySelector('[data-testid=\"article-toc-toggle\"]')` returned null because the inner button hadn't been parsed yet. The script set `_articleTocClose` on the root but never attached the FAB click listener; `astro:page-load` re-ran `init()` later and quietly fixed it — too late for the e2e first-tap.

- Rewrote `init()` to be idempotent: if the toggle isn't there yet, a `MutationObserver` re-arms wiring once it arrives.
- On success, the overlay stamps `data-toc-ready=\"true\"` so tests have a deterministic signal to wait on.
- `openMobilePanel` waits for that attribute before driving the FAB.
- Removed the four `test.skip`s.

### sticky-header (2 tests)
`html { scroll-behavior: smooth }` made the test's `window.scrollTo(0, 500)` an animated scroll, and in headless chromium it occasionally failed to engage at all inside a same-task `page.evaluate()` — `window.scrollY` stayed near 0 and the rAF observer never saw the new position.

- `scrollAndSettle` now passes `behavior: 'instant'` explicitly so the position jumps in the same tick.
- Removed the two `test.skip`s.

## Test plan
- [x] `npx playwright test e2e/article-toc.pw.ts --project=chromium` — 9/9 pass
- [x] `npx playwright test e2e/sticky-header.pw.ts --project=chromium` — 5/5 pass
- [x] Full chromium suite — **197/197 pass** (previously 191/197 with 6 skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)