### PR TITLE
feat(footer): embed Revolutionary Internationalists webring (tickets#22)

### DIFF
--- a/e2e/footer.pw.ts
+++ b/e2e/footer.pw.ts
@@ -38,6 +38,23 @@ test.describe('Footer widgets', () => {
     await expect(email).toContainText('public@comprom.org');
   });
 
+  /*
+   * The Revolutionary Internationalists webring (tickets#22) is
+   * embedded as the `<revint-webring>` custom element, loaded from
+   * cdn.comprom.org. We assert the markup is present and the loader
+   * script points at the CDN — not that the element upgrades (that
+   * needs the external bundle + network, covered in the webring
+   * repo's own Playwright suite).
+   */
+  test('webring element + CDN loader are embedded', async ({ page }) => {
+    await visit(page, '/en');
+    const ring = page.getByTestId('footer-webring');
+    await expectVisible(page, ring);
+    await expect(ring.locator('revint-webring')).toHaveAttribute('lang', 'en');
+    const loader = page.locator('script[src="https://cdn.comprom.org/webring.js"]');
+    await expect(loader).toHaveCount(1);
+  });
+
   test('copyright still renders in Russian locale', async ({ page }) => {
     await visit(page, '/ru');
     await expectVisible(page, page.locator('footer').getByText('Communist Prometheus'));

--- a/src/features/navigation/components/Footer.astro
+++ b/src/features/navigation/components/Footer.astro
@@ -97,7 +97,18 @@ const mailtoHref = `mailto:${PUBLIC_EMAIL}`;
         </a>
       </li>
     </ul>
+    <div class="webring" data-testid="footer-webring">
+      <span class="webring-label text-secondary text-sm">
+        Revolutionary Internationalists webring
+      </span>
+      <revint-webring lang={lang}></revint-webring>
+    </div>
   </div>
+  <script
+    is:inline
+    type="module"
+    src="https://cdn.comprom.org/webring.js"
+  ></script>
 </footer>
 
 <style>
@@ -109,6 +120,20 @@ const mailtoHref = `mailto:${PUBLIC_EMAIL}`;
 
   p {
     text-align: center;
+  }
+
+  .webring {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--spacing-xs);
+    margin-top: var(--spacing-md);
+  }
+
+  /* Tint the ring button to the site's accent for visual cohesion. */
+  .webring revint-webring {
+    --revint-accent: var(--color-accent, #b3231d);
+    --revint-fg: #fff;
   }
 
   /*


### PR DESCRIPTION
Embeds the `<revint-webring>` web component + its CDN loader (`https://cdn.comprom.org/webring.js`) in the footer — one button sends the visitor to a random allied site. Tinted to the site accent, labelled per page `lang`.

- CDN is **live**: `cdn.comprom.org/webring.js` (text/javascript) + `members.json` (application/json), both `Access-Control-Allow-Origin: *`.
- Component fetches `members.json` from the CDN with a bundled fallback.
- e2e asserts the element + loader are present with the right `lang`.

NB: ring currently has comprom.org + 2 **placeholder** members — replace with real allied sites in `communist-prometheus/webring` → `members.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)