### PR TITLE
fix(blog): show newspaper badge from issue articles[] (tickets#29)

### DIFF
--- a/src/features/newspaper/helpers/resolveArticleIssue.test.ts
+++ b/src/features/newspaper/helpers/resolveArticleIssue.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { type IssueArticles, resolveIssueSlug } from './resolveArticleIssue';
+
+const ISSUES: readonly IssueArticles[] = [
+  {
+    id: 'vypusk-14/index.en.md',
+    data: { articles: ['worker-solidarity', 'weekly-chronicle'] },
+  },
+  { id: 'vypusk-14/index.ru.md', data: {} },
+  { id: 'vypusk-13/index.en.md', data: { articles: ['old-news'] } },
+];
+
+describe('resolveIssueSlug', () => {
+  it('prefers the article own newspaper field', () => {
+    expect(resolveIssueSlug(ISSUES, 'anything', 'vypusk-13')).toBe('vypusk-13');
+  });
+
+  it('reverse-looks-up the issue when no newspaper field is set', () => {
+    expect(resolveIssueSlug(ISSUES, 'weekly-chronicle')).toBe('vypusk-14');
+  });
+
+  it('derives the bare slug from a sub-path issue id', () => {
+    expect(resolveIssueSlug(ISSUES, 'old-news')).toBe('vypusk-13');
+  });
+
+  it('returns undefined when no issue references the article', () => {
+    expect(resolveIssueSlug(ISSUES, 'orphan-article')).toBeUndefined();
+  });
+});

--- a/src/features/newspaper/helpers/resolveArticleIssue.ts
+++ b/src/features/newspaper/helpers/resolveArticleIssue.ts
@@ -1,0 +1,31 @@
+const slugFrom = (id: string): string => id.split('/').at(0) ?? id;
+
+/** Minimal shape needed to reverse-link an article to its issue. */
+export interface IssueArticles {
+  readonly id: string;
+  readonly data: {
+    readonly articles?: readonly string[] | undefined;
+  };
+}
+
+/**
+ * Determine the newspaper-issue slug an article belongs to, for the
+ * blog "published in" badge. Prefers the article's own `newspaper`
+ * slug; otherwise falls back to the first issue whose `articles[]`
+ * lists this article — so the badge appears whenever an issue
+ * references the article, even when the article frontmatter omits the
+ * back-link (see tickets#29).
+ * @param issues - Newspaper collection (only id + articles[] are read).
+ * @param articleSlug - The current article's slug.
+ * @param ownNewspaper - The article's own `newspaper` field, if set.
+ * @returns The issue slug, or undefined when nothing references it.
+ */
+export const resolveIssueSlug = (
+  issues: readonly IssueArticles[],
+  articleSlug: string,
+  ownNewspaper?: string,
+): string | undefined => {
+  if (ownNewspaper) return ownNewspaper;
+  const match = issues.find((i) => i.data.articles?.includes(articleSlug));
+  return match ? slugFrom(match.id) : undefined;
+};

--- a/src/pages/[lang]/blog/[...slug].astro
+++ b/src/pages/[lang]/blog/[...slug].astro
@@ -15,6 +15,7 @@ import { deriveDescription } from '@/features/content/helpers/deriveDescription'
 import { getCategoryLabel } from '@/features/content/helpers/getCategoryLabel';
 import { formatArticleDate } from '@/features/i18n/format-date';
 import MissingTranslation from '@/features/i18n/MissingTranslation.astro';
+import { resolveIssueSlug } from '@/features/newspaper/helpers/resolveArticleIssue';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
 /*
@@ -88,19 +89,25 @@ const articleLD = post
     })
   : undefined;
 
+/*
+ * The badge keys off EITHER the article's own `newspaper` slug OR a
+ * reverse lookup across issues whose `articles[]` list this article —
+ * so an article referenced only from the issue side still gets the
+ * "published in" link (see tickets#29).
+ */
 const newspaperRef = await (async () => {
-  if (!post?.data.newspaper) return undefined;
+  if (!post || !slug) return undefined;
   const issues = await getCollection('newspaper');
+  const issueSlug = resolveIssueSlug(issues, slug, post.data.newspaper);
+  if (!issueSlug) return undefined;
   const slugFrom = (id: string) => id.split('/').at(0) ?? id;
   const byKey = new Map(issues.map((i) => [`${i.data.lang}/${slugFrom(i.id)}`, i] as const));
-  const issue =
-    byKey.get(`${lang}/${post.data.newspaper}`) ??
-    byKey.get(`${DEFAULT_LANGUAGE}/${post.data.newspaper}`);
+  const issue = byKey.get(`${lang}/${issueSlug}`) ?? byKey.get(`${DEFAULT_LANGUAGE}/${issueSlug}`);
   if (!issue) return undefined;
   return {
     title: issue.data.title,
     image: issue.data.image,
-    href: `/${lang}/newspaper/${post.data.newspaper}`,
+    href: `/${lang}/newspaper/${issueSlug}`,
   };
 })();
 ---


### PR DESCRIPTION
## Bug

On the blog article detail page, the "published in newspaper" badge did NOT render for some articles even though they were listed in that issue's `articles:` frontmatter array. Reported on `en`.

## Root cause

The badge resolved **only** from the article's own `newspaper:` frontmatter field. The article↔issue link is asymmetric: the newspaper detail page builds its TOC from the issue's `articles[]`, but the badge never reverse-looked-up that array. So an article referenced from the issue side, without its own `newspaper:` field, got the TOC link but no badge.

## Fix

New pure helper `resolveIssueSlug(issues, articleSlug, ownNewspaper?)`: prefers the article's own `newspaper` slug, else falls back to the first issue whose `articles[]` lists the article. The blog page uses it, then resolves the issue (title/image/href) with native collection types as before. Bidirectional link, badge now appears whenever an issue references the article.

## Tests

`resolveArticleIssue.test.ts` — own-field, reverse-lookup, sub-path id slug derivation, and the no-match case. Lint + `astro check` + build green.

Fixes tickets#29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)