### PR TITLE
test(language-switcher): assert <html lang>, bump toolkit for readyState wait

### DIFF
--- a/e2e/language-switcher.pw.ts
+++ b/e2e/language-switcher.pw.ts
@@ -1,6 +1,7 @@
 import {
   click,
   expect,
+  expectAttribute,
   expectHidden,
   expectText,
   expectVisible,
@@ -45,7 +46,12 @@ test.describe('Language switcher - Desktop', () => {
     await expectVisible(page, ruOption);
     await click(page, ruOption);
     await waitForUrl(page, /\/ru\/blog\/?$/);
-    await expectVisible(page, page.locator('h1'));
+    /*
+     * Assert the new document — not the old one — has settled by
+     * checking <html lang> flipped. `expectVisible(h1)` would also
+     * pass on the still-mounted old page mid-swap, masking races.
+     */
+    await expectAttribute(page, page.locator('html'), 'lang', 'ru');
   });
 
   test('switches from RU to EN and navigates to equivalent page', async ({ page }) => {
@@ -56,7 +62,7 @@ test.describe('Language switcher - Desktop', () => {
     await expectVisible(page, enOption);
     await click(page, enOption);
     await waitForUrl(page, /\/en\/manifest\/?$/);
-    await expectVisible(page, page.locator('h1'));
+    await expectAttribute(page, page.locator('html'), 'lang', 'en');
   });
 
   test('preserves path segments when switching language on home page', async ({ page }) => {


### PR DESCRIPTION
## Summary

- Switches the RU→EN and EN→RU assertions from \`expectVisible(h1)\` to \`expectAttribute(html, 'lang', target)\`. The old assertion passed for the wrong reason — the previous document's h1 was still mounted mid-swap.
- Bumps \`e2e-toolkit\` submodule pointer to \`455660f\`, which adds a \`document.readyState !== 'loading'\` poll between \`page.waitForURL\` and the network settle wait. Closes the Astro View Transition race end-to-end so callers cannot land on the still-old DOM.
- Fixes the CI flake that has been red on PR #119 and #120 deploys.

## Test plan

- [x] \`npx playwright test e2e/language-switcher.pw.ts --project chromium --repeat-each 3\` — 27/27 pass locally.
- [ ] Master deploy CI goes green after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)