### PR TITLE
feat(links): /[lang]/links — resources & allies directory

### DIFF
--- a/e2e/links-page.pw.ts
+++ b/e2e/links-page.pw.ts
@@ -1,0 +1,42 @@
+import { expect, expectVisible, test, visit } from '@prometheus/e2e-toolkit';
+
+/*
+ * `/[lang]/links` — the "Resources & allies" directory built from
+ * src/data/links.ts. Asserts the page renders, the three groups
+ * are present, a known organisation + a known archive resolve, and
+ * external links open safely. The footer link is covered in
+ * footer.pw.ts.
+ */
+test.describe('Links page', () => {
+  test('renders grouped resources & allies (en)', async ({ page }) => {
+    await visit(page, '/en/links');
+    await expectVisible(page, page.locator('h1'));
+    await expect(page.locator('h1')).toHaveText(/Resources & allies/i);
+    // Three group headings.
+    await expect(page.locator('.link-group h2')).toHaveCount(3);
+    // A known organisation + a known archive are listed as external links.
+    const ict = page.locator('a.link-name', {
+      hasText: 'Internationalist Communist Tendency',
+    });
+    await expectVisible(page, ict);
+    await expect(ict).toHaveAttribute('href', 'https://www.leftcom.org/');
+    await expect(ict).toHaveAttribute('rel', /noopener/);
+    await expect(ict).toHaveAttribute('target', '_blank');
+    await expectVisible(
+      page,
+      page.locator('a.link-name', { hasText: 'Marxists Internet Archive' }),
+    );
+  });
+
+  test('localises the heading for Russian', async ({ page }) => {
+    await visit(page, '/ru/links');
+    await expect(page.locator('h1')).toHaveText(/Ресурсы и союзники/);
+  });
+
+  test('is reachable from the footer link', async ({ page }) => {
+    await visit(page, '/en');
+    const footerLink = page.getByTestId('footer-links-page');
+    await expectVisible(page, footerLink);
+    await expect(footerLink).toHaveAttribute('href', '/en/links');
+  });
+});

--- a/src/data/links.ts
+++ b/src/data/links.ts
@@ -1,0 +1,295 @@
+/**
+ * Curated external links — the "Resources & allies" directory.
+ *
+ * Single source for the `/[lang]/links` page. The `organizations`
+ * group mirrors the webring members
+ * (cdn.comprom.org/members.json); `resources` (archives/libraries)
+ * and `friendly` (allied but non-internationalist-communist) are
+ * page-only and intentionally NOT in the ring.
+ *
+ * Descriptions are Russian for now (the list was authored in
+ * Russian); the `lang` badge tells the reader each site's own
+ * language. Localising descriptions is a later enhancement.
+ */
+export interface LinkEntry {
+  readonly url: string;
+  readonly name: string;
+  /** BCP-47 primary language of the target site (shown as a badge). */
+  readonly lang: string;
+  readonly description: string;
+}
+
+export interface LinkGroup {
+  readonly id: string;
+  readonly entries: readonly LinkEntry[];
+}
+
+/** Archives & libraries — reference material, not ring members. */
+const resources: readonly LinkEntry[] = [
+  {
+    url: 'https://www.marxists.org/',
+    name: 'Marxists Internet Archive',
+    lang: 'en',
+    description: 'Марксистский интернет-архив.',
+  },
+  {
+    url: 'https://www.sinistra.net/',
+    name: 'Sinistra',
+    lang: 'it',
+    description: 'Онлайн-архив коммунистической левой.',
+  },
+  {
+    url: 'https://libcom.org/',
+    name: 'libcom.org',
+    lang: 'en',
+    description: 'Новости и анализ борьбы рабочих, дискуссии и постоянно растущий архив.',
+  },
+  {
+    url: 'https://www.daadengedachte.nl/',
+    name: 'Daad en Gedachte',
+    lang: 'nl',
+    description: 'Архив прекратившего существование голландского левокоммунистического журнала.',
+  },
+  {
+    url: 'https://alter-maulwurf.de/',
+    name: 'Alter Maulwurf',
+    lang: 'de',
+    description: 'Тексты Амадео Бордиги на немецком языке.',
+  },
+  {
+    url: 'https://redtexts.org/',
+    name: 'redtexts.org',
+    lang: 'en',
+    description: 'Архив коммунистических текстов.',
+  },
+  {
+    url: 'https://www.aaap.be/Pages/Frontpage.html',
+    name: 'Anton Pannekoek Archives',
+    lang: 'en',
+    description: 'Архив Антона Паннекука.',
+  },
+];
+
+/** Internationalist / left-communist organisations & publications. */
+const organizations: readonly LinkEntry[] = [
+  {
+    url: 'https://www.leftcom.org/',
+    name: 'Internationalist Communist Tendency',
+    lang: 'en',
+    description: 'Интернациональная коммунистическая тенденция.',
+  },
+  {
+    url: 'http://www.igcl.org/',
+    name: 'International Group of the Communist Left',
+    lang: 'en',
+    description: 'Интернациональная группа коммунистической левой (Revolution or War).',
+  },
+  {
+    url: 'https://barbaria.net/',
+    name: 'Barbaria',
+    lang: 'es',
+    description: 'Испанская левокоммунистическая группа.',
+  },
+  {
+    url: 'https://balanceyavante1.wordpress.com/',
+    name: 'Balance y Avante',
+    lang: 'es',
+    description: 'Испанская левокоммунистическая группа.',
+  },
+  {
+    url: 'https://internationalistcommunists.org/',
+    name: 'League of Internationalist Communists',
+    lang: 'en',
+    description: 'Лига интернационалистических коммунистов.',
+  },
+  {
+    url: 'https://leftdis.wordpress.com/',
+    name: 'Left Discussions',
+    lang: 'en',
+    description: 'Левокоммунистический сайт.',
+  },
+  {
+    url: 'https://arbeidersstemmen.nl/',
+    name: 'Arbeidersstemmen (NL)',
+    lang: 'nl',
+    description: 'Левокоммунистическое онлайн-издание на голландском.',
+  },
+  {
+    url: 'https://arbeidersstemmen.wordpress.com/',
+    name: 'Arbeidersstemmen (DE)',
+    lang: 'de',
+    description: 'Левокоммунистическое онлайн-издание на немецком.',
+  },
+  {
+    url: 'https://inter-rev.foroactivo.com/',
+    name: 'Inter-Rev — Foro de la Izquierda Comunista',
+    lang: 'es',
+    description: 'Форум интернационалистических коммунистических левых на испанском.',
+  },
+  {
+    url: 'https://www.leftcommunism.org/',
+    name: 'Left Communism Forum',
+    lang: 'en',
+    description: 'Форум интернационалистических коммунистических левых.',
+  },
+  {
+    url: 'https://en.internationalism.org/',
+    name: 'International Communist Current',
+    lang: 'en',
+    description: 'Интернациональное коммунистическое течение (ICC).',
+  },
+  {
+    url: 'https://www.internationalcommunistparty.org/index.php/it/',
+    name: 'International Communist Party (.org)',
+    lang: 'it',
+    description: 'Одна из бордигистских Интернациональных коммунистических партий.',
+  },
+  {
+    url: 'https://www.international-communist-party.org/',
+    name: 'International Communist Party (-party.org)',
+    lang: 'en',
+    description: 'Ещё одна из бордигистских Интернациональных коммунистических партий.',
+  },
+  {
+    url: 'https://www.pcielcomunista.org/index.php/es/',
+    name: 'Partido Comunista Internacional (El Comunista)',
+    lang: 'es',
+    description: 'Ещё одна из бордигистских Интернациональных коммунистических партий.',
+  },
+  {
+    url: 'https://www.pcint.org/',
+    name: 'Partito Comunista Internazionale (Il Programma Comunista)',
+    lang: 'it',
+    description: 'Ещё одна из бордигистских Интернациональных коммунистических партий.',
+  },
+  {
+    url: 'https://sinistracomunistainternazionale.com/',
+    name: 'La Sinistra Comunista Internazionale',
+    lang: 'it',
+    description: 'Бордигистская организация.',
+  },
+  {
+    url: 'https://www.quinterna.org/',
+    name: 'n+1 / Quinterna',
+    lang: 'it',
+    description: "Сайт бордигистов из группы 'n+1'.",
+  },
+  {
+    url: 'https://www.raetekommunismus.de/',
+    name: 'Rätekommunismus',
+    lang: 'de',
+    description: 'Немецкий сайт коммунистов советов.',
+  },
+  {
+    url: 'https://kosmoprolet.org/',
+    name: 'Kosmoprolet',
+    lang: 'de',
+    description: 'Немецкая левокоммунистическая организация.',
+  },
+  {
+    url: 'https://coalizioneoperaia.com/',
+    name: 'Coalizione Operaia',
+    lang: 'it',
+    description: 'Итальянские коммунисты-интернационалисты.',
+  },
+  {
+    url: 'https://www.prospettivamarxista.org/Home.htm',
+    name: 'Prospettiva Marxista',
+    lang: 'it',
+    description: 'Итальянские коммунисты-интернационалисты.',
+  },
+  {
+    url: 'https://www.che-fare.org/',
+    name: 'Che Fare',
+    lang: 'it',
+    description: 'Итальянские коммунисты-интернационалисты.',
+  },
+  {
+    url: 'https://colectivoobrerocomunista.wordpress.com/',
+    name: 'Colectivo Obrero Comunista',
+    lang: 'es',
+    description: 'Мексиканские левые коммунисты.',
+  },
+  {
+    url: 'https://www.councilist.org/landing-page',
+    name: 'Councilist',
+    lang: 'en',
+    description: 'Коммунисты советов.',
+  },
+  {
+    url: 'https://criticadesapiedada.com.br/',
+    name: 'Crítica Desapiedada',
+    lang: 'pt',
+    description: 'Бразильский левокоммунистический сайт.',
+  },
+  {
+    url: 'https://communistleft.jinbo.net/xe/',
+    name: 'Internationalist Communist Perspective (Korea)',
+    lang: 'ko',
+    description: 'Корейская левокоммунистическая организация.',
+  },
+  {
+    url: 'https://sonoraninternational.org/',
+    name: 'Sonoran International',
+    lang: 'en',
+    description: 'Левые коммунисты из Тусона (Аризона).',
+  },
+  {
+    url: 'https://shoraha.net/',
+    name: 'Shoraha',
+    lang: 'fa',
+    description: 'Иранский левокоммунистический сайт.',
+  },
+  {
+    url: 'https://en.internationalistvoice.org/',
+    name: 'Internationalist Voice',
+    lang: 'en',
+    description: 'Иранская левокоммунистическая организация.',
+  },
+  {
+    url: 'https://wpiran.org/english/',
+    name: 'Worker-communist Party of Iran',
+    lang: 'en',
+    description: 'Рабочая партия Ирана (левокоммунистическая).',
+  },
+  {
+    url: 'https://internationalistperspective.org/',
+    name: 'Internationalist Perspective',
+    lang: 'en',
+    description: 'Левокоммунистическая организация.',
+  },
+  {
+    url: 'https://medium.com/@fiovermelho1917',
+    name: 'Fio Vermelho',
+    lang: 'pt',
+    description: 'Коммунисты-интернационалисты (португальский).',
+  },
+  {
+    url: 'https://coletivoruptura.wordpress.com/',
+    name: 'Coletivo Ruptura',
+    lang: 'pt',
+    description: 'Коммунисты-интернационалисты (португальский).',
+  },
+  {
+    url: 'https://counselingcommunism.com/',
+    name: 'Counseling Communism',
+    lang: 'en',
+    description: 'Коммунисты советов.',
+  },
+];
+
+/** Allied but outside the internationalist-communist tradition. */
+const friendly: readonly LinkEntry[] = [
+  {
+    url: 'https://www.anarchy.bg/',
+    name: 'Federation of Anarcho-Communists of Bulgaria',
+    lang: 'bg',
+    description: 'Сайт дружественной нам Федерации анархо-коммунистов Болгарии.',
+  },
+];
+
+export const LINK_GROUPS: readonly LinkGroup[] = [
+  { id: 'organizations', entries: organizations },
+  { id: 'resources', entries: resources },
+  { id: 'friendly', entries: friendly },
+];

--- a/src/features/navigation/components/Footer.astro
+++ b/src/features/navigation/components/Footer.astro
@@ -16,6 +16,18 @@ const rssHref = `/${lang}/rss.xml`;
 const githubHref = 'https://github.com/communist-prometheus';
 const PUBLIC_EMAIL = 'public@comprom.org';
 const mailtoHref = `mailto:${PUBLIC_EMAIL}`;
+
+const linksHref = `/${lang}/links`;
+const LINKS_LABELS: Readonly<Record<string, string>> = {
+  en: 'Links',
+  ru: 'Ссылки',
+  it: 'Link',
+  es: 'Enlaces',
+  uk: 'Посилання',
+  pl: 'Linki',
+  bl: 'Връзки',
+};
+const linksLabel = LINKS_LABELS[lang] ?? 'Links';
 ---
 
 <footer transition:persist="footer">
@@ -24,6 +36,31 @@ const mailtoHref = `mailto:${PUBLIC_EMAIL}`;
       {currentYear} Communist Prometheus. {copyright}
     </p>
     <ul class="footer-links" data-testid="footer-links">
+      <li>
+        <a
+          href={linksHref}
+          class="footer-link"
+          data-testid="footer-links-page"
+        >
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M10 13a5 5 0 0 0 7 0l3-3a5 5 0 0 0-7-7l-1 1m1 7a5 5 0 0 0-7 0l-3 3a5 5 0 0 0 7 7l1-1"
+            />
+          </svg>
+          <span>{linksLabel}</span>
+        </a>
+      </li>
       <li>
         <a
           href={rssHref}

--- a/src/pages/[lang]/links.astro
+++ b/src/pages/[lang]/links.astro
@@ -1,0 +1,179 @@
+---
+import { SUPPORTED_LANGUAGES } from '@/config/i18n';
+import { LINK_GROUPS } from '@/data/links';
+import BaseLayout from '@/layouts/BaseLayout.astro';
+
+/* One static page per supported language (see blog/index.astro). */
+export const getStaticPaths = async () => SUPPORTED_LANGUAGES.map((lang) => ({ params: { lang } }));
+
+const { lang } = Astro.params;
+
+/*
+ * Inline i18n for the page chrome only — headings + intro. The link
+ * entries themselves are language-neutral names + a per-site lang
+ * badge (descriptions are RU for now; see src/data/links.ts).
+ */
+type Strings = {
+  readonly title: string;
+  readonly intro: string;
+  readonly organizations: string;
+  readonly resources: string;
+  readonly friendly: string;
+};
+
+const EN: Strings = {
+  title: 'Resources & allies',
+  intro: 'Archives, publications and organisations of the internationalist communist left.',
+  organizations: 'Internationalist communist organisations',
+  resources: 'Archives & libraries',
+  friendly: 'Friendly organisations',
+};
+
+const I18N: Readonly<Record<string, Strings>> = {
+  en: EN,
+  ru: {
+    title: 'Ресурсы и союзники',
+    intro: 'Архивы, издания и организации интернационалистской коммунистической левой.',
+    organizations: 'Интернационалистские коммунистические организации',
+    resources: 'Архивы и библиотеки',
+    friendly: 'Дружественные организации',
+  },
+  it: {
+    title: 'Risorse e alleati',
+    intro: 'Archivi, pubblicazioni e organizzazioni della sinistra comunista internazionalista.',
+    organizations: 'Organizzazioni comuniste internazionaliste',
+    resources: 'Archivi e biblioteche',
+    friendly: 'Organizzazioni amiche',
+  },
+  es: {
+    title: 'Recursos y aliados',
+    intro: 'Archivos, publicaciones y organizaciones de la izquierda comunista internacionalista.',
+    organizations: 'Organizaciones comunistas internacionalistas',
+    resources: 'Archivos y bibliotecas',
+    friendly: 'Organizaciones amigas',
+  },
+  uk: {
+    title: 'Ресурси та союзники',
+    intro: 'Архіви, видання та організації інтернаціоналістської комуністичної лівиці.',
+    organizations: 'Інтернаціоналістські комуністичні організації',
+    resources: 'Архіви та бібліотеки',
+    friendly: 'Дружні організації',
+  },
+  pl: {
+    title: 'Zasoby i sojusznicy',
+    intro: 'Archiwa, publikacje i organizacje internacjonalistycznej lewicy komunistycznej.',
+    organizations: 'Internacjonalistyczne organizacje komunistyczne',
+    resources: 'Archiwa i biblioteki',
+    friendly: 'Zaprzyjaźnione organizacje',
+  },
+  bl: {
+    title: 'Ресурси и съюзници',
+    intro: 'Архиви, издания и организации на интернационалистическата комунистическа левица.',
+    organizations: 'Интернационалистически комунистически организации',
+    resources: 'Архиви и библиотеки',
+    friendly: 'Приятелски организации',
+  },
+};
+
+const t: Strings = I18N[lang] ?? EN;
+const groupTitle = (id: string): string =>
+  id === 'resources' ? t.resources : id === 'friendly' ? t.friendly : t.organizations;
+---
+
+<BaseLayout title={t.title} description={t.intro} lang={lang}>
+  <div class="section">
+    <div class="container links-page">
+      <h1>{t.title}</h1>
+      <p class="intro">{t.intro}</p>
+
+      {LINK_GROUPS.map((group) => (
+        <section class="link-group">
+          <h2>{groupTitle(group.id)}</h2>
+          <ul class="link-list">
+            {group.entries.map((e) => (
+              <li class="link-item">
+                <a
+                  class="link-name"
+                  href={e.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {e.name}
+                </a>
+                <span class="link-lang" aria-hidden="true">{e.lang.toUpperCase()}</span>
+                <span class="link-desc">{e.description}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  </div>
+</BaseLayout>
+
+<style>
+  .links-page {
+    max-width: 820px;
+  }
+
+  .intro {
+    color: var(--color-text-secondary);
+    margin-bottom: var(--spacing-xl);
+  }
+
+  .link-group {
+    margin-bottom: var(--spacing-2xl);
+  }
+
+  .link-group h2 {
+    font-size: 1.25rem;
+    padding-bottom: var(--spacing-xs);
+    border-bottom: 1px solid var(--color-border);
+    margin-bottom: var(--spacing-md);
+  }
+
+  .link-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-md);
+  }
+
+  .link-item {
+    display: grid;
+    grid-template-columns: auto auto;
+    align-items: baseline;
+    gap: 0.25rem 0.5rem;
+  }
+
+  .link-name {
+    font-weight: 600;
+    color: var(--color-accent);
+    text-decoration: none;
+  }
+
+  .link-name:hover,
+  .link-name:focus-visible {
+    text-decoration: underline;
+  }
+
+  .link-lang {
+    font-size: 0.6875rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    color: var(--color-text-secondary);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: 0.05rem 0.35rem;
+    justify-self: start;
+  }
+
+  .link-desc {
+    grid-column: 1 / -1;
+    color: var(--color-text-secondary);
+    font-size: 0.9375rem;
+    line-height: 1.5;
+  }
+</style>


### PR DESCRIPTION
A curated external-links page built from the owner's list, grouped into:
- **Internationalist communist organisations** (mirrors the webring members)
- **Archives & libraries** (Marxists Internet Archive, libcom, Sinistra, Pannekoek archive, …)
- **Friendly organisations** (Anarcho-Communist Federation of Bulgaria)

Single source `src/data/links.ts` — the `organizations` group matches the webring's `members.json`; `resources` + `friendly` are page-only and intentionally NOT in the ring (per "only internationalist communist organisations in the ring"). Page chrome localised for all 7 locales; each entry shows the target site's own language as a badge (descriptions are RU for now — localising them is a later enhancement). Footer gains a localised **Links** entry.

e2e (`links-page.pw.ts`): groups render, a known org + archive resolve as safe external links (`rel=noopener target=_blank`), RU heading localises, footer link points to `/<lang>/links`. Full chromium suite: 206/206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)