### PR TITLE
feat(footer): expose public@comprom.org as a mailto: link

### DIFF
--- a/e2e/footer.pw.ts
+++ b/e2e/footer.pw.ts
@@ -30,6 +30,14 @@ test.describe('Footer widgets', () => {
     await expect(gh).toHaveAttribute('rel', /noopener/);
   });
 
+  test('public email is exposed as a mailto: link', async ({ page }) => {
+    await visit(page, '/en');
+    const email = page.getByTestId('footer-email');
+    await expectVisible(page, email);
+    await expect(email).toHaveAttribute('href', 'mailto:public@comprom.org');
+    await expect(email).toContainText('public@comprom.org');
+  });
+
   test('copyright still renders in Russian locale', async ({ page }) => {
     await visit(page, '/ru');
     await expectVisible(page, page.locator('footer').getByText('Communist Prometheus'));

--- a/src/features/navigation/components/Footer.astro
+++ b/src/features/navigation/components/Footer.astro
@@ -14,6 +14,8 @@ const copyright = nav?.data.copyright ?? '© All rights reserved';
 
 const rssHref = `/${lang}/rss.xml`;
 const githubHref = 'https://github.com/communist-prometheus';
+const PUBLIC_EMAIL = 'public@comprom.org';
+const mailtoHref = `mailto:${PUBLIC_EMAIL}`;
 ---
 
 <footer transition:persist="footer">
@@ -42,6 +44,32 @@ const githubHref = 'https://github.com/communist-prometheus';
             />
           </svg>
           <span>RSS</span>
+        </a>
+      </li>
+      <li>
+        <a
+          href={mailtoHref}
+          class="footer-link"
+          aria-label={`Contact: ${PUBLIC_EMAIL}`}
+          data-testid="footer-email"
+        >
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M3 7l9 6l9-6M3 7v10a1 1 0 0 0 1 1h16a1 1 0 0 0 1-1V7M3 7a1 1 0 0 1 1-1h16a1 1 0 0 1 1 1"
+            />
+          </svg>
+          <span>{PUBLIC_EMAIL}</span>
         </a>
       </li>
       <li>


### PR DESCRIPTION
## Summary
Adds a third footer-link widget between RSS and GitHub: an envelope icon + the literal address \`public@comprom.org\`, wrapped in a \`mailto:\` anchor. Showing the address as visible text (not just an aria-label) lets readers copy it into a non-default mail client; the icon and styling reuse the existing \`.footer-link\` rules so the row stays balanced across locales.

## Tests
Regression test in \`e2e/footer.pw.ts\` pins:
- the \`data-testid=\"footer-email\"\` anchor is visible on \`/en\`
- its \`href\` is exactly \`mailto:public@comprom.org\`
- the visible text contains the address verbatim

Locally: 201/201 chromium tests pass.

## Out-of-scope reminder
This PR is purely the front-end footer link. Actual mail-receiving on \`public@comprom.org\` still needs the DNS + provider setup we discussed (Proton paid / Infomaniak / Zoho free / CF Email Routing forwarding) — none of those is wired yet. Until DNS is set up, clicking the link will open the user's mail client but the message will bounce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)