### PR TITLE
chore(ci): bump actions to node24 majors, add dependabot, TS 6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  # The repo's lockfile is bun.lock — the `bun` ecosystem (GA since
+  # Feb 2025) updates package.json AND the lockfile together.
+  - package-ecosystem: bun
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      dev-minor:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  # e2e-toolkit submodule — keeps the pinned SHA moving with upstream.
+  - package-ecosystem: gitsubmodule
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
       CONTENT_BRANCH: ${{ github.ref_name }}
     steps:
       - name: Cloning git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # e2e-toolkit lives in a separate repo and is wired as a
           # submodule. Without this, the e2e tsconfig path mapping
@@ -58,7 +58,7 @@ jobs:
         run: bunx playwright test --project=chromium --reporter=line
 
       - name: Deploying to Cloudflare Workers
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/redeploy-on-content.yml
+++ b/.github/workflows/redeploy-on-content.yml
@@ -25,7 +25,7 @@ jobs:
   redeploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.client_payload.branch }}
           token: ${{ secrets.GH_PAT }}

--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
         "lint-staged": "^16.2.7",
         "playwright-lighthouse": "^4.0.0",
         "to-ico": "^1.1.5",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
       },
     },
   },
@@ -1701,7 +1701,7 @@
 
     "typesafe-path": ["typesafe-path@0.2.2", "", {}, "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "typescript-auto-import-cache": ["typescript-auto-import-cache@0.3.6", "", { "dependencies": { "semver": "^7.3.8" } }, "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ=="],
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "lint-staged": "^16.2.7",
     "playwright-lighthouse": "^4.0.0",
     "to-ico": "^1.1.5",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "lint-staged": {
     "*": [


### PR DESCRIPTION
## Summary
- `actions/checkout` v4→v6, `cloudflare/wrangler-action` v3→v4 — v4-era actions run on Node 20, force-migrated to Node 24 on **June 16, 2026**.
- New dependabot config with `bun`, `github-actions`, `gitsubmodule` ecosystems (repo previously had none).
- TypeScript `^5.9.3` → `^6.0.3` (latest stable).

## Test plan
- [x] `astro check` — 0 errors on TS 6.0.3
- [ ] CI deploy (incl. e2e) green on the bumped actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)