### PR TITLE
fix(footnotes): map legacy #endnote-(ref-)N hashes to GFM ids

### DIFF
--- a/e2e/footnotes.pw.ts
+++ b/e2e/footnotes.pw.ts
@@ -91,3 +91,23 @@ test.describe('Footnote popover enhancer — legacy bottom list', () => {
     await expect(page.locator('li#endnote-3')).toBeInViewport();
   });
 });
+
+/*
+ * Old external shares predating the GFM rename use `#endnote-N` /
+ * `#endnote-ref-N`. On articles that have been re-imported to GFM
+ * those ids no longer exist in the DOM (the GFM rename moved the
+ * marker id to `user-content-fnref-N` and the body to
+ * `user-content-fn-N`); the enhancer maps the legacy hash to the
+ * new id so old links keep working.
+ */
+test.describe('Footnote popover enhancer — legacy hash on GFM article', () => {
+  test('#endnote-ref-N scrolls to the GFM marker', async ({ page }) => {
+    await page.goto(`${TEST_URL}#endnote-ref-1`);
+    await expect(page.locator('#user-content-fnref-1')).toBeInViewport();
+  });
+
+  test('#endnote-N scrolls to the GFM footnote body', async ({ page }) => {
+    await page.goto(`${TEST_URL}#endnote-1`);
+    await expect(page.locator('#user-content-fn-1')).toBeInViewport();
+  });
+});

--- a/src/features/footnotes/setup.ts
+++ b/src/features/footnotes/setup.ts
@@ -25,11 +25,40 @@ const pageLang = (): string => document.documentElement.lang || 'en';
  * the target wasn't reachable a moment ago.
  */
 const FOOTNOTE_HASH = /^#(?:footnote|endnote|fn|user-content-fn)-?\d+$/;
+const LEGACY_REF_HASH = /^#(?:footnote|endnote)-ref-(\d+)$/;
+const LEGACY_BODY_HASH = /^#(?:footnote|endnote|fn)-(\d+)$/;
+
+const resolveHash = (hash: string): HTMLElement | undefined => {
+  const refMatch = LEGACY_REF_HASH.exec(hash);
+  if (refMatch) {
+    /*
+     * External shares like `#endnote-ref-19` predate the GFM
+     * rename; they now have to land on `user-content-fnref-19`.
+     */
+    return (
+      document.getElementById(`user-content-fnref-${refMatch[1]}`) ??
+      document.getElementById(hash.slice(1)) ??
+      undefined
+    );
+  }
+  const bodyMatch = LEGACY_BODY_HASH.exec(hash);
+  if (bodyMatch) {
+    /*
+     * `#endnote-19` (legacy) or `#fn19` (Pandoc) → GFM body id.
+     */
+    return (
+      document.getElementById(`user-content-fn-${bodyMatch[1]}`) ??
+      document.getElementById(hash.slice(1)) ??
+      undefined
+    );
+  }
+  return document.getElementById(hash.slice(1)) ?? undefined;
+};
 
 const restoreHashScroll = (): void => {
   const hash = globalThis.location.hash;
-  if (!FOOTNOTE_HASH.test(hash)) return;
-  const target = document.getElementById(hash.slice(1));
+  if (!FOOTNOTE_HASH.test(hash) && !LEGACY_REF_HASH.test(hash)) return;
+  const target = resolveHash(hash);
   if (target) target.scrollIntoView({ block: 'start' });
 };
 


### PR DESCRIPTION
External shares like `#endnote-ref-19` predate the GFM rename and no longer hit anything on articles re-imported through the new pipeline. `restoreHashScroll` now maps the legacy hashes (`#endnote-N`, `#endnote-ref-N`, `#fnN`) to the GFM-style ids (`user-content-fnref-N`, `user-content-fn-N`) before scrolling. +2 chromium e2e cases (9 total, all pass).