### PR TITLE
feat(archive): URL-driven viewer + inline svg/txt/pdf/docx readers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
         "@astrojs/rss": "^4.0.18",
         "@astrojs/sitemap": "^3.7.2",
         "astro": "^5.17.1",
+        "docx-preview": "^0.3.7",
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.6",
@@ -771,6 +772,8 @@
 
     "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
 
+    "docx-preview": ["docx-preview@0.3.7", "", { "dependencies": { "jszip": ">=3.0.0" } }, "sha512-Lav69CTA/IYZPJTsKH7oYeoZjyg96N0wEJMNslGJnZJ+dMUZK85Lt5ASC79yUlD48ecWjuv+rkcmFt6EVPV0Xg=="],
+
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
     "dom-walk": ["dom-walk@0.1.2", "", {}, "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="],
@@ -1067,6 +1070,8 @@
 
     "is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
 
+    "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
+
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "isomorphic-fetch": ["isomorphic-fetch@3.0.0", "", { "dependencies": { "node-fetch": "^2.6.1", "whatwg-fetch": "^3.4.1" } }, "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA=="],
@@ -1099,6 +1104,8 @@
 
     "jsprim": ["jsprim@1.4.2", "", { "dependencies": { "assert-plus": "1.0.0", "extsprintf": "1.3.0", "json-schema": "0.4.0", "verror": "1.10.0" } }, "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw=="],
 
+    "jszip": ["jszip@3.10.1", "", { "dependencies": { "lie": "~3.3.0", "pako": "~1.0.2", "readable-stream": "~2.3.6", "setimmediate": "^1.0.5" } }, "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g=="],
+
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
@@ -1107,7 +1114,7 @@
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
-    "lie": ["lie@3.1.1", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw=="],
+    "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
 
     "lighthouse": ["lighthouse@13.0.3", "", { "dependencies": { "@paulirish/trace_engine": "0.0.61", "@sentry/node": "^9.28.1", "axe-core": "^4.11.0", "chrome-launcher": "^1.2.1", "configstore": "^7.0.0", "csp_evaluator": "1.1.5", "devtools-protocol": "0.0.1527314", "enquirer": "^2.3.6", "http-link-header": "^1.1.1", "intl-messageformat": "^10.5.3", "jpeg-js": "^0.4.4", "js-library-detector": "^6.7.0", "lighthouse-logger": "^2.0.2", "lighthouse-stack-packs": "1.12.3", "lodash-es": "^4.17.21", "lookup-closest-locale": "6.2.0", "open": "^8.4.0", "puppeteer-core": "^24.23.0", "robots-parser": "^3.0.1", "speedline-core": "^1.4.3", "third-party-web": "^0.27.0", "tldts-icann": "^7.0.17", "ws": "^7.0.0", "yargs": "^17.3.1", "yargs-parser": "^21.0.0" }, "bin": { "lighthouse": "cli/index.js", "chrome-debug": "core/scripts/manual-chrome-launcher.js", "smokehouse": "cli/test/smokehouse/frontends/smokehouse-bin.js" } }, "sha512-mEHAQV3nn4fB+3FDapye+KGeeE4V8FERgbCFegKT7HxqDVGWVOM/BoH9Qof71fzVYVMLIiGnDsnWRrH0sQ9o4Q=="],
 
@@ -1345,6 +1352,8 @@
 
     "package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
 
+    "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
+
     "parse-bmfont-ascii": ["parse-bmfont-ascii@1.0.6", "", {}, "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA=="],
 
     "parse-bmfont-binary": ["parse-bmfont-binary@1.0.6", "", {}, "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA=="],
@@ -1435,6 +1444,8 @@
 
     "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
 
+    "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
+
     "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
 
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
@@ -1466,6 +1477,8 @@
     "raw-body": ["raw-body@2.5.3", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "unpipe": "~1.0.0" } }, "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA=="],
 
     "read-chunk": ["read-chunk@1.0.1", "", {}, "sha512-5NLTTdX45dKFtG8CX5pKmvS9V5u9wBE+gkklN7xhDuhq3pA2I4O7ALfKxosCMcLHOhkxj6GNacZhfXtp5nlCdg=="],
+
+    "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
@@ -1551,6 +1564,8 @@
 
     "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
 
+    "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
+
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
@@ -1618,6 +1633,8 @@
     "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
@@ -1989,6 +2006,8 @@
 
     "lighthouse-logger/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
+    "localforage/lie": ["lie@3.1.1", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw=="],
+
     "log-update/ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
     "log-update/cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
@@ -2011,6 +2030,8 @@
 
     "puppeteer-core/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
+    "readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
     "request/qs": ["qs@6.5.5", "", {}, "sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ=="],
 
     "request/uuid": ["uuid@3.4.0", "", { "bin": { "uuid": "./bin/uuid" } }, "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="],
@@ -2030,6 +2051,8 @@
     "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
     "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "string_decoder/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "svgo/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.2",
-    "astro": "^5.17.1"
+    "astro": "^5.17.1",
+    "docx-preview": "^0.3.7"
   },
   "packageManager": "bun@latest",
   "devDependencies": {

--- a/src/features/archive/components/ArchiveGallery.astro
+++ b/src/features/archive/components/ArchiveGallery.astro
@@ -90,8 +90,10 @@ const imageOf = (asset: ArchiveAsset): ImageMetadata | undefined =>
 <script>
   import { initArchiveLightbox } from '@/features/archive/scripts/archive-lightbox';
 
-  initArchiveLightbox();
-  document.addEventListener('astro:after-swap', initArchiveLightbox);
+  // `astro:page-load` fires on the initial load AND after every view
+  // transition, always against the live DOM — so the viewer is never
+  // built against a staging document that gets swapped away.
+  document.addEventListener('astro:page-load', initArchiveLightbox);
 </script>
 
 <style>
@@ -300,8 +302,9 @@ const imageOf = (asset: ArchiveAsset): ImageMetadata | undefined =>
     right: var(--spacing-sm);
   }
 
-  /* The dragged item (image or file pictogram) — follows the finger on
-   * swipe, snaps/slides on release. Arrows stay fixed (absolute). */
+  /* Holds the current item (image or file pictogram). Named so prev/next
+   * navigation cross-fades via the View Transitions API. Arrows stay
+   * fixed (absolute). */
   .archive-viewer-content {
     position: relative;
     display: flex;
@@ -310,18 +313,53 @@ const imageOf = (asset: ArchiveAsset): ImageMetadata | undefined =>
     width: 100%;
     height: 100%;
     min-height: 0;
-    touch-action: pan-y;
-    will-change: transform;
+    view-transition-name: archive-viewer-pane;
   }
 
-  .archive-viewer-content.is-animating {
-    transition:
-      transform var(--transition-base, 0.25s) ease,
-      opacity var(--transition-base, 0.25s) ease;
+  /* Directional slide on left/right navigation; the nav direction is set
+   * on <html> just for the duration of the transition. */
+  @keyframes archive-vt-out-left {
+    to {
+      transform: translateX(-6%);
+      opacity: 0;
+    }
   }
 
-  .archive-viewer[data-reduced-motion] .archive-viewer-content.is-animating {
-    transition: none;
+  @keyframes archive-vt-in-right {
+    from {
+      transform: translateX(6%);
+      opacity: 0;
+    }
+  }
+
+  @keyframes archive-vt-out-right {
+    to {
+      transform: translateX(6%);
+      opacity: 0;
+    }
+  }
+
+  @keyframes archive-vt-in-left {
+    from {
+      transform: translateX(-6%);
+      opacity: 0;
+    }
+  }
+
+  :root[data-archive-nav='next']::view-transition-old(archive-viewer-pane) {
+    animation: archive-vt-out-left 0.22s ease both;
+  }
+
+  :root[data-archive-nav='next']::view-transition-new(archive-viewer-pane) {
+    animation: archive-vt-in-right 0.22s ease both;
+  }
+
+  :root[data-archive-nav='prev']::view-transition-old(archive-viewer-pane) {
+    animation: archive-vt-out-right 0.22s ease both;
+  }
+
+  :root[data-archive-nav='prev']::view-transition-new(archive-viewer-pane) {
+    animation: archive-vt-in-left 0.22s ease both;
   }
 
   .archive-viewer-image {
@@ -335,9 +373,47 @@ const imageOf = (asset: ArchiveAsset): ImageMetadata | undefined =>
 
   /* The global reset `img { display: block }` (author origin) defeats the
    * UA `[hidden]` rule, so a srcless image stayed visible as a broken box
-   * next to the file panel. Re-hide it from the author layer. */
-  .archive-viewer-image[hidden] {
+   * next to the file panel. Re-hide it (and the doc pane, which we set to
+   * flex) from the author layer. */
+  .archive-viewer-image[hidden],
+  .archive-viewer-doc[hidden] {
     display: none;
+  }
+
+  /* Inline document pane (text / pdf / docx), rendered by the lazily
+   * imported archive-renderers chunk. Scrolls within the viewer. */
+  .archive-viewer-doc {
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+    background: #f4f4f4;
+  }
+
+  .archive-doc-text {
+    margin: 0;
+    padding: var(--spacing-lg);
+    min-height: 100%;
+    box-sizing: border-box;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    font:
+      0.875rem / 1.6 ui-monospace,
+      'SF Mono',
+      monospace;
+    color: #1a1a1a;
+  }
+
+  .archive-doc-frame {
+    width: 100%;
+    height: 100%;
+    border: 0;
+    background: #fff;
+  }
+
+  .archive-doc-docx {
+    width: 100%;
+    color: #111;
   }
 
   /* Loading spinner shown while the (optimised) image decodes, so a

--- a/src/features/archive/scripts/archive-lightbox.ts
+++ b/src/features/archive/scripts/archive-lightbox.ts
@@ -5,19 +5,40 @@
  * tiles carry `data-kind` (image|file), `data-name`, `data-download`
  * and, for images, `data-full` (optimised large image URL). Clicking a
  * tile opens a single shared <dialog> overlay that navigates across the
- * whole gallery — images render full, any other file renders a
- * pictogram + filename + download (R2.5), so there is no image/file
- * divide and per-type previewers can be added later without changing
- * call sites.
+ * whole gallery.
+ *
+ * Rendering: images render inline; text / pdf / docx render inline via
+ * the lazily-imported `archive-renderers` chunk (heavy code arrives only
+ * on an archive page, and only when a document is opened — a spinner
+ * covers the load); anything else falls back to a pictogram + download.
+ *
+ * URL-driven: the open item lives in the `#asset=<name>` hash, so the
+ * view is deep-linkable and the Back button closes it.
  *
  * Accessibility: native `dialog.showModal()` provides the focus trap;
  * we restore focus to the invoking tile on close, announce the current
  * position via a polite live region, and wire ArrowLeft/Right + Escape.
- * Touch drag follows the finger and snaps/slides on release.
+ * A horizontal flick navigates; the visual is a View Transition.
  */
 
+import type { DocKind } from './archive-renderers';
+
 const SWIPE_THRESHOLD = 60;
-const TAP_SLOP = 6;
+const HASH_KEY = 'asset';
+const TEXT_EXTS: ReadonlySet<string> = new Set([
+  'txt',
+  'md',
+  'markdown',
+  'csv',
+  'tsv',
+  'log',
+  'json',
+  'xml',
+  'yml',
+  'yaml',
+]);
+
+type ViewerMode = 'image' | DocKind | 'other';
 
 interface GalleryItem {
   readonly kind: 'image' | 'file';
@@ -34,6 +55,7 @@ interface Viewer {
   readonly stage: HTMLElement;
   readonly content: HTMLElement;
   readonly image: HTMLImageElement;
+  readonly doc: HTMLElement;
   readonly filePanel: HTMLElement;
   readonly fileExt: HTMLElement;
   readonly fileName: HTMLElement;
@@ -65,6 +87,15 @@ const fullscreenSupported = (): boolean =>
  */
 const fullscreenUseful = (): boolean =>
   fullscreenSupported() && globalThis.matchMedia?.('(pointer: coarse)').matches !== true;
+
+const viewerMode = (item: GalleryItem): ViewerMode => {
+  if (item.kind === 'image') return 'image';
+  const ext = item.ext.toLowerCase();
+  if (ext === 'pdf') return 'pdf';
+  if (ext === 'docx') return 'docx';
+  if (TEXT_EXTS.has(ext)) return 'text';
+  return 'other';
+};
 
 const makeButton = (className: string, label: string, glyph: string): HTMLButtonElement => {
   const btn = document.createElement('button');
@@ -117,6 +148,10 @@ const buildViewer = (): Viewer => {
   image.alt = '';
   image.decoding = 'async';
 
+  const doc = document.createElement('div');
+  doc.className = 'archive-viewer-doc';
+  doc.hidden = true;
+
   const counter = document.createElement('span');
   counter.className = 'archive-viewer-counter';
   counter.setAttribute('aria-hidden', 'true');
@@ -144,7 +179,7 @@ const buildViewer = (): Viewer => {
 
   const content = document.createElement('div');
   content.className = 'archive-viewer-content';
-  content.append(image, filePanel);
+  content.append(image, doc, filePanel);
 
   const stage = document.createElement('figure');
   stage.className = 'archive-viewer-stage';
@@ -160,6 +195,7 @@ const buildViewer = (): Viewer => {
     stage,
     content,
     image,
+    doc,
     filePanel,
     fileExt,
     fileName,
@@ -174,30 +210,67 @@ const buildViewer = (): Viewer => {
 };
 
 let viewer: Viewer | undefined;
+let activeItems: ReadonlyArray<GalleryItem> = [];
+let renderToken = 0;
+let programmaticClose = false;
 const session: Session = { items: [], index: 0, invoker: undefined };
+
+let renderersPromise: Promise<typeof import('./archive-renderers')> | undefined;
+const loadRenderers = (): Promise<typeof import('./archive-renderers')> => {
+  renderersPromise ??= import('./archive-renderers');
+  return renderersPromise;
+};
 
 const getViewer = (): Viewer => {
   if (!viewer) viewer = buildViewer();
+  /*
+   * The module persists across ClientRouter view transitions, but the
+   * <body> we appended to is swapped away — re-attach to the live body
+   * so showModal() never throws "element is not in a Document".
+   */
+  if (!viewer.dialog.isConnected) document.body.append(viewer.dialog);
   return viewer;
 };
 
-const renderImage = (v: Viewer, item: GalleryItem): void => {
-  v.filePanel.hidden = true;
-  v.image.hidden = false;
+const showMode = (v: Viewer, mode: ViewerMode): void => {
+  v.image.hidden = mode !== 'image';
+  v.filePanel.hidden = mode !== 'other';
+  v.doc.hidden = mode === 'image' || mode === 'other';
+};
+
+const applyImage = (v: Viewer, item: GalleryItem): void => {
   v.stage.classList.add('is-loading');
   v.image.src = item.full ?? item.download;
   v.image.alt = item.name;
 };
 
-const renderFile = (v: Viewer, item: GalleryItem): void => {
+const applyFile = (v: Viewer, item: GalleryItem): void => {
   v.stage.classList.remove('is-loading');
-  v.image.hidden = true;
   v.image.removeAttribute('src');
   v.image.alt = '';
-  v.filePanel.hidden = false;
   v.fileExt.textContent = item.ext;
   v.fileName.textContent = item.name;
   v.fileDownload.href = item.download;
+};
+
+const applyDoc = (v: Viewer, item: GalleryItem, kind: DocKind): void => {
+  const token = ++renderToken;
+  v.image.removeAttribute('src');
+  v.doc.replaceChildren();
+  v.stage.classList.add('is-loading');
+  loadRenderers()
+    .then((mod) =>
+      token === renderToken ? mod.renderDoc(kind, item.download, item.name, v.doc) : undefined,
+    )
+    .then(() => {
+      if (token === renderToken) v.stage.classList.remove('is-loading');
+    })
+    .catch(() => {
+      if (token !== renderToken) return;
+      v.stage.classList.remove('is-loading');
+      showMode(v, 'other');
+      applyFile(v, item);
+    });
 };
 
 const render = (v: Viewer): void => {
@@ -210,11 +283,11 @@ const render = (v: Viewer): void => {
   v.prevBtn.disabled = session.index === 0;
   v.nextBtn.disabled = session.index === total - 1;
   v.download.href = item.download;
-  if (item.kind === 'image') {
-    renderImage(v, item);
-  } else {
-    renderFile(v, item);
-  }
+  const mode = viewerMode(item);
+  showMode(v, mode);
+  if (mode === 'image') applyImage(v, item);
+  else if (mode === 'other') applyFile(v, item);
+  else applyDoc(v, item, mode);
 };
 
 const go = (delta: number): void => {
@@ -227,6 +300,41 @@ const go = (delta: number): void => {
 const canGo = (delta: number): boolean => {
   const next = session.index + delta;
   return next >= 0 && next < session.items.length;
+};
+
+const setHash = (name: string, push: boolean): void => {
+  const url = `#${HASH_KEY}=${encodeURIComponent(name)}`;
+  if (push) history.pushState(null, '', url);
+  else history.replaceState(null, '', url);
+};
+
+const assetFromHash = (): string | undefined => {
+  const match = location.hash.match(/(?:^#|&)asset=([^&]+)/);
+  return match ? decodeURIComponent(match[1] ?? '') : undefined;
+};
+
+/*
+ * Move to a neighbouring item through the View Transitions API so any
+ * left/right change cross-fades / slides (direction set on <html> for
+ * the duration). Browsers without the API — or reduced-motion — get an
+ * instant swap. The open item is mirrored into the URL hash.
+ */
+const navigate = (delta: number): void => {
+  if (!canGo(delta)) return;
+  const target = session.items[session.index + delta]?.name;
+  const run = (): void => {
+    go(delta);
+    if (target !== undefined) setHash(target, false);
+  };
+  if (prefersReducedMotion() || typeof document.startViewTransition !== 'function') {
+    run();
+    return;
+  }
+  document.documentElement.setAttribute('data-archive-nav', delta > 0 ? 'next' : 'prev');
+  const transition = document.startViewTransition(run);
+  transition.finished.finally(() => {
+    document.documentElement.removeAttribute('data-archive-nav');
+  });
 };
 
 const exitFullscreen = (): void => {
@@ -248,10 +356,10 @@ const onKeydown = (event: KeyboardEvent): void => {
   if (!viewer?.dialog.open) return;
   if (event.key === 'ArrowLeft') {
     event.preventDefault();
-    go(-1);
+    navigate(-1);
   } else if (event.key === 'ArrowRight') {
     event.preventDefault();
-    go(1);
+    navigate(1);
   } else if (event.key === 'Escape' && document.fullscreenElement) {
     /* Exit fullscreen first; a second Escape closes the dialog. */
     event.preventDefault();
@@ -259,72 +367,54 @@ const onKeydown = (event: KeyboardEvent): void => {
   }
 };
 
-const setTransform = (v: Viewer, x: number, animate: boolean): void => {
-  v.content.classList.toggle('is-animating', animate);
-  v.content.style.transform = x === 0 ? '' : `translateX(${x}px)`;
-};
-
 /*
- * Slide the current item out, swap to the neighbour, then slide it in
- * from the opposite edge. Reduced-motion users get an instant swap.
+ * A horizontal flick past the threshold navigates; the visual is the
+ * shared View Transition, not a finger-tracking drag.
  */
-const commitSwipe = (v: Viewer, dir: number): void => {
-  const width = v.content.clientWidth || globalThis.innerWidth || 1;
-  if (prefersReducedMotion()) {
-    go(dir);
-    setTransform(v, 0, false);
-    return;
-  }
-  setTransform(v, dir > 0 ? -width : width, true);
-  v.content.addEventListener(
-    'transitionend',
-    () => {
-      go(dir);
-      setTransform(v, dir > 0 ? width : -width, false);
-      requestAnimationFrame(() => setTransform(v, 0, true));
-    },
-    { once: true },
-  );
-};
-
-const wireDrag = (v: Viewer): void => {
+const wireSwipe = (v: Viewer): void => {
   let startX: number | undefined;
-  let dx = 0;
   v.content.addEventListener('pointerdown', (e: PointerEvent) => {
-    if (e.pointerType === 'mouse' && e.button !== 0) return;
     startX = e.clientX;
-    dx = 0;
-    v.content.classList.remove('is-animating');
   });
-  v.content.addEventListener('pointermove', (e: PointerEvent) => {
-    if (startX === undefined) return;
-    dx = e.clientX - startX;
-    /* Rubber-band at the ends so there is nothing to swipe past. */
-    const resisted = canGo(dx < 0 ? 1 : -1) ? dx : dx * 0.3;
-    setTransform(v, resisted, false);
-  });
-  const end = (): void => {
-    if (startX === undefined) return;
+  v.content.addEventListener('pointercancel', () => {
     startX = undefined;
-    const dir = dx < 0 ? 1 : -1;
-    if (Math.abs(dx) >= SWIPE_THRESHOLD && canGo(dir)) {
-      commitSwipe(v, dir);
-    } else if (Math.abs(dx) > TAP_SLOP) {
-      setTransform(v, 0, true);
-    }
-  };
-  v.content.addEventListener('pointerup', end);
-  v.content.addEventListener('pointercancel', end);
+  });
+  v.content.addEventListener('pointerup', (e: PointerEvent) => {
+    if (startX === undefined) return;
+    const dx = e.clientX - startX;
+    startX = undefined;
+    if (Math.abs(dx) < SWIPE_THRESHOLD) return;
+    navigate(dx < 0 ? 1 : -1);
+  });
 };
 
-const open = (items: ReadonlyArray<GalleryItem>, index: number): void => {
+const open = (items: ReadonlyArray<GalleryItem>, index: number, fromUrl: boolean): void => {
   const v = getViewer();
   session.items = items;
   session.index = index;
   session.invoker = items[index]?.trigger;
-  setTransform(v, 0, false);
   render(v);
-  v.dialog.showModal();
+  if (!v.dialog.open) v.dialog.showModal();
+  const name = items[index]?.name;
+  if (!fromUrl && name !== undefined) setHash(name, true);
+};
+
+const onPopState = (): void => {
+  const name = assetFromHash();
+  const v = getViewer();
+  if (name !== undefined) {
+    const index = activeItems.findIndex((item) => item.name === name);
+    if (index < 0) return;
+    if (!v.dialog.open) open(activeItems, index, true);
+    else if (index !== session.index) {
+      session.index = index;
+      render(v);
+    }
+  } else if (v.dialog.open) {
+    programmaticClose = true;
+    v.dialog.close();
+    programmaticClose = false;
+  }
 };
 
 const collectItems = (gallery: HTMLElement): ReadonlyArray<GalleryItem> =>
@@ -345,17 +435,19 @@ const collectItems = (gallery: HTMLElement): ReadonlyArray<GalleryItem> =>
   });
 
 const wireViewerOnce = (v: Viewer): void => {
-  v.prevBtn.addEventListener('click', () => go(-1));
-  v.nextBtn.addEventListener('click', () => go(1));
+  v.prevBtn.addEventListener('click', () => navigate(-1));
+  v.nextBtn.addEventListener('click', () => navigate(1));
   v.fullscreenBtn.addEventListener('click', () => toggleFullscreen(v));
   v.image.addEventListener('load', () => v.stage.classList.remove('is-loading'));
   v.image.addEventListener('error', () => v.stage.classList.remove('is-loading'));
   v.dialog.addEventListener('close', () => {
     exitFullscreen();
     session.invoker?.focus();
+    if (!programmaticClose && assetFromHash() !== undefined) history.back();
   });
-  wireDrag(v);
+  wireSwipe(v);
   document.addEventListener('keydown', onKeydown);
+  window.addEventListener('popstate', onPopState);
 };
 
 /**
@@ -367,18 +459,39 @@ export const initArchiveLightbox = (): void => {
   const galleries = document.querySelectorAll<HTMLElement>('[data-archive-gallery]');
   if (galleries.length === 0) return;
 
+  /*
+   * Prefetch the renderer chunk as soon as an archive page loads, so it
+   * is usually ready by the time a document is opened (the spinner
+   * covers a fast click that beats the download).
+   */
+  loadRenderers().catch(() => undefined);
+
   const v = getViewer();
   if (v.dialog.getAttribute('data-wired') !== 'true') {
     v.dialog.setAttribute('data-wired', 'true');
     wireViewerOnce(v);
   }
 
+  /*
+   * The first gallery on the page drives URL deep-links; refresh it each
+   * run so navigating between archive pages tracks the live DOM.
+   */
+  const first = galleries[0];
+  if (first) activeItems = collectItems(first);
+
   galleries.forEach((gallery) => {
     if (gallery.getAttribute('data-archive-wired') === 'true') return;
     gallery.setAttribute('data-archive-wired', 'true');
     const items = collectItems(gallery);
     items.forEach((item, index) => {
-      item.trigger.addEventListener('click', () => open(items, index));
+      item.trigger.addEventListener('click', () => open(items, index, false));
     });
   });
+
+  /* Deep link: open the item named in the URL hash on load. */
+  const initial = assetFromHash();
+  if (initial !== undefined) {
+    const index = activeItems.findIndex((item) => item.name === initial);
+    if (index >= 0) open(activeItems, index, true);
+  }
 };

--- a/src/features/archive/scripts/archive-renderers.ts
+++ b/src/features/archive/scripts/archive-renderers.ts
@@ -1,0 +1,63 @@
+/*
+ * Lazy-loaded per-type renderers for the archive viewer. This module is
+ * imported as its own chunk only on a page that has an archive gallery,
+ * and the heavy docx engine is imported on demand inside `renderDocx`,
+ * so neither weighs on pages without archive content. Each renderer
+ * fills the passed container; the caller owns the spinner + fallback.
+ */
+
+/** Document kinds the viewer renders inline (beyond plain images). */
+export type DocKind = 'text' | 'pdf' | 'docx';
+
+const fetchOk = async (url: string): Promise<Response> => {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res;
+};
+
+const renderText = async (url: string, container: HTMLElement): Promise<void> => {
+  const text = await (await fetchOk(url)).text();
+  const pre = document.createElement('pre');
+  pre.className = 'archive-doc-text';
+  pre.textContent = text;
+  container.replaceChildren(pre);
+};
+
+const renderPdf = (url: string, name: string, container: HTMLElement): void => {
+  const frame = document.createElement('iframe');
+  frame.className = 'archive-doc-frame';
+  frame.src = url;
+  frame.title = name;
+  container.replaceChildren(frame);
+};
+
+const renderDocx = async (url: string, container: HTMLElement): Promise<void> => {
+  const [{ renderAsync }, res] = await Promise.all([import('docx-preview'), fetchOk(url)]);
+  const blob = await res.blob();
+  const page = document.createElement('div');
+  page.className = 'archive-doc-docx';
+  container.replaceChildren(page);
+  await renderAsync(blob, page, undefined, { inWrapper: true, ignoreWidth: true });
+};
+
+/**
+ * Render a document of the given kind into `container`.
+ * @param kind - The document kind (text/pdf/docx).
+ * @param url - Same-origin URL of the asset file.
+ * @param name - Filename, used for the PDF frame title.
+ * @param container - Element to fill with the rendered output.
+ * @returns Promise that resolves once rendering completes.
+ */
+export const renderDoc = (
+  kind: DocKind,
+  url: string,
+  name: string,
+  container: HTMLElement,
+): Promise<void> => {
+  if (kind === 'text') return renderText(url, container);
+  if (kind === 'pdf') {
+    renderPdf(url, name, container);
+    return Promise.resolve();
+  }
+  return renderDocx(url, container);
+};


### PR DESCRIPTION
Verified on dev.comprom.org at 390px.

- URL-driven viewer: open item lives in '#asset=<name>' — deep-linkable, Back closes.
- Inline readers for text / pdf / docx (images + svg already inline). pdf = native iframe; docx = docx-preview. Renderer code is a separate chunk loaded only on an archive page; the heavy docx engine loads on demand with a spinner. Unknown types fall back to pictogram + download.
- Fixes the ClientRouter body-swap detach (showModal 'not in a Document') by re-attaching the dialog + running init on 'astro:page-load'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)