### PR TITLE
fix(test): pwa touch-icon assertion now expects favicon raster

### DIFF
--- a/e2e/pwa.pw.ts
+++ b/e2e/pwa.pw.ts
@@ -28,9 +28,17 @@ test.describe('PWA install criteria', () => {
       'href',
       '/manifest.webmanifest',
     );
+    /*
+     * apple-touch-icon used to point at `/pwa-icon.svg` (the red "P"
+     * placeholder). It now points at the brand favicon's 192×192
+     * PNG raster so Google's SERP favicon picker stops falling
+     * through to the placeholder. The exact href could grow more
+     * size variants over time — assert the raster suffix, not the
+     * literal string.
+     */
     await expect(page.locator('link[rel="apple-touch-icon"]')).toHaveAttribute(
       'href',
-      '/pwa-icon.svg',
+      /\/favicon-\d+\.png$/,
     );
     const themeColors = await page.locator('meta[name="theme-color"]').count();
     expect(themeColors).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary

Hot-fix for the master deploy that went red after PR #122 (favicon overhaul). The favicon work repointed `apple-touch-icon` at `/favicon-192.png`, but `pwa.pw.ts` still asserted the old literal `/pwa-icon.svg` href. CI e2e blocks deploy, so the favicon never reached prod.

Relaxes the assertion to `/favicon-\d+\.png$` so future size bumps don''t need a test edit.

## Test plan

- [x] `bun x playwright test --project=chromium` — 234/234 pass locally
- [ ] After merge: `Deploy to Cloudflare Workers` goes green, favicon stack ships to prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)