### PR TITLE
feat(security): publish /.well-known/security.txt (RFC 9116)

### DIFF
--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,4 @@
+Contact: mailto:public@comprom.org
+Expires: 2027-05-30T00:00:00Z
+Preferred-Languages: en, ru
+Canonical: https://comprom.org/.well-known/security.txt

--- a/public/_headers
+++ b/public/_headers
@@ -26,6 +26,13 @@
 /favicons/*
   Cache-Control: public, max-age=86400
 
+# RFC 9116 security.txt. CF Workers Static Assets serves no
+# extension as `application/octet-stream` by default — force
+# `text/plain` so the contact info renders inline rather than
+# triggering a download.
+/.well-known/security.txt
+  Content-Type: text/plain; charset=utf-8
+
 # The Service Worker script controls which precached HTML the
 # browser serves. If `/sw.js` itself is cached the browser keeps
 # running the OLD worker — old `<script src="…hash.js">` references


### PR DESCRIPTION
## Summary

Cloudflare Security Center flagged the missing `security.txt` (RFC 9116) as a Low-severity finding. This adds:

- `public/.well-known/security.txt` — points at the existing `public@comprom.org` mailbox. `Expires: 2027-05-30T00:00:00Z` (RFC requires < 1 year out).
- `_headers` rule forcing `Content-Type: text/plain; charset=utf-8` on the path — CF Workers Static Assets defaults extension-less files to `application/octet-stream` and would otherwise download instead of display.

## Test plan

- [x] file content: `Contact: mailto:public@comprom.org`, `Expires`, `Preferred-Languages: en, ru`, `Canonical: https://comprom.org/.well-known/security.txt`
- [ ] after deploy: `curl -i https://comprom.org/.well-known/security.txt` returns 200 with `Content-Type: text/plain; charset=utf-8`
- [ ] CF Security Center marks `security_txt_not_enabled` issue resolved on next scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)