### PR TITLE
feat(footnotes): briefly highlight the target after a jump

### DIFF
--- a/e2e/footnotes.pw.ts
+++ b/e2e/footnotes.pw.ts
@@ -111,3 +111,55 @@ test.describe('Footnote popover enhancer — legacy hash on GFM article', () => 
     await expect(page.locator('#user-content-fn-1')).toBeInViewport();
   });
 });
+
+/*
+ * Highlight the target so the reader sees where they landed.
+ * Driven by `:target` + a CSS animation in `styles.css`; we verify
+ * the animation actually attaches via the Web Animations API.
+ */
+test.describe('Footnote popover enhancer — target flash', () => {
+  test('a deep-link to a footnote body runs the flash animation', async ({ page }) => {
+    await page.goto(`${TEST_URL}#user-content-fn-1`);
+    const animations = await page
+      .locator('#user-content-fn-1')
+      .evaluate((el) =>
+        el
+          .getAnimations()
+          .map((a) => (a as Animation & { animationName?: string }).animationName ?? ''),
+      );
+    expect(animations.some((n) => n === 'footnote-target-flash')).toBe(true);
+  });
+
+  test('browser-back to the marker also flashes it', async ({ page }) => {
+    /*
+     * Open popover → jump to footnote → back. The back transition
+     * lands on `#user-content-fnref-1`; CSS `:target` re-evaluates
+     * and the marker button picks up the flash animation.
+     */
+    await page.goto(TEST_URL);
+    await page.locator('button[data-footnote-ref]').first().click();
+    await page.locator('#user-content-fn-popover-1 a.footnote-jump').click();
+    await page.goBack();
+    await expect(page).toHaveURL(/#user-content-fnref-1$/);
+    const animations = await page
+      .locator('#user-content-fnref-1')
+      .evaluate((el) =>
+        el
+          .getAnimations()
+          .map((a) => (a as Animation & { animationName?: string }).animationName ?? ''),
+      );
+    expect(animations.some((n) => n === 'footnote-target-flash')).toBe(true);
+  });
+
+  test('flash also fires on the legacy bottom-list <li>', async ({ page }) => {
+    await page.goto(`${LEGACY_URL}#endnote-1`);
+    const animations = await page
+      .locator('li#endnote-1')
+      .evaluate((el) =>
+        el
+          .getAnimations()
+          .map((a) => (a as Animation & { animationName?: string }).animationName ?? ''),
+      );
+    expect(animations.some((n) => n === 'footnote-target-flash')).toBe(true);
+  });
+});

--- a/src/features/footnotes/styles.css
+++ b/src/features/footnotes/styles.css
@@ -81,3 +81,61 @@
     }
   }
 }
+
+/*
+ * Flash highlight on hash-target navigation. When the URL hash
+ * points at a footnote marker or a footnote body, briefly tint the
+ * target so the reader can see where they landed after a jump or
+ * a browser-back. Light/dark mode swap the tint via a CSS variable
+ * so the animation keyframes stay declared once.
+ */
+:root {
+  --color-footnote-flash-bg: oklch(0.93 0.16 90 / 0.85);
+}
+
+[data-theme="dark"] {
+  --color-footnote-flash-bg: oklch(0.5 0.14 80 / 0.55);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --color-footnote-flash-bg: oklch(0.5 0.14 80 / 0.55);
+  }
+}
+
+@keyframes footnote-target-flash {
+  from {
+    background-color: var(--color-footnote-flash-bg);
+  }
+  to {
+    background-color: transparent;
+  }
+}
+
+.footnote-ref-button:target {
+  animation: footnote-target-flash 2.5s ease-out both;
+  border-radius: 0.2em;
+  padding: 0 0.2em;
+  scroll-margin-block: 6rem;
+}
+
+[data-footnotes] li:target,
+li[id^="endnote-"]:target,
+li[id^="user-content-fn-"]:target {
+  animation: footnote-target-flash 2.5s ease-out both;
+  border-radius: 0.35rem;
+  scroll-margin-block: 1rem;
+  padding-inline: 0.25rem;
+  margin-inline: -0.25rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .footnote-ref-button:target,
+  [data-footnotes] li:target,
+  li[id^="endnote-"]:target,
+  li[id^="user-content-fn-"]:target {
+    animation: none;
+    background-color: var(--color-footnote-flash-bg);
+    transition: background-color 0.6s ease-out 1.5s;
+  }
+}


### PR DESCRIPTION
After the popover-jump → footnote or browser-back → marker, the page scrolled without any visual cue so the reader had to hunt for the destination line.

New `:target` rule briefly tints the target (both marker button and footnote `<li>` body, GFM `user-content-fn-*` and legacy `endnote-*` annotated by the runtime), fading out over 2.5s. Theme-aware via CSS variable (lighter yellow on light theme, dimmer ochre on dark). Reduced-motion users get a hold-and-fade variant.

Tests: 3 new chromium e2e on top of 9 existing (12 total, all pass) — verified via `element.getAnimations()`. Build green.