### PR TITLE
fix(i18n): resolve category keys to localized labels (#26)

### DIFF
--- a/src/features/blog/components/CategoryFilter.astro
+++ b/src/features/blog/components/CategoryFilter.astro
@@ -1,15 +1,19 @@
 ---
+import type { Language } from '@/config/i18n';
+import { getCategoryLabel } from '@/features/content/helpers/getCategoryLabel';
+
 interface Props {
   categories: string[];
+  lang: Language;
   allLabel?: string;
 }
 
-const { categories, allLabel = 'All' } = Astro.props;
+const { categories, lang, allLabel = 'All' } = Astro.props;
 ---
 
 <div class="category-filter">
   <button class="category-btn active" data-category="all">{allLabel}</button>
-  {categories.map((category) => <button class="category-btn" data-category={category}>{category}</button>)}
+  {categories.map((category) => <button class="category-btn" data-category={category}>{getCategoryLabel(category, lang)}</button>)}
 </div>
 
 <script>

--- a/src/features/blog/components/PostCard.astro
+++ b/src/features/blog/components/PostCard.astro
@@ -3,6 +3,7 @@ import type { ImageMetadata } from 'astro';
 import CpCard from '@/components/cp/CpCard.astro';
 import type { Language } from '@/config/i18n';
 import BlogPicture from '@/features/blog/components/BlogPicture.astro';
+import { getCategoryLabel } from '@/features/content/helpers/getCategoryLabel';
 
 interface Props {
   title: string;
@@ -27,7 +28,7 @@ const href = `/${lang}/blog/${slug}`;
 <CpCard hoverable elevated class="post-card">
   {image && <div class="post-image"><BlogPicture image={image} alt={title} preset="thumbnail" /></div>}
   <div class="post-content">
-    <span class="category">{category}</span>
+    <span class="category">{getCategoryLabel(category, lang)}</span>
     {/*
       The heading anchor + `::before` overlay pattern: the link is
       attached to the title (so screen readers announce a real

--- a/src/features/content/helpers/getCategoryLabel.ts
+++ b/src/features/content/helpers/getCategoryLabel.ts
@@ -1,0 +1,33 @@
+import { DEFAULT_LANGUAGE } from '@/config/i18n';
+import labelsData from '@/content/settings/labels.json';
+
+interface LabelEntry {
+  readonly key: string;
+  readonly translations: Record<string, string>;
+}
+
+const byKey = new Map((labelsData as readonly LabelEntry[]).map((l) => [l.key, l.translations]));
+
+/**
+ * Resolve a content category to its localized label.
+ *
+ * Categories are stored as canonical keys (e.g. `editorial`) and the
+ * localized text lives in `settings/labels.json`. This is the single
+ * place that turns a key into display text — cards, detail headers and
+ * the filter all go through it so a category renders in the page
+ * language instead of as a raw key.
+ *
+ * Tolerant by design: a key resolves to the language's translation
+ * (falling back to English, then the key); a value that is NOT a known
+ * key — a legacy hand-entered display string — is returned unchanged so
+ * not-yet-migrated content keeps rendering.
+ *
+ * @param category - Category key (canonical) or legacy display value
+ * @param lang - Current page language code
+ * @returns Localized label for display
+ */
+export const getCategoryLabel = (category: string, lang: string): string => {
+  const translations = byKey.get(category);
+  if (!translations) return category;
+  return translations[lang] ?? translations[DEFAULT_LANGUAGE] ?? category;
+};

--- a/src/pages/[lang]/blog/[...slug].astro
+++ b/src/pages/[lang]/blog/[...slug].astro
@@ -12,6 +12,7 @@ import ArticleTocOverlay from '@/features/content/components/ArticleTocOverlay.a
 import ArticleTocSidebar from '@/features/content/components/ArticleTocSidebar.astro';
 import SuggestChangesLink from '@/features/content/components/SuggestChangesLink.astro';
 import { deriveDescription } from '@/features/content/helpers/deriveDescription';
+import { getCategoryLabel } from '@/features/content/helpers/getCategoryLabel';
 import { formatArticleDate } from '@/features/i18n/format-date';
 import MissingTranslation from '@/features/i18n/MissingTranslation.astro';
 import BaseLayout from '@/layouts/BaseLayout.astro';
@@ -123,7 +124,7 @@ const newspaperRef = await (async () => {
       <ArticleTocSidebar headings={headings} label={tocLabel} articleTitle={post.data.title} />
       <div class="container">
         <header class="post-header" id="article-top">
-          <span class="category">{post.data.category}</span>
+          <span class="category">{getCategoryLabel(post.data.category, lang)}</span>
           <h1 itemprop="name">{post.data.title}</h1>
           <p class="post-meta">
             <time datetime={isoDate} itemprop="datePublished">

--- a/src/pages/[lang]/blog/index.astro
+++ b/src/pages/[lang]/blog/index.astro
@@ -42,7 +42,7 @@ const readMore = labels?.data.readMore ?? 'Read more';
       <h1>{heading}</h1>
       {posts.length > 0 ? (
         <>
-          <CategoryFilter categories={categories} allLabel={allCategory} />
+          <CategoryFilter categories={categories} lang={lang} allLabel={allCategory} />
           <div class="grid grid-2">
             {posts.map((post) => (
               <div data-category={post.data.category}>


### PR DESCRIPTION
## Fix #26 — categories now translate by key

The public render printed `post.data.category` **raw**, so a category never translated by language — it showed whatever string was stored. Localized values that had been hand-entered as the category "worked" by accident (the stored text *was* the localized label, but the same text then showed on every language's page); canonical keys would have shown the bare key.

This adds `getCategoryLabel(key, lang)` (reads `settings/labels.json`) and routes every category render through it:
- `PostCard.astro` (cards / home / positions widget)
- blog detail header
- `CategoryFilter.astro` button labels

`data-category` stays the **key** so the client-side filter matching is unchanged — only the visible text is localized.

**Tolerant by design**: an unknown legacy value (not a key) passes through unchanged, so this is safe to deploy *before* the content migration (public-website-content#17). Once that merges, every category resolves to its per-language label.

### Verified
- `bun run build` green (205 pages). Built filter buttons show `data-category="technology"` → label **"Technology"** (key resolved), with legacy values passing through.

Tickets #26 (+ #27 content half in public-website-content#17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
