### PR TITLE
fix(archive): whole archive card clickable (reuse PostCard)

### DIFF
--- a/src/features/blog/components/PostCard.astro
+++ b/src/features/blog/components/PostCard.astro
@@ -8,11 +8,18 @@ import { getCategoryLabel } from '@/features/content/helpers/getCategoryLabel';
 interface Props {
   title: string;
   description: string;
-  category: string;
+  /** Optional category badge — omitted for sections without categories (e.g. archive). */
+  category?: string | undefined;
   slug: string;
   image?: ImageMetadata | undefined;
   lang: Language;
   headingLevel?: 2 | 3;
+  /**
+   * Target URL. Defaults to the blog post route; pass it explicitly to
+   * reuse this card for other sections (archive, etc.) so they get the
+   * same fully-clickable behaviour instead of a bespoke copy.
+   */
+  href?: string | undefined;
   /**
    * Legacy slot. Kept for backwards-compat with the home page +
    * positions widget call sites, but ignored — the whole card is the
@@ -22,13 +29,13 @@ interface Props {
 }
 
 const { title, description, category, slug, image, lang, headingLevel = 3 } = Astro.props;
-const href = `/${lang}/blog/${slug}`;
+const href = Astro.props.href ?? `/${lang}/blog/${slug}`;
 ---
 
 <CpCard hoverable elevated class="post-card">
   {image && <div class="post-image"><BlogPicture image={image} alt={title} preset="thumbnail" /></div>}
   <div class="post-content">
-    <span class="category">{getCategoryLabel(category, lang)}</span>
+    {category && <span class="category">{getCategoryLabel(category, lang)}</span>}
     {/*
       The heading anchor + `::before` overlay pattern: the link is
       attached to the title (so screen readers announce a real

--- a/src/pages/[lang]/archive/index.astro
+++ b/src/pages/[lang]/archive/index.astro
@@ -1,9 +1,8 @@
 ---
-import CpCard from '@/components/cp/CpCard.astro';
 import { DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES } from '@/config/i18n';
 import { getLabelsData } from '@/config/translations';
 import { getArchiveItems, getArchiveSlug } from '@/features/archive/helpers/getArchiveItems';
-import BlogPicture from '@/features/blog/components/BlogPicture.astro';
+import PostCard from '@/features/blog/components/PostCard.astro';
 import { deriveSummary } from '@/features/content/helpers/deriveSummary';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
@@ -35,20 +34,17 @@ const heading = labels?.data.archiveTitle ?? 'Archive';
           {items.map((item) => {
             const slug = getArchiveSlug(item);
             const summary = item.data.description ?? deriveSummary(item.body) ?? '';
-            const href = `/${lang}/archive/${slug}`;
             return (
               <li>
-                <CpCard hoverable elevated class="archive-card">
-                  {item.data.image && (
-                    <div class="archive-card-image">
-                      <BlogPicture image={item.data.image} alt={item.data.title} preset="thumbnail" />
-                    </div>
-                  )}
-                  <div class="archive-card-body">
-                    <h2 class="archive-card-title"><a href={href}>{item.data.title}</a></h2>
-                    {summary && <p class="archive-card-summary text-secondary">{summary}</p>}
-                  </div>
-                </CpCard>
+                <PostCard
+                  title={item.data.title}
+                  description={summary}
+                  slug={slug}
+                  image={item.data.image}
+                  lang={lang}
+                  headingLevel={2}
+                  href={`/${lang}/archive/${slug}`}
+                />
               </li>
             );
           })}
@@ -86,75 +82,6 @@ const heading = labels?.data.archiveTitle ?? 'Archive';
     .archive-grid {
       grid-template-columns: repeat(3, 1fr);
     }
-  }
-
-  :global(.archive-card) {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    padding: 0;
-    overflow: hidden;
-    position: relative;
-  }
-
-  .archive-card-image {
-    width: 100%;
-    height: clamp(120px, 30vw, 180px);
-    overflow: hidden;
-    flex-shrink: 0;
-  }
-
-  .archive-card-image :global(img) {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-  }
-
-  .archive-card-body {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-xs);
-    padding: var(--spacing-md);
-    flex: 1;
-    min-width: 0;
-  }
-
-  .archive-card-title {
-    font-size: 1.125rem;
-    font-weight: 600;
-    line-height: 1.3;
-    margin: 0;
-  }
-
-  .archive-card-title a {
-    color: inherit;
-    text-decoration: none;
-  }
-
-  .archive-card-title a::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    z-index: 0;
-  }
-
-  .archive-card-title a:focus-visible {
-    outline: 2px solid var(--color-focus-ring);
-    outline-offset: 4px;
-    border-radius: var(--radius-sm);
-  }
-
-  .archive-card-summary {
-    margin: 0;
-    font-size: 0.9rem;
-    line-height: 1.5;
-    display: -webkit-box;
-    -webkit-line-clamp: 4;
-    line-clamp: 4;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    position: relative;
-    z-index: 1;
   }
 
   .empty-state {


### PR DESCRIPTION
## What
Archive listing cards now reuse the already-fixed `PostCard` (with optional `category`/`href`) instead of a bespoke copy.

## Why
The bespoke archive card reimplemented the clickable-card overlay with the z-index inverted — the summary (`position:relative;z-index:1`) sat above the title-link `::before` overlay (`z-index:0`), so only the title/image were clickable. Reusing PostCard gives the whole card a single fully-clickable overlay from one source of truth. Verified on dev.comprom.org: the shipped CSS has `.post-title a::before{...z-index:1}` stretching over the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)