### PR TITLE
feat(features): build-time feature flags from content settings

### DIFF
--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -1,0 +1,36 @@
+import featuresData from '@/content/settings/features.json';
+
+/**
+ * Build-time feature flags. The source of truth lives in the
+ * content repo at `settings/features.json` and is pulled in by
+ * `scripts/fetch-content.ts` alongside the rest of the site
+ * content. Flipping a flag is a content-repo commit — no code
+ * change required.
+ *
+ * Adding a new flag: extend `FeatureFlags` with the field, add
+ * the field to `DEFAULTS` (so old content checkouts keep
+ * building), and surface it in the admin UI editor.
+ */
+export type FeatureFlags = {
+  readonly webring: boolean;
+};
+
+const DEFAULTS: FeatureFlags = {
+  webring: false,
+};
+
+type PartialFlags = { readonly webring?: unknown };
+
+const isObject = (x: unknown): x is PartialFlags => x !== null && typeof x === 'object';
+
+const readBool = (raw: unknown, fallback: boolean): boolean =>
+  typeof raw === 'boolean' ? raw : fallback;
+
+const parse = (raw: unknown): FeatureFlags =>
+  isObject(raw) ? { webring: readBool(raw.webring, DEFAULTS.webring) } : DEFAULTS;
+
+/**
+ * Resolved feature-flag bundle, ready for `{features.X && ...}`
+ * conditional rendering at build time.
+ */
+export const features: FeatureFlags = parse(featuresData);

--- a/src/features/navigation/components/Footer.astro
+++ b/src/features/navigation/components/Footer.astro
@@ -1,4 +1,5 @@
 ---
+import { features } from '@/config/features';
 import type { Language } from '@/config/i18n';
 import { getMenuData } from '@/config/translations';
 
@@ -134,18 +135,26 @@ const linksLabel = LINKS_LABELS[lang] ?? 'Links';
         </a>
       </li>
     </ul>
-    <div class="webring" data-testid="footer-webring">
-      <span class="webring-label text-secondary text-sm">
-        Revolutionary Internationalists webring
-      </span>
-      <revint-webring lang={lang}></revint-webring>
-    </div>
+    {
+      features.webring && (
+        <div class="webring" data-testid="footer-webring">
+          <span class="webring-label text-secondary text-sm">
+            Revolutionary Internationalists webring
+          </span>
+          <revint-webring lang={lang} />
+        </div>
+      )
+    }
   </div>
-  <script
-    is:inline
-    type="module"
-    src="https://cdn.comprom.org/webring.js"
-  ></script>
+  {
+    features.webring && (
+      <script
+        is:inline
+        type="module"
+        src="https://cdn.comprom.org/webring.js"
+      />
+    )
+  }
 </footer>
 
 <style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import { ClientRouter } from 'astro:transitions';
+import { features } from '@/config/features';
 import type { Language } from '@/config/i18n';
 import { buildHreflangAlternates, SITE_URL } from '@/config/seo';
 import { buildOrganizationLD, buildWebSiteLD } from '@/config/structured-data';
@@ -64,7 +65,7 @@ const websiteLD = buildWebSiteLD(lang);
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     {/* Warm the connection for the footer webring bundle + members list. */}
-    <link rel="preconnect" href="https://cdn.comprom.org" crossorigin />
+    {features.webring && <link rel="preconnect" href="https://cdn.comprom.org" crossorigin />}
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="apple-touch-icon" href="/pwa-icon.svg" />
     <link rel="manifest" href="/manifest.webmanifest" />


### PR DESCRIPTION
## Summary

- `src/config/features.ts` reads from `@/content/settings/features.json` and provides a typed `features` bundle. Defaults to everything-off so a missing/malformed file never breaks the build.
- `Footer.astro` wraps the Revolutionary Internationalists webring + its CDN script in `{features.webring && ...}`.
- `BaseLayout.astro` wraps the `cdn.comprom.org` preconnect link in the same gate.

With todays content (`{webring: false}`), no webring markup, script, or preconnect ships in the final bundle.

## Verification

```
CONTENT_KEEP=1 bun run build
```

Greps confirm absence in `dist/*.html`:
- `data-testid="footer-webring"` — none
- `<revint-webring>` — none
- `cdn.comprom.org/webring.js` — none
- preconnect to `cdn.comprom.org` — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)