### PR TITLE
fix(i18n): UKR not UK as Ukrainian switcher abbreviation (#20)

### DIFF
--- a/e2e/language-switcher.pw.ts
+++ b/e2e/language-switcher.pw.ts
@@ -25,6 +25,18 @@ test.describe('Language switcher - Desktop', () => {
     await expectText(page, page.locator(switcherSel), 'EN');
   });
 
+  /*
+   * Ticket #20: the Ukrainian route code is `uk` (ISO 639-1), which
+   * uppercases to "UK" — the United Kingdom country code. Editors
+   * asked for the abbreviation "UKR" instead. The trigger must show
+   * UKR, not UK, on /uk.
+   */
+  test('shows UKR (not UK) as the abbreviation on the Ukrainian page', async ({ page }) => {
+    await visit(page, '/uk');
+    const trigger = page.locator(`${switcherSel} .lang-current`);
+    await expectText(page, trigger, 'UKR');
+  });
+
   test('switches from EN to RU and navigates to equivalent page', async ({ page }) => {
     await visit(page, '/en/blog');
     const switcher = page.locator(switcherSel);

--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -15,3 +15,19 @@ export const DEFAULT_LANGUAGE = SUPPORTED_LANGUAGES[0] ?? 'en';
 export const LANGUAGE_LABELS: Readonly<Record<string, string>> = Object.fromEntries(
   languages.map((l) => [l.code, l.label]),
 );
+
+/*
+ * Overrides for the short abbreviation shown in the language-switcher
+ * trigger. Defaults to the uppercased route code, but Ukrainian's
+ * ISO 639-1 code `uk` uppercases to "UK" — the country code for the
+ * United Kingdom — so editors asked for "UKR" instead (ticket #20).
+ */
+const SHORT_LABEL_OVERRIDES: Readonly<Record<string, string>> = { uk: 'UKR' };
+
+/**
+ * The abbreviation shown for a language in the switcher trigger.
+ * @param code - The language route code (e.g. `uk`, `ru`).
+ * @returns The override abbreviation when defined, else uppercased code.
+ */
+export const shortLabel = (code: string): string =>
+  SHORT_LABEL_OVERRIDES[code] ?? code.toUpperCase();

--- a/src/features/navigation/components/LanguageSwitcher.astro
+++ b/src/features/navigation/components/LanguageSwitcher.astro
@@ -1,6 +1,6 @@
 ---
 import type { Language } from '@/config/i18n';
-import { LANGUAGE_LABELS, SUPPORTED_LANGUAGES } from '@/config/i18n';
+import { LANGUAGE_LABELS, SUPPORTED_LANGUAGES, shortLabel } from '@/config/i18n';
 import SmartDropdown from '@/features/ui/SmartDropdown/SmartDropdown.astro';
 
 interface Props {
@@ -26,7 +26,7 @@ const hrefFor = (code: string) => (rest === '' ? `/${code}` : `/${code}${rest}`)
     aria-haspopup="listbox"
     aria-label="Select language"
   >
-    <span class="lang-current">{lang.toUpperCase()}</span>
+    <span class="lang-current">{shortLabel(lang)}</span>
     <svg
       class="lang-chevron"
       width="12"
@@ -65,6 +65,8 @@ const hrefFor = (code: string) => (rest === '' ? `/${code}` : `/${code}${rest}`)
 </SmartDropdown>
 
 <script>
+  import { shortLabel } from '@/config/i18n';
+
   /*
    * SmartDropdown handles open/close/positioning. This script keeps
    * the in-place "current language" label + per-page hrefs in sync
@@ -83,7 +85,7 @@ const hrefFor = (code: string) => (rest === '' ? `/${code}` : `/${code}${rest}`)
     const rest = path.replace(/^\/[a-z]{2}(?=\/|$)/, '');
 
     const label = switcher.querySelector<HTMLElement>('.lang-current');
-    if (label) label.textContent = activeLang.toUpperCase();
+    if (label) label.textContent = shortLabel(activeLang);
 
     switcher
       .querySelectorAll<HTMLAnchorElement>('.lang-option')


### PR DESCRIPTION
Closes the one remaining point of tickets/#20.

The switcher trigger rendered `code.toUpperCase()`, so the Ukrainian route code `uk` showed as **UK** (the UK country code). Editors asked for **UKR**. Added `shortLabel(code)` in `config/i18n.ts` (`SHORT_LABEL_OVERRIDES = { uk: 'UKR' }`, default = uppercased code), used in the template + the SPA-sync inline script.

The ticket's other two points were already shipped in content: «Газета»→«Журнал» across langs (en Magazine / es Revista / it Rivista / ru Журнал) and EN manifest→Manifesto.

e2e: `language-switcher.pw.ts` asserts the trigger shows "UKR" on /uk. Full chromium suite: 202/202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)