### PR TITLE
fix(archive): clean viewer file view, finger-swipe animation, no dead fullscreen on mobile

### DIFF
--- a/src/features/archive/components/ArchiveGallery.astro
+++ b/src/features/archive/components/ArchiveGallery.astro
@@ -211,13 +211,14 @@ const imageOf = (asset: ArchiveAsset): ImageMetadata | undefined =>
     margin: 0;
     padding: 0;
     border: none;
-    background: rgb(0 0 0 / 0.92);
+    /* Near-opaque so the page never bleeds through the viewer. */
+    background: rgb(8 8 8 / 0.985);
     color: #fff;
     overflow: hidden;
   }
 
   .archive-viewer::backdrop {
-    background: rgb(0 0 0 / 0.8);
+    background: rgb(0 0 0 / 0.85);
   }
 
   .archive-viewer[open] {
@@ -299,6 +300,30 @@ const imageOf = (asset: ArchiveAsset): ImageMetadata | undefined =>
     right: var(--spacing-sm);
   }
 
+  /* The dragged item (image or file pictogram) — follows the finger on
+   * swipe, snaps/slides on release. Arrows stay fixed (absolute). */
+  .archive-viewer-content {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    touch-action: pan-y;
+    will-change: transform;
+  }
+
+  .archive-viewer-content.is-animating {
+    transition:
+      transform var(--transition-base, 0.25s) ease,
+      opacity var(--transition-base, 0.25s) ease;
+  }
+
+  .archive-viewer[data-reduced-motion] .archive-viewer-content.is-animating {
+    transition: none;
+  }
+
   .archive-viewer-image {
     max-width: 100%;
     max-height: 100%;
@@ -306,6 +331,13 @@ const imageOf = (asset: ArchiveAsset): ImageMetadata | undefined =>
     user-select: none;
     -webkit-user-select: none;
     touch-action: pan-y;
+  }
+
+  /* The global reset `img { display: block }` (author origin) defeats the
+   * UA `[hidden]` rule, so a srcless image stayed visible as a broken box
+   * next to the file panel. Re-hide it from the author layer. */
+  .archive-viewer-image[hidden] {
+    display: none;
   }
 
   /* Loading spinner shown while the (optimised) image decodes, so a

--- a/src/features/archive/scripts/archive-lightbox.ts
+++ b/src/features/archive/scripts/archive-lightbox.ts
@@ -13,10 +13,11 @@
  * Accessibility: native `dialog.showModal()` provides the focus trap;
  * we restore focus to the invoking tile on close, announce the current
  * position via a polite live region, and wire ArrowLeft/Right + Escape.
- * Touch swipe (pointer delta) mirrors prev/next.
+ * Touch drag follows the finger and snaps/slides on release.
  */
 
-const SWIPE_THRESHOLD = 50;
+const SWIPE_THRESHOLD = 60;
+const TAP_SLOP = 6;
 
 interface GalleryItem {
   readonly kind: 'image' | 'file';
@@ -31,6 +32,7 @@ interface GalleryItem {
 interface Viewer {
   readonly dialog: HTMLDialogElement;
   readonly stage: HTMLElement;
+  readonly content: HTMLElement;
   readonly image: HTMLImageElement;
   readonly filePanel: HTMLElement;
   readonly fileExt: HTMLElement;
@@ -55,6 +57,14 @@ const prefersReducedMotion = (): boolean =>
 
 const fullscreenSupported = (): boolean =>
   document.fullscreenEnabled === true && typeof Element.prototype.requestFullscreen === 'function';
+
+/*
+ * Fullscreen is pointless on touch devices — the modal already fills the
+ * viewport and the Fullscreen API is flaky/absent there. Show the toggle
+ * only with a fine pointer (desktop), so mobile never gets a dead button.
+ */
+const fullscreenUseful = (): boolean =>
+  fullscreenSupported() && globalThis.matchMedia?.('(pointer: coarse)').matches !== true;
 
 const makeButton = (className: string, label: string, glyph: string): HTMLButtonElement => {
   const btn = document.createElement('button');
@@ -120,11 +130,10 @@ const buildViewer = (): Viewer => {
   const prevBtn = makeButton('archive-viewer-prev', 'Previous file', '‹');
   const nextBtn = makeButton('archive-viewer-next', 'Next file', '›');
   const fullscreenBtn = makeButton('archive-viewer-fullscreen', 'Toggle fullscreen', '⛶');
-  if (!fullscreenSupported()) fullscreenBtn.hidden = true;
 
   const bar = document.createElement('div');
   bar.className = 'archive-viewer-bar';
-  bar.append(counter, download, fullscreenBtn, closeBtn);
+  bar.append(counter, download, ...(fullscreenUseful() ? [fullscreenBtn] : []), closeBtn);
 
   const {
     panel: filePanel,
@@ -133,9 +142,13 @@ const buildViewer = (): Viewer => {
     download: fileDownload,
   } = buildFilePanel();
 
+  const content = document.createElement('div');
+  content.className = 'archive-viewer-content';
+  content.append(image, filePanel);
+
   const stage = document.createElement('figure');
   stage.className = 'archive-viewer-stage';
-  stage.append(prevBtn, image, filePanel, nextBtn);
+  stage.append(prevBtn, content, nextBtn);
 
   dialog.append(bar, stage, live);
   document.body.append(dialog);
@@ -145,6 +158,7 @@ const buildViewer = (): Viewer => {
   return {
     dialog,
     stage,
+    content,
     image,
     filePanel,
     fileExt,
@@ -179,6 +193,7 @@ const renderFile = (v: Viewer, item: GalleryItem): void => {
   v.stage.classList.remove('is-loading');
   v.image.hidden = true;
   v.image.removeAttribute('src');
+  v.image.alt = '';
   v.filePanel.hidden = false;
   v.fileExt.textContent = item.ext;
   v.fileName.textContent = item.name;
@@ -207,6 +222,11 @@ const go = (delta: number): void => {
   if (next < 0 || next >= session.items.length) return;
   session.index = next;
   if (viewer) render(viewer);
+};
+
+const canGo = (delta: number): boolean => {
+  const next = session.index + delta;
+  return next >= 0 && next < session.items.length;
 };
 
 const exitFullscreen = (): void => {
@@ -239,18 +259,62 @@ const onKeydown = (event: KeyboardEvent): void => {
   }
 };
 
-const wireTouch = (v: Viewer): void => {
+const setTransform = (v: Viewer, x: number, animate: boolean): void => {
+  v.content.classList.toggle('is-animating', animate);
+  v.content.style.transform = x === 0 ? '' : `translateX(${x}px)`;
+};
+
+/*
+ * Slide the current item out, swap to the neighbour, then slide it in
+ * from the opposite edge. Reduced-motion users get an instant swap.
+ */
+const commitSwipe = (v: Viewer, dir: number): void => {
+  const width = v.content.clientWidth || globalThis.innerWidth || 1;
+  if (prefersReducedMotion()) {
+    go(dir);
+    setTransform(v, 0, false);
+    return;
+  }
+  setTransform(v, dir > 0 ? -width : width, true);
+  v.content.addEventListener(
+    'transitionend',
+    () => {
+      go(dir);
+      setTransform(v, dir > 0 ? width : -width, false);
+      requestAnimationFrame(() => setTransform(v, 0, true));
+    },
+    { once: true },
+  );
+};
+
+const wireDrag = (v: Viewer): void => {
   let startX: number | undefined;
-  v.image.addEventListener('pointerdown', (e: PointerEvent) => {
+  let dx = 0;
+  v.content.addEventListener('pointerdown', (e: PointerEvent) => {
+    if (e.pointerType === 'mouse' && e.button !== 0) return;
     startX = e.clientX;
+    dx = 0;
+    v.content.classList.remove('is-animating');
   });
-  v.image.addEventListener('pointerup', (e: PointerEvent) => {
+  v.content.addEventListener('pointermove', (e: PointerEvent) => {
     if (startX === undefined) return;
-    const deltaX = e.clientX - startX;
-    startX = undefined;
-    if (Math.abs(deltaX) < SWIPE_THRESHOLD) return;
-    go(deltaX < 0 ? 1 : -1);
+    dx = e.clientX - startX;
+    /* Rubber-band at the ends so there is nothing to swipe past. */
+    const resisted = canGo(dx < 0 ? 1 : -1) ? dx : dx * 0.3;
+    setTransform(v, resisted, false);
   });
+  const end = (): void => {
+    if (startX === undefined) return;
+    startX = undefined;
+    const dir = dx < 0 ? 1 : -1;
+    if (Math.abs(dx) >= SWIPE_THRESHOLD && canGo(dir)) {
+      commitSwipe(v, dir);
+    } else if (Math.abs(dx) > TAP_SLOP) {
+      setTransform(v, 0, true);
+    }
+  };
+  v.content.addEventListener('pointerup', end);
+  v.content.addEventListener('pointercancel', end);
 };
 
 const open = (items: ReadonlyArray<GalleryItem>, index: number): void => {
@@ -258,6 +322,7 @@ const open = (items: ReadonlyArray<GalleryItem>, index: number): void => {
   session.items = items;
   session.index = index;
   session.invoker = items[index]?.trigger;
+  setTransform(v, 0, false);
   render(v);
   v.dialog.showModal();
 };
@@ -289,7 +354,7 @@ const wireViewerOnce = (v: Viewer): void => {
     exitFullscreen();
     session.invoker?.focus();
   });
-  wireTouch(v);
+  wireDrag(v);
   document.addEventListener('keydown', onKeydown);
 };
 


### PR DESCRIPTION
Follow-up polish on the unified archive viewer (#143/#144/#145), from on-device feedback. Verified at 390px with Playwright + on dev.comprom.org.

- **Broken file view** — the viewer image stayed visible (broken, srcless) beside the file panel because the global `img{display:block}` reset (author origin) overrides the UA `[hidden]` rule. Re-hidden from the author layer + alt cleared on file render; backdrop is now near-opaque so the page never bleeds through.
- **Finger-following swipe** — a `.archive-viewer-content` wrapper is dragged by pointer delta (rubber-band at the ends) and slides to the neighbour or snaps back on release; honours `prefers-reduced-motion`.
- **Fullscreen on mobile** — the toggle is shown only with a fine pointer; on touch the modal already fills the viewport, so the dead button is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)