### PR TITLE
fix(footer): email on its own row below RSS/GitHub on mobile

### DIFF
--- a/src/features/navigation/components/Footer.astro
+++ b/src/features/navigation/components/Footer.astro
@@ -111,8 +111,18 @@ const mailtoHref = `mailto:${PUBLIC_EMAIL}`;
     text-align: center;
   }
 
+  /*
+   * Default: all three widgets on a single centered row (desktop /
+   * tablet). On narrow viewports the email's visible text
+   * (`public@comprom.org`, ~22 chars) blows the row past 375 px and
+   * pushes RSS off the left edge and GitHub past the right.
+   * `flex-wrap: wrap` lets the row break; on `< 480px` the email
+   * gets `order: 1` + full-width so it lands on its own row BELOW
+   * RSS+GitHub instead of between them.
+   */
   .footer-links {
     display: flex;
+    flex-wrap: wrap;
     justify-content: center;
     gap: var(--spacing-md);
     list-style: none;
@@ -135,5 +145,14 @@ const mailtoHref = `mailto:${PUBLIC_EMAIL}`;
   .footer-link:hover,
   .footer-link:focus-visible {
     color: var(--color-accent);
+  }
+
+  @media (max-width: 480px) {
+    .footer-links li:has([data-testid='footer-email']) {
+      order: 1;
+      flex-basis: 100%;
+      display: flex;
+      justify-content: center;
+    }
   }
 </style>


### PR DESCRIPTION
At 375px the email's visible text (`public@comprom.org`) overflowed the single centered footer row — RSS clipped off the left edge (x=-12), GitHub past the right (x=387 > 375). `flex-wrap: wrap` + `order: 1` / `flex-basis: 100%` on the email `<li>` under `max-width: 480px` drops it onto its own centered row below RSS+GitHub. Desktop unchanged.

Verified at 375x812: RSS 70-156, GitHub 180-290 (inside viewport), email on the row below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)