### PR TITLE
fix(blog): card hover lift animates (was snapping)

### DIFF
--- a/e2e/blog-card-click.pw.ts
+++ b/e2e/blog-card-click.pw.ts
@@ -38,3 +38,23 @@ test('clicking the category badge navigates to the article', async ({ page }) =>
   await cards.first().locator('.category').click();
   await page.waitForURL(/\/ru\/blog\/.+/);
 });
+
+test('card hover lift is animated, not snapped', async ({ page }) => {
+  await visit(page, BLOG);
+
+  const card = page.locator('.post-card').first();
+  await expect(card).toBeVisible();
+
+  /*
+   * CpCard's `.card { transition: box-shadow }` and PostCard's rule are
+   * equal-specificity; if CpCard wins, `transform` drops from the
+   * transition and the lift snaps. Assert the resolved transition keeps
+   * transform with a non-zero duration.
+   */
+  const transition = await card.evaluate((el) => {
+    const s = getComputedStyle(el);
+    return { prop: s.transitionProperty, dur: s.transitionDuration };
+  });
+  expect(transition.prop).toContain('transform');
+  expect(transition.dur).not.toMatch(/^0s(?:,\s*0s)*$/);
+});

--- a/src/features/blog/components/PostCard.astro
+++ b/src/features/blog/components/PostCard.astro
@@ -54,7 +54,13 @@ const href = `/${lang}/blog/${slug}`;
    * the nearest positioned ancestor (body) and intercepts clicks on
    * the category filter buttons rendered above the grid.
    */
-  :global(.post-card) {
+  /*
+   * `.card.post-card` (not `.post-card`) so this transition outranks
+   * CpCard's `.card { transition: box-shadow }` — equal-specificity
+   * single-class rules let CpCard's win on source order, which dropped
+   * `transform` from the transition and made the hover lift snap.
+   */
+  :global(.card.post-card) {
     display: flex;
     flex-direction: column;
     height: 100%;
@@ -162,16 +168,16 @@ const href = `/${lang}/blog/${slug}`;
    * rise so the whole card reads as interactive. Disabled under
    * reduced-motion.
    */
-  :global(.post-card:hover) {
+  :global(.card.post-card:hover) {
     transform: translateY(-4px);
   }
 
   @media (prefers-reduced-motion: reduce) {
-    :global(.post-card) {
+    :global(.card.post-card) {
       transition: box-shadow var(--transition-fast);
     }
 
-    :global(.post-card:hover) {
+    :global(.card.post-card:hover) {
       transform: none;
     }
   }


### PR DESCRIPTION
Follow-up to #135. The hover lift applied but **snapped** — CpCard's `.card { transition: box-shadow }` and the `.post-card` rule are equal-specificity single-class selectors, so CpCard's won on source order and `transform` was never in the transition. Raise to `.card.post-card` so the transform transition wins.

E2E: new guard asserts the resolved `transition-property` includes `transform` with a non-zero duration. Verified locally — `bun run lint` + `bun run build` + 3/3 card e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)