### PR TITLE
feat(links): drop the per-site language badge from the directory

### DIFF
--- a/src/features/links/get-links.ts
+++ b/src/features/links/get-links.ts
@@ -6,7 +6,6 @@ export interface LinkEntry {
   readonly url: string;
   readonly name: string;
   readonly category: string;
-  readonly siteLang: string;
   readonly inRing: boolean;
   readonly descriptions: Readonly<Record<string, string>>;
 }

--- a/src/pages/[lang]/links.astro
+++ b/src/pages/[lang]/links.astro
@@ -9,10 +9,10 @@ export const getStaticPaths = async () => SUPPORTED_LANGUAGES.map((lang) => ({ p
 const { lang } = Astro.params;
 
 /*
- * Inline i18n for the page chrome only — headings + intro. The link
- * entries themselves are language-neutral names + a per-site lang
- * badge. Data + per-lang descriptions come from the content repo
- * (settings/links.json), editable from the admin.
+ * Inline i18n for the page chrome only — headings + intro. Link
+ * entries are language-neutral names; per-lang descriptions come
+ * from the content repo (settings/links.json), editable from the
+ * admin.
  */
 type Strings = {
   readonly title: string;
@@ -104,17 +104,14 @@ const groups = getLinkGroups();
                       <path fill="none" stroke="currentColor" stroke-width="2" d="M12 3a9 9 0 1 0 0 18a9 9 0 0 0 0-18m-9 9h18M12 3c2.5 2.5 3.5 6 3.5 9s-1 6.5-3.5 9c-2.5-2.5-3.5-6-3.5-9s1-6.5 3.5-9"/>
                     </svg>
                   )}
-                  <span class="link-head">
-                    <a
-                      class="link-name"
-                      href={e.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      {e.name}
-                    </a>
-                    <span class="link-lang" aria-hidden="true">{e.siteLang.toUpperCase()}</span>
-                  </span>
+                  <a
+                    class="link-name"
+                    href={e.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {e.name}
+                  </a>
                   <span class="link-desc">{describe(e, lang)}</span>
                 </li>
               );
@@ -156,12 +153,7 @@ const groups = getLinkGroups();
     gap: var(--spacing-md);
   }
 
-  /*
-   * 2 columns: [favicon] [content]. Name + lang badge live together
-   * in `.link-head` (a flex row) so the badge sits immediately after
-   * each name — not aligned to the widest name in the group, which
-   * is what a shared `auto` grid column would do.
-   */
+  /* 2 columns: [favicon] [content]. */
   .link-item {
     display: grid;
     grid-template-columns: 16px 1fr;
@@ -179,16 +171,9 @@ const groups = getLinkGroups();
     color: var(--color-text-secondary);
   }
 
-  .link-head {
+  .link-name {
     grid-column: 2;
     grid-row: 1;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    flex-wrap: wrap;
-  }
-
-  .link-name {
     font-weight: 600;
     color: var(--color-accent);
     text-decoration: none;
@@ -197,17 +182,6 @@ const groups = getLinkGroups();
   .link-name:hover,
   .link-name:focus-visible {
     text-decoration: underline;
-  }
-
-  .link-lang {
-    flex-shrink: 0;
-    font-size: 0.6875rem;
-    font-weight: 700;
-    letter-spacing: 0.05em;
-    color: var(--color-text-secondary);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-sm);
-    padding: 0.05rem 0.35rem;
   }
 
   .link-desc {


### PR DESCRIPTION
## Summary

`/[lang]/links` rendered a small uppercase 2-letter badge after each
site name, derived from `siteLang` on entries in content
`settings/links.json`. Editors set it inconsistently — it labels the
*site's* primary language, not the language of the resource, and
multi-lingual sites needed an arbitrary tag — so it confused readers
more than it informed them.

This removes:

- the badge `<span class=\"link-lang\">` from `[lang]/links.astro`
- the `.link-head` flex wrapper that only existed to align badge + name
- the corresponding `.link-lang` / `.link-head` styles; `.link-name` now claims the grid cell directly (identical visual minus the badge)
- the `siteLang` member of the `LinkEntry` TS interface in `features/links/get-links.ts`

A matching content-repo commit strips `siteLang` from
`settings/links.json` (42 entries). The admin LinksEditor field is
removed in a companion PR on `admin-website`.

## Test plan

- [x] full Astro build clean (`bun run build` against the updated content) — 145 pages rebuilt, no TS errors
- [x] inspected built `dist/en/links/index.html`: no `link-lang` / `siteLang` strings; cards render `favicon → name → description`
- [ ] e2e `links-page.pw.ts` on the preview deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)