### PR TITLE
perf: immutable cache for /_astro/* + preconnect cdn

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -12,6 +12,20 @@
 # The single splat is greedy across `/`, so `/newspaper/*.fb2`
 # captures both the slug and the per-lang suffix.
 
+# Content-hashed build assets are immutable — the filename changes
+# whenever the bytes change, so cache them forever. Without this, CF
+# Workers Static Assets serves them `max-age=0, must-revalidate`
+# (the default), making the render-blocking `_astro/*.css`
+# revalidate on EVERY navigation — a visible white-screen stall on
+# slow connections / cold loads.
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Build-time fetched favicons (stable per-host filenames, not
+# hashed) — a day's cache is safe.
+/favicons/*
+  Cache-Control: public, max-age=86400
+
 # Force .fb2 (FictionBook) downloads instead of inline XML preview.
 /newspaper/*.fb2
   Content-Type: application/x-fictionbook+xml

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -62,6 +62,8 @@ const websiteLD = buildWebSiteLD(lang);
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    {/* Warm the connection for the footer webring bundle + members list. */}
+    <link rel="preconnect" href="https://cdn.comprom.org" crossorigin />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="apple-touch-icon" href="/pwa-icon.svg" />
     <link rel="manifest" href="/manifest.webmanifest" />


### PR DESCRIPTION
**White-screen-on-cold-load fix.** The render-blocking `_astro/*.css` was served with CF's default `Cache-Control: max-age=0, must-revalidate` — no `_headers` rule covered `/_astro/*` — so the browser revalidated it on **every** navigation, a visible stall on slow/cold loads.

`_astro/*` assets are content-hashed (filename changes with content), so they're safe to cache forever:
- `/_astro/*` → `public, max-age=31536000, immutable`
- `/favicons/*` → `public, max-age=86400` (stable per-host names, not hashed)
- `<link rel=preconnect href=cdn.comprom.org>` — warms the connection for the footer webring (loads bundle + members.json on every page).

Trace context: page LCP is 255 ms / CLS 0, but the single render-blocking CSS revalidating each load is what the user saw as a ~1s white screen in incognito.