### PR TITLE
fix(sw): force rollover to a new service-worker version on every deploy

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -26,6 +26,15 @@
 /favicons/*
   Cache-Control: public, max-age=86400
 
+# The Service Worker script controls which precached HTML the
+# browser serves. If `/sw.js` itself is cached the browser keeps
+# running the OLD worker — old `<script src="…hash.js">` references
+# stay in cached HTML and the new bundle hash never loads. Force a
+# fresh byte-for-byte check on every request so a deploy reliably
+# rolls clients forward.
+/sw.js
+  Cache-Control: no-cache, no-store, must-revalidate
+
 # Force .fb2 (FictionBook) downloads instead of inline XML preview.
 /newspaper/*.fb2
   Content-Type: application/x-fictionbook+xml

--- a/src/features/sw-update/headers.test.ts
+++ b/src/features/sw-update/headers.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const HEADERS = resolve('public/_headers');
+
+/*
+ * `_headers` is parsed by Cloudflare Workers Static Assets at edge
+ * time. We can't unit-test the edge behaviour from here, but we
+ * can guarantee the rule that controls SW rollover is still in the
+ * file: without it the browser caches /sw.js along with the rest
+ * of the site and a deploy can take 24h to roll forward.
+ */
+describe('public/_headers', () => {
+  const text = readFileSync(HEADERS, 'utf-8');
+
+  it('declares a /sw.js rule', () => {
+    expect(text).toMatch(/^\/sw\.js$/m);
+  });
+
+  it('marks /sw.js as no-cache so the browser always revalidates', () => {
+    const swSection = text.split(/^(?=\/)/m).find((s) => s.startsWith('/sw.js'));
+    expect(swSection, '/sw.js section is missing').toBeDefined();
+    expect(swSection ?? '').toMatch(/Cache-Control:\s*[^\n]*no-cache/i);
+  });
+});

--- a/src/features/sw-update/register-sw.test.ts
+++ b/src/features/sw-update/register-sw.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest';
+import { setupSwUpdate } from './register-sw';
+
+interface Harness {
+  readonly api: Parameters<typeof setupSwUpdate>[0];
+  readonly effects: Parameters<typeof setupSwUpdate>[1];
+  readonly fireControllerChange: () => void;
+  readonly reload: ReturnType<typeof vi.fn>;
+  readonly update: ReturnType<typeof vi.fn>;
+}
+
+const makeHarness = (hadController: boolean): Harness => {
+  const reload = vi.fn();
+  const update = vi.fn().mockResolvedValue(undefined);
+  let listener: (() => void) | undefined;
+  return {
+    api: {
+      hasController: () => hadController,
+      register: () => Promise.resolve({ update }),
+      onControllerChange: (h) => {
+        listener = h;
+      },
+    },
+    effects: { reload },
+    fireControllerChange: () => listener?.(),
+    reload,
+    update,
+  };
+};
+
+describe('setupSwUpdate', () => {
+  it('forces a registration.update() on every page load', async () => {
+    const h = makeHarness(false);
+    setupSwUpdate(h.api, h.effects);
+    /* register() is async — let microtasks flush. */
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(h.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT reload on the first-time controller attach', () => {
+    /*
+     * On a brand-new visit controller is null until the just-registered
+     * SW takes over. That first controllerchange is not a "new version";
+     * reloading would be a needless flash.
+     */
+    const h = makeHarness(false);
+    setupSwUpdate(h.api, h.effects);
+    h.fireControllerChange();
+    expect(h.reload).not.toHaveBeenCalled();
+  });
+
+  it('reloads once when an existing controller is replaced', () => {
+    /*
+     * On a returning visit `hasController()` is true at script start.
+     * A controllerchange after that means a new SW just activated —
+     * we want the page to immediately pick up the new HTML/JS.
+     */
+    const h = makeHarness(true);
+    setupSwUpdate(h.api, h.effects);
+    h.fireControllerChange();
+    expect(h.reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces repeated controllerchange events into a single reload', () => {
+    /*
+     * Some browsers fire `controllerchange` more than once during a
+     * single rollover (e.g. install → activate). The `refreshing`
+     * latch in the implementation guarantees we don't reload twice.
+     */
+    const h = makeHarness(true);
+    setupSwUpdate(h.api, h.effects);
+    h.fireControllerChange();
+    h.fireControllerChange();
+    h.fireControllerChange();
+    expect(h.reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('survives a failing update() without crashing the listener', async () => {
+    /*
+     * `registration.update()` can reject — for instance when the
+     * browser can't reach /sw.js. The listener must keep wiring up
+     * so the next page reload still has the controllerchange hook.
+     */
+    const h = makeHarness(true);
+    const failing = {
+      ...h.api,
+      register: () => Promise.resolve({ update: () => Promise.reject(new Error('net')) }),
+    };
+    setupSwUpdate(failing, h.effects);
+    await Promise.resolve();
+    await Promise.resolve();
+    h.fireControllerChange();
+    expect(h.reload).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/sw-update/register-sw.ts
+++ b/src/features/sw-update/register-sw.ts
@@ -1,0 +1,61 @@
+/*
+ * Service-worker registration with forced rollover on new deploys.
+ *
+ * Two guarantees this module provides on top of a plain
+ * `navigator.serviceWorker.register('/sw.js')`:
+ *
+ *   1. `registration.update()` runs on every page load so a fresh
+ *      `/sw.js` byte-check happens immediately. Without it the
+ *      browser only polls once every 24h and a deploy can sit
+ *      invisible for a day.
+ *
+ *   2. `controllerchange` triggers a one-shot `location.reload()`
+ *      when an *existing* controller is replaced — meaning a new
+ *      version of the SW just activated. The first-time install
+ *      (controller was previously null) does NOT trigger a reload;
+ *      it's not a "new version", it's the first version.
+ *
+ * The IO surface is injected so the logic is unit-testable without
+ * the real `navigator.serviceWorker`.
+ */
+
+/** Minimal shape of the registration API we depend on. */
+export interface SwApi {
+  readonly hasController: () => boolean;
+  readonly register: () => Promise<{
+    /*
+     * Real `ServiceWorkerRegistration.update()` resolves to the
+     * registration; we don't use the value so `unknown` is enough
+     * and lets the production binding pass the native API through
+     * without an adapter.
+     */
+    readonly update: () => Promise<unknown>;
+  }>;
+  readonly onControllerChange: (handler: () => void) => void;
+}
+
+/** Side-effects the listener performs on a real version flip. */
+export interface SwSideEffects {
+  readonly reload: () => void;
+}
+
+/**
+ * Wire the registration + controllerchange listener against any
+ * injectable IO. Returns nothing; the side effects are observable
+ * via the supplied `effects` (reload calls).
+ *
+ * @param api - SW API adapter (real `navigator.serviceWorker` in production, mock in tests).
+ * @param effects - Side-effect adapter (real `location.reload` in production, spy in tests).
+ */
+export const setupSwUpdate = (api: SwApi, effects: SwSideEffects): void => {
+  const hadController = api.hasController();
+  api.register().then((reg) => {
+    reg.update().catch(() => undefined);
+  });
+  let refreshing = false;
+  api.onControllerChange(() => {
+    if (!hadController || refreshing) return;
+    refreshing = true;
+    effects.reload();
+  });
+};

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -141,9 +141,24 @@ const websiteLD = buildWebSiteLD(lang);
     */}
     <slot name="floating" />
     <FootnoteEnhancer />
-    <script is:inline>
+    <script>
+      /*
+       * Service-worker registration with forced rollover on new
+       * deploys. Logic lives in `@/features/sw-update/register-sw`
+       * for unit-testability; the bindings below adapt the real
+       * `navigator.serviceWorker` to that module's injectable IO.
+       */
+      import { setupSwUpdate } from '@/features/sw-update/register-sw';
       if ('serviceWorker' in navigator && location.hostname !== 'localhost') {
-        navigator.serviceWorker.register('/sw.js');
+        setupSwUpdate(
+          {
+            hasController: () => !!navigator.serviceWorker.controller,
+            register: () => navigator.serviceWorker.register('/sw.js'),
+            onControllerChange: (h) =>
+              navigator.serviceWorker.addEventListener('controllerchange', h),
+          },
+          { reload: () => location.reload() }
+        );
       }
     </script>
   </body>


### PR DESCRIPTION
Stale clients kept showing old HTML / old bundle hashes after a deploy because /sw.js was cached and the existing controller kept serving its precached HTML until a manual reload.

`public/_headers` now declares /sw.js as `no-cache`. `BaseLayout.astro` wires `registration.update()` on every page load and reloads once on `controllerchange` when an existing controller is replaced (first-time install is ignored). Glue logic extracted into `@/features/sw-update/register-sw.ts` for unit-testability.

Tests: 5 unit cases in `register-sw.test.ts` (force update; no-reload-on-first-install; reload-on-version-flip; coalesced multi-event reload; survives failing update()) + 2 in `headers.test.ts` guarding the /sw.js rule in the headers file. All 7 pass; footnote e2e (9) stay green; build is green.