### PR TITLE
fix(footnotes): scroll to legacy hash after the late-arriving id

### DIFF
--- a/e2e/footnotes.pw.ts
+++ b/e2e/footnotes.pw.ts
@@ -79,4 +79,15 @@ test.describe('Footnote popover enhancer — legacy bottom list', () => {
     await expect(li).toBeInViewport();
     await expect(li).toContainText('Friedrich Engels');
   });
+
+  test('loads a footnote hash that did not exist at first paint', async ({ page }) => {
+    /*
+     * The browser tries to scroll to `#endnote-N` once, right after
+     * the initial parse — before the annotation pass has added the
+     * id. The enhancer must re-fire the scroll itself so the user
+     * lands on the footnote, not at the top of the page.
+     */
+    await page.goto(`${LEGACY_URL}#endnote-3`);
+    await expect(page.locator('li#endnote-3')).toBeInViewport();
+  });
 });

--- a/src/features/footnotes/setup.ts
+++ b/src/features/footnotes/setup.ts
@@ -16,6 +16,23 @@ const targetOf = (anchor: HTMLAnchorElement): Element | undefined => {
 
 const pageLang = (): string => document.documentElement.lang || 'en';
 
+/*
+ * The browser scrolls to `location.hash` once, right after the
+ * initial parse. If our annotation only put the id on the list
+ * item *after* that scroll attempt, the user lands at the top of
+ * the page even though the id now exists. Re-fire the scroll
+ * manually when the hash matches a footnote/endnote pattern and
+ * the target wasn't reachable a moment ago.
+ */
+const FOOTNOTE_HASH = /^#(?:footnote|endnote|fn|user-content-fn)-?\d+$/;
+
+const restoreHashScroll = (): void => {
+  const hash = globalThis.location.hash;
+  if (!FOOTNOTE_HASH.test(hash)) return;
+  const target = document.getElementById(hash.slice(1));
+  if (target) target.scrollIntoView({ block: 'start' });
+};
+
 const enhanceOne = (anchor: HTMLAnchorElement, li: Element, lang: string): void => {
   transformFootnoteRef({ anchor, footnoteLi: li, lang });
 };
@@ -45,6 +62,7 @@ export const enhanceFootnotes = (): void => {
   if (document.body.hasAttribute(PROCESSED_FLAG)) return;
   document.body.setAttribute(PROCESSED_FLAG, '');
   annotateLegacyList();
+  restoreHashScroll();
   if (!supportsPopover()) return;
   const lang = pageLang();
   enhanceGfm(lang);


### PR DESCRIPTION
Follow-up on #110: visits to  would land at the top of the page even after legacy ids were applied, because the browser's hash-scroll happens before the annotation pass. The enhancer now re-fires the scroll itself once the late-arriving id is in place. +1 regression test (7 chromium e2e total, all pass).