### PR TITLE
feat(cards): prefer frontmatter description over body-derived summary

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -9,11 +9,10 @@ const blogCollection = defineCollection({
     z.object({
       title: z.string(),
       /*
-       * Description is optional now: editors stopped filling it in
-       * the admin (the field was retired). Listings derive their
-       * card preview from the body's first paragraph; the article
-       * page renders description as a lead block when an old entry
-       * still carries one.
+       * Description is the editorial card preview. Listings show it
+       * directly and fall back to the body's first paragraph (via
+       * deriveSummary) when missing. The article page also renders
+       * it as a lead block when present.
        */
       description: z.string().optional(),
       category: z.string(),

--- a/src/features/blog/components/PostCard.astro
+++ b/src/features/blog/components/PostCard.astro
@@ -64,9 +64,9 @@ const href = `/${lang}/blog/${slug}`;
   }
 
   .post-image {
-    margin: var(--spacing-sm);
-    width: calc(100% - var(--spacing-sm) * 2);
-    height: clamp(120px, 30vw, 200px);
+    margin: var(--spacing-xs);
+    width: calc(100% - var(--spacing-xs) * 2);
+    height: clamp(96px, 22vw, 160px);
     overflow: hidden;
     border-radius: var(--radius-md);
     flex-shrink: 0;
@@ -81,8 +81,8 @@ const href = `/${lang}/blog/${slug}`;
   .post-content {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-sm);
-    padding: clamp(var(--spacing-sm), 3vw, var(--spacing-lg));
+    gap: var(--spacing-xs);
+    padding: clamp(var(--spacing-xs), 2vw, var(--spacing-md));
     flex: 1;
     min-width: 0;
     min-height: 0;
@@ -90,10 +90,10 @@ const href = `/${lang}/blog/${slug}`;
 
   .category {
     display: inline-block;
-    padding: 0.25rem 0.75rem;
+    padding: 0.15rem 0.55rem;
     background: var(--color-accent);
     color: var(--color-on-accent);
-    font-size: 0.75rem;
+    font-size: 0.7rem;
     font-weight: 500;
     border-radius: var(--radius-sm);
     width: fit-content;
@@ -103,8 +103,8 @@ const href = `/${lang}/blog/${slug}`;
   }
 
   .post-title {
-    font-size: clamp(1rem, 3vw, 1.25rem);
-    line-height: 1.4;
+    font-size: clamp(0.95rem, 2.6vw, 1.15rem);
+    line-height: 1.25;
     overflow-wrap: break-word;
     word-break: break-word;
     display: -webkit-box;
@@ -141,9 +141,11 @@ const href = `/${lang}/blog/${slug}`;
   .post-summary {
     flex: 1;
     margin: 0;
+    font-size: 0.9rem;
+    line-height: 1.45;
     display: -webkit-box;
-    -webkit-line-clamp: 6;
-    line-clamp: 6;
+    -webkit-line-clamp: 12;
+    line-clamp: 12;
     -webkit-box-orient: vertical;
     overflow: hidden;
     min-height: 0;

--- a/src/features/content/helpers/deriveSummary.ts
+++ b/src/features/content/helpers/deriveSummary.ts
@@ -1,11 +1,6 @@
 /*
- * Widget summary — short preview text shown on cards in listings.
- *
- * Editor wants widgets (PostCard, NewspaperCard, position cards) to
- * always derive their preview from the article body, NOT from the
- * frontmatter `description` field. The frontmatter description is
- * being repurposed as the preface block on the article page itself
- * — see deriveDescription for the SEO meta path.
+ * Widget summary — fallback preview text shown on cards in listings
+ * when the entry has no editorial `description` in frontmatter.
  *
  * Rules:
  * - Strip markdown decorations (headings, lists, bold, italic, …).
@@ -41,15 +36,14 @@ const stripMarkdown = (raw: string): string => {
   return out;
 };
 
-const MAX_LEN = 160;
+const MAX_LEN = 320;
 
 /**
- * Build the preview snippet shown on listing cards. Always derives
- * from the article body — frontmatter `description` is reserved for
- * the lead/preface block on the detail page now.
+ * Build the preview snippet shown on listing cards. Used as a fallback
+ * when the entry has no editorial `description` in frontmatter.
  *
  * @param body Raw markdown body.
- * @returns Short summary (~160 chars), or undefined if body is empty.
+ * @returns Short summary (~320 chars), or undefined if body is empty.
  */
 export const deriveSummary = (body: string | undefined): string | undefined => {
   if (!body) return undefined;

--- a/src/features/home/components/NewsSection.astro
+++ b/src/features/home/components/NewsSection.astro
@@ -30,7 +30,7 @@ const { posts, lang, latestNewsLabel, viewAllLabel } = Astro.props;
           {posts.map((post) => (
             <PostCard
               title={post.data.title}
-              description={deriveSummary(post.body) ?? ''}
+              description={post.data.description ?? deriveSummary(post.body) ?? ''}
               category={post.data.category}
               slug={getArticleSlug(post)}
               image={post.data.image}

--- a/src/features/positions/components/PositionsWidget.astro
+++ b/src/features/positions/components/PositionsWidget.astro
@@ -34,7 +34,7 @@ const readMore = labels?.data.readMore ?? 'Read more';
           {positions.map((pos) => (
             <PositionCard
               title={pos.data.title}
-              description={deriveSummary(pos.body) ?? ''}
+              description={pos.data.description ?? deriveSummary(pos.body) ?? ''}
               slug={pos.id.split('/').at(0) ?? pos.id}
               lang={lang}
               readMoreLabel={readMore}

--- a/src/pages/[lang]/blog/index.astro
+++ b/src/pages/[lang]/blog/index.astro
@@ -48,7 +48,7 @@ const readMore = labels?.data.readMore ?? 'Read more';
               <div data-category={post.data.category}>
                 <PostCard
                   title={post.data.title}
-                  description={deriveSummary(post.body) ?? ''}
+                  description={post.data.description ?? deriveSummary(post.body) ?? ''}
                   category={post.data.category}
                   slug={getArticleSlug(post)}
                   image={post.data.image}

--- a/src/pages/[lang]/newspaper/index.astro
+++ b/src/pages/[lang]/newspaper/index.astro
@@ -37,7 +37,7 @@ const fb2Label = labels?.data.downloadFb2 ?? 'Download FB2';
           {items.map((item) => (
             <NewspaperCard
               title={item.data.title}
-              description={deriveSummary(item.body) ?? item.data.description ?? ''}
+              description={item.data.description ?? deriveSummary(item.body) ?? ''}
               slug={item.id.split('/').at(0) ?? item.id}
               lang={lang}
               image={item.data.image ?? undefined}

--- a/src/pages/[lang]/positions/index.astro
+++ b/src/pages/[lang]/positions/index.astro
@@ -31,7 +31,7 @@ const readMore = labels?.data.readMore ?? 'Read more';
           {positions.map((pos) => (
             <PositionCard
               title={pos.data.title}
-              description={deriveSummary(pos.body) ?? pos.data.description ?? ''}
+              description={pos.data.description ?? deriveSummary(pos.body) ?? ''}
               slug={pos.id.split('/').at(0) ?? pos.id}
               lang={lang}
               headingLevel={2}


### PR DESCRIPTION
## Summary
- All listing widgets (blog, positions, newspaper) now use editorial `description` first; `deriveSummary(body)` is the fallback only when the field is empty.
- PostCard layout tightened so longer editorial copy fits: smaller image cap (160px max), leaner paddings/gaps, summary `line-clamp 12` with smaller font/line-height.
- `deriveSummary` MAX_LEN bumped 160 → 320 for the same reason. Comments in `content.config.ts` and `deriveSummary.ts` updated to reflect the new policy.

## Test plan
- [ ] `/ru/blog` — cards show editorial description verbatim; layout still uniform.
- [ ] `/ru` home — News widget pulls description first.
- [ ] `/ru/positions` and `/ru/newspaper` — same priority order.
- [ ] An entry with no `description` still renders a sensible fallback snippet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)