### PR TITLE
fix(e2e): drop unused waitForCondition imports + bump toolkit

### DIFF
--- a/e2e/language-coverage.pw.ts
+++ b/e2e/language-coverage.pw.ts
@@ -1,15 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import {
-  click,
-  expect,
-  expectVisible,
-  test,
-  visit,
-  waitForCondition,
-  waitForUrl,
-} from '@prometheus/e2e-toolkit';
+import { click, expect, expectVisible, test, visit, waitForUrl } from '@prometheus/e2e-toolkit';
 import { buildSectionAvailability, hasSection } from './helpers/content-coverage';
 
 /*

--- a/e2e/language-switcher.pw.ts
+++ b/e2e/language-switcher.pw.ts
@@ -7,7 +7,6 @@ import {
   pressKey,
   test,
   visit,
-  waitForCondition,
   waitForUrl,
 } from '@prometheus/e2e-toolkit';
 

--- a/e2e/verify-about-page.pw.ts
+++ b/e2e/verify-about-page.pw.ts
@@ -1,15 +1,7 @@
 import { mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 import process from 'node:process';
-import {
-  click,
-  expectText,
-  expectVisible,
-  test,
-  visit,
-  waitForCondition,
-  waitForUrl,
-} from '@prometheus/e2e-toolkit';
+import { click, expectText, expectVisible, test, visit, waitForUrl } from '@prometheus/e2e-toolkit';
 
 /**
  * Manual prod probe for the About page split.


### PR DESCRIPTION
Three test files lost their last `waitForCondition` call when the URL-poll sites migrated to `waitForUrl` (#119). The stale imports left ts(6133) compile errors that blocked the deploy pipeline.

Removes the unused imports and advances the e2e-toolkit submodule to the master commit that ships the matching `UrlPattern` signature fix (Playwrights `page.waitForURL` takes a synchronous predicate only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)