### PR TITLE
test(blog): block comment (eslint) to unblock card-click deploy

### DIFF
--- a/e2e/blog-card-click.pw.ts
+++ b/e2e/blog-card-click.pw.ts
@@ -31,8 +31,10 @@ test('clicking the category badge navigates to the article', async ({ page }) =>
   const cards = page.locator('.post-card');
   await expectMinCount(page, cards, 1);
 
-  // The category badge is on every card (unlike the cover image) and is
-  // non-link content under the overlay — same dead-zone the fix closes.
+  /*
+   * The category badge is on every card (unlike the cover image) and is
+   * non-link content under the overlay — same dead-zone the fix closes.
+   */
   await cards.first().locator('.category').click();
   await page.waitForURL(/\/ru\/blog\/.+/);
 });


### PR DESCRIPTION
The deploy build runs `eslint .`; the two consecutive `//` lines in the card-click test tripped `multiline-comment-style` and failed the build, blocking the PostCard click fix (#135) from shipping. Convert to a block comment. eslint + biome clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)