### PR TITLE
fix(header): scroll behaviour survives View Transitions (#28)

### DIFF
--- a/e2e/header-view-transitions.pw.ts
+++ b/e2e/header-view-transitions.pw.ts
@@ -1,0 +1,49 @@
+import { expect, test, visit } from '@prometheus/e2e-toolkit';
+
+/**
+ * Header scroll behaviour must survive a ClientRouter (View
+ * Transitions) navigation. The header's inline script publishes
+ * `--header-height`, which the sticky article TOC and global
+ * `scroll-padding-top` depend on. A menu navigation swaps the header
+ * element; if the script keeps measuring the old detached node it
+ * publishes a stale/zero height and content positioning diverges from
+ * a full reload — which is the correct, server-rendered baseline.
+ */
+
+const headerHeight = (page: import('@playwright/test').Page) =>
+  page.evaluate(() =>
+    getComputedStyle(document.documentElement).getPropertyValue('--header-height').trim(),
+  );
+
+test('--header-height after client nav matches a full reload', async ({ page }) => {
+  await visit(page, '/en/blog');
+  const onListing = await headerHeight(page);
+  expect(Number.parseFloat(onListing)).toBeGreaterThan(0);
+
+  /*
+   * Client-side navigation (no reload) to an article. Wait for the
+   * ClientRouter's page-load (registered BEFORE the click) so the
+   * header script has re-run against the swapped-in header before we
+   * read the height it publishes — the CSS var on <html> survives the
+   * swap and would otherwise still hold the listing's value.
+   */
+  const pageLoaded = page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        document.addEventListener('astro:page-load', () => resolve(), {
+          once: true,
+        });
+      }),
+  );
+  await page.locator('.post-card a').first().click();
+  await page.waitForURL(/\/en\/blog\/.+/);
+  await pageLoaded;
+  const viaMenu = await headerHeight(page);
+
+  // Full reload of the same article — the server-rendered baseline.
+  await page.reload();
+  const viaReload = await headerHeight(page);
+
+  expect(Number.parseFloat(viaReload)).toBeGreaterThan(0);
+  expect(viaMenu).toBe(viaReload);
+});

--- a/src/features/navigation/components/Header.astro
+++ b/src/features/navigation/components/Header.astro
@@ -47,55 +47,88 @@ const { lang } = Astro.props;
    * below the header line could subtract this offset to follow the
    * reveal). Header height is published as `--header-height`.
    */
+  /*
+   * Re-init on every `astro:page-load`, NOT once. With the
+   * ClientRouter a menu navigation swaps the <header> for a fresh
+   * element; a one-shot IIFE would keep operating on the old,
+   * detached node — publishing a stale `--header-height` and
+   * transforming a header nobody can see, so the sticky TOC offset
+   * and scroll positioning diverged from a full reload (the correct,
+   * server-rendered baseline). Mirrors ArticleTocSidebar's pattern.
+   */
   (function () {
-    var header = document.querySelector('[data-scroll-header]');
-    if (!header) return;
-    var lastY = window.scrollY;
-    var offset = 0;
-    var ticking = false;
+    if (window.__headerScrollInit) return;
+    window.__headerScrollInit = true;
 
-    function publishHeight() {
-      var h = header.getBoundingClientRect().height || 60;
-      document.documentElement.style.setProperty(
-        '--header-height',
-        h + 'px'
-      );
-    }
-    function applyOffset(o) {
-      header.style.transform = 'translateY(' + o + 'px)';
-      document.documentElement.style.setProperty(
-        '--header-offset',
-        o + 'px'
-      );
-    }
-    function handleScroll() {
-      ticking = false;
-      var height = header.getBoundingClientRect().height || 60;
-      var y = window.scrollY;
-      var dy = y - lastY;
-      lastY = y;
-      if (y < height) {
-        offset = 0;
-      } else {
-        offset = Math.max(-height, Math.min(0, offset - dy));
+    var cleanups = [];
+
+    function init() {
+      while (cleanups.length > 0) {
+        var c = cleanups.pop();
+        if (c) c();
       }
-      applyOffset(offset);
+
+      var header = document.querySelector('[data-scroll-header]');
+      if (!header) return;
+      var lastY = window.scrollY;
+      var offset = 0;
+      var ticking = false;
+
+      function publishHeight() {
+        var h = header.getBoundingClientRect().height || 60;
+        document.documentElement.style.setProperty(
+          '--header-height',
+          h + 'px'
+        );
+      }
+      function applyOffset(o) {
+        header.style.transform = 'translateY(' + o + 'px)';
+        document.documentElement.style.setProperty(
+          '--header-offset',
+          o + 'px'
+        );
+      }
+      function handleScroll() {
+        ticking = false;
+        var height = header.getBoundingClientRect().height || 60;
+        var y = window.scrollY;
+        var dy = y - lastY;
+        lastY = y;
+        if (y < height) {
+          offset = 0;
+        } else {
+          offset = Math.max(-height, Math.min(0, offset - dy));
+        }
+        applyOffset(offset);
+      }
+
+      publishHeight();
+      applyOffset(0);
+
+      var onScroll = function () {
+        if (ticking) return;
+        ticking = true;
+        window.requestAnimationFrame(handleScroll);
+      };
+      window.addEventListener('scroll', onScroll, { passive: true });
+      cleanups.push(function () {
+        window.removeEventListener('scroll', onScroll);
+      });
+      window.addEventListener('resize', publishHeight);
+      cleanups.push(function () {
+        window.removeEventListener('resize', publishHeight);
+      });
     }
 
-    publishHeight();
-    applyOffset(0);
-    window.addEventListener('scroll', function () {
-      if (ticking) return;
-      ticking = true;
-      window.requestAnimationFrame(handleScroll);
-    }, { passive: true });
-    window.addEventListener('resize', publishHeight);
+    init();
+    /* Neutralise the outgoing header's transform so the VT snapshot
+     * isn't frozen mid-reveal. */
     document.addEventListener('astro:before-swap', function () {
-      offset = 0;
-      lastY = 0;
-      applyOffset(0);
+      var h = document.querySelector('[data-scroll-header]');
+      if (h) h.style.transform = 'translateY(0)';
+      document.documentElement.style.setProperty('--header-offset', '0px');
     });
-    document.addEventListener('astro:after-swap', publishHeight);
+    document.addEventListener('astro:page-load', init);
   })();
 </script>
 


### PR DESCRIPTION
Closes #28. A menu navigation (ClientRouter / View Transitions) swaps the `<header>`; the one-shot inline script kept operating on the old detached node, publishing a stale `--header-height` and breaking hide-on-scroll — so the sticky TOC and scroll positioning diverged from a full reload (the correct, server-rendered baseline). Re-init on every `astro:page-load` with listener cleanup (same pattern `ArticleTocSidebar` already uses), guarded against double-registration.

E2E (`header-view-transitions.pw.ts`): `--header-height` after a client navigation equals a full reload. Verified locally — `bun run lint` + `bun run build` + e2e all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)