### PR TITLE
fix(blog): whole card clickable (text dead-zone) + hover lift

### DIFF
--- a/e2e/blog-card-click.pw.ts
+++ b/e2e/blog-card-click.pw.ts
@@ -1,0 +1,39 @@
+import { expect, expectMinCount, test, visit } from '@prometheus/e2e-toolkit';
+
+/**
+ * Blog card click target E2E.
+ *
+ * The whole card is a single link (a stretched `::before` overlay on
+ * the title anchor). Regression guard: clicking the SUMMARY text must
+ * navigate — it previously sat above the overlay (`z-index: 1`) so
+ * clicks on the description were swallowed and did nothing.
+ */
+
+const BLOG = '/ru/blog';
+
+test('clicking a card summary navigates to the article', async ({ page }) => {
+  await visit(page, BLOG);
+
+  const cards = page.locator('.post-card');
+  await expectMinCount(page, cards, 1);
+
+  const firstSummary = cards.first().locator('.post-summary');
+  await expect(firstSummary).toBeVisible();
+
+  await firstSummary.click();
+  await page.waitForURL(/\/ru\/blog\/.+/);
+  expect(new URL(page.url()).pathname).not.toBe(BLOG);
+});
+
+test('clicking the card image navigates to the article', async ({ page }) => {
+  await visit(page, BLOG);
+
+  const card = page
+    .locator('.post-card')
+    .filter({ has: page.locator('.post-image') })
+    .first();
+  await expect(card).toBeVisible();
+
+  await card.locator('.post-image').click();
+  await page.waitForURL(/\/ru\/blog\/.+/);
+});

--- a/src/features/blog/components/PostCard.astro
+++ b/src/features/blog/components/PostCard.astro
@@ -33,8 +33,8 @@ const href = `/${lang}/blog/${slug}`;
       The heading anchor + `::before` overlay pattern: the link is
       attached to the title (so screen readers announce a real
       headline link), and the absolute ::before stretches it over
-      the entire card so any pointer click navigates. The summary
-      keeps `z-index: 1` so users can still select its text.
+      the entire card so a click ANYWHERE — including on the summary
+      text — navigates to the article.
     */}
     {headingLevel === 2
       ? <h2 class="post-title"><a href={href}>{title}</a></h2>
@@ -62,6 +62,9 @@ const href = `/${lang}/blog/${slug}`;
     overflow: hidden;
     padding: 0;
     position: relative;
+    transition:
+      transform var(--transition-base),
+      box-shadow var(--transition-fast);
   }
 
   .post-image {
@@ -122,15 +125,17 @@ const href = `/${lang}/blog/${slug}`;
   }
 
   /*
-   * Stretch the title link over the whole card so any pointer
-   * click navigates to the article. Sits below the summary
-   * (z-index < .post-summary's z-index) so text remains selectable.
+   * Stretch the title link over the whole card so a pointer click
+   * anywhere navigates to the article. As a positioned element it
+   * paints above the in-flow card content (image, category, summary),
+   * so clicks on any of them land on the link — that's the whole
+   * point of a clickable card.
    */
   .post-title a::before {
     content: '';
     position: absolute;
     inset: 0;
-    z-index: 0;
+    z-index: 1;
   }
 
   .post-title a:focus-visible {
@@ -150,8 +155,24 @@ const href = `/${lang}/blog/${slug}`;
     -webkit-box-orient: vertical;
     overflow: hidden;
     min-height: 0;
-    /* Sit above the ::before overlay so the text is selectable. */
-    position: relative;
-    z-index: 1;
+  }
+
+  /*
+   * Hover lift: CpCard already animates the shadow; this adds a gentle
+   * rise so the whole card reads as interactive. Disabled under
+   * reduced-motion.
+   */
+  :global(.post-card:hover) {
+    transform: translateY(-4px);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    :global(.post-card) {
+      transition: box-shadow var(--transition-fast);
+    }
+
+    :global(.post-card:hover) {
+      transform: none;
+    }
   }
 </style>


### PR DESCRIPTION
## Fix: clicking a card on its text did nothing + add hover animation

**Bug.** The whole blog card is a single link (a stretched `::before` overlay on the title anchor). But `.post-summary` was given `position: relative; z-index: 1` (to keep its text selectable), which put it **above** the overlay — so a click that landed on the description text was swallowed and didn't navigate. Clicking the image had the same dead zone.

**Fix.** Raise the link overlay above the in-flow card content (image / category / summary) so a pointer click **anywhere** navigates to the article. The summary is no longer text-selectable, which is the expected behaviour for a fully-clickable card.

**Hover animation.** Added a gentle lift (`translateY(-4px)`) on top of CpCard's existing shadow transition, disabled under `prefers-reduced-motion`.

### Verified
- `bun run build` green.
- New E2E `e2e/blog-card-click.pw.ts` (2 tests, green): clicking the **summary text** and the **image** both navigate to the article — regression guard for the dead-zone bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
