### PR TITLE
fix(archive): clean slide animation, focus-reachable arrows + E2E coverage

### DIFF
--- a/e2e/archive-viewer.pw.ts
+++ b/e2e/archive-viewer.pw.ts
@@ -1,0 +1,111 @@
+import {
+  expect,
+  expectAttribute,
+  expectHidden,
+  expectMinCount,
+  expectText,
+  expectVisible,
+  pressKey,
+  test,
+  visit,
+} from '@prometheus/e2e-toolkit';
+
+/**
+ * Archive viewer E2E.
+ *
+ * Covers the inline reader (text/pdf/docx render in the modal, not just
+ * download), URL-driven state (`#asset=<name>` deep-links + Back closes),
+ * keyboard navigation, and the regression that the prev/next arrows must
+ * stay focusable and reappear on focus instead of being `disabled` away.
+ *
+ * Relies on the seeded `founding-documents` album (5 assets: flag.svg,
+ * manifesto-poster.svg, sample-charter.docx, sample-charter.pdf,
+ * working-notes.txt — sorted by name).
+ */
+
+const ARCHIVE = '/en/archive/founding-documents/';
+const DIALOG = 'dialog.archive-viewer';
+
+const tile = (name: string): string => `[data-archive-item][data-name="${name}"]`;
+
+test('opens the viewer from a tile and mirrors the item into the URL', async ({ page }) => {
+  await visit(page, ARCHIVE);
+  await expectMinCount(page, page.locator('[data-archive-item]'), 1);
+  await page.locator(tile('working-notes.txt')).click();
+  await expectVisible(page, page.locator(DIALOG));
+  await expect(page).toHaveURL(/#asset=working-notes\.txt$/);
+});
+
+test('renders a text file inline', async ({ page }) => {
+  await visit(page, `${ARCHIVE}#asset=working-notes.txt`);
+  await expectVisible(page, page.locator('.archive-viewer-doc pre.archive-doc-text'));
+  await expectText(page, page.locator('.archive-doc-text'), /Founding documents/);
+});
+
+test('renders a pdf inline', async ({ page }) => {
+  await visit(page, `${ARCHIVE}#asset=sample-charter.pdf`);
+  await expectVisible(page, page.locator('iframe.archive-doc-frame'));
+});
+
+test('renders a docx inline', async ({ page }) => {
+  await visit(page, `${ARCHIVE}#asset=sample-charter.docx`);
+  await expectText(page, page.locator('.archive-doc-docx'), /founding document/i);
+});
+
+test('a deep-link opens the named item on first load', async ({ page }) => {
+  await visit(page, `${ARCHIVE}#asset=sample-charter.pdf`);
+  await expectVisible(page, page.locator(DIALOG));
+  await expectText(page, page.locator('.archive-viewer-counter'), '4 / 5');
+});
+
+test('Back closes the viewer instead of leaving the page', async ({ page }) => {
+  await visit(page, ARCHIVE);
+  await page.locator(tile('working-notes.txt')).click();
+  await expectVisible(page, page.locator(DIALOG));
+  await page.goBack();
+  await expectHidden(page, page.locator(DIALOG));
+  expect(new URL(page.url()).hash).toBe('');
+});
+
+test('arrow keys navigate and update hash + counter', async ({ page }) => {
+  await visit(page, `${ARCHIVE}#asset=flag.svg`);
+  await expectVisible(page, page.locator(DIALOG));
+  await expectText(page, page.locator('.archive-viewer-counter'), '1 / 5');
+  await pressKey(page, 'ArrowRight');
+  await expectText(page, page.locator('.archive-viewer-counter'), '2 / 5');
+  await expect(page).toHaveURL(/#asset=manifesto-poster\.svg$/);
+});
+
+test('nav arrows stay focusable and reappear on focus (not disabled away)', async ({ page }) => {
+  await visit(page, `${ARCHIVE}#asset=flag.svg`);
+  const next = page.locator('.archive-viewer-next');
+  const prev = page.locator('.archive-viewer-prev');
+  /*
+   * never removed from the DOM, never a `disabled` button (which the
+   * original bug used — it dropped the arrow out of the tab order)
+   */
+  await expect(next).toBeAttached();
+  await expect(next).not.toBeDisabled();
+  // hidden until focus on a hover-capable pointer, then revealed on focus
+  await expect(next).toHaveCSS('opacity', '0');
+  await next.focus();
+  await expect(next).toBeFocused();
+  await expect(next).toHaveCSS('opacity', '1');
+  /*
+   * the no-neighbour direction is aria-disabled (announced to AT) but
+   * STILL in the tab order — focus must land on it and reveal it
+   */
+  await expectAttribute(page, prev, 'aria-disabled', 'true');
+  await prev.focus();
+  await expect(prev).toBeFocused();
+  await expect(prev).toHaveCSS('opacity', '0.3');
+});
+
+test('the close control closes the viewer and clears the hash in place', async ({ page }) => {
+  await visit(page, `${ARCHIVE}#asset=working-notes.txt`);
+  await expectVisible(page, page.locator(DIALOG));
+  await page.locator('.archive-viewer-close').click();
+  await expectHidden(page, page.locator(DIALOG));
+  expect(new URL(page.url()).pathname).toBe(ARCHIVE);
+  expect(new URL(page.url()).hash).toBe('');
+});

--- a/src/features/archive/components/ArchiveGallery.astro
+++ b/src/features/archive/components/ArchiveGallery.astro
@@ -286,12 +286,19 @@ const imageOf = (asset: ArchiveAsset): ImageMetadata | undefined =>
     min-height: 0;
   }
 
+  /* Arrow visibility rides a custom property so every rule just sets
+   * `--arrow-op` and the single `opacity` declaration reads the cascaded
+   * winner — no opacity-specificity fights between the disabled and
+   * reveal states. */
   .archive-viewer-prev,
   .archive-viewer-next {
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
-    z-index: 1;
+    z-index: 2;
+    --arrow-op: 1;
+    opacity: var(--arrow-op);
+    transition: opacity var(--transition-fast, 0.15s) ease;
   }
 
   .archive-viewer-prev {
@@ -302,9 +309,47 @@ const imageOf = (asset: ArchiveAsset): ImageMetadata | undefined =>
     right: var(--spacing-sm);
   }
 
-  /* Holds the current item (image or file pictogram). Named so prev/next
-   * navigation cross-fades via the View Transitions API. Arrows stay
-   * fixed (absolute). */
+  /* A direction with no neighbour is dimmed, but kept in the tab order
+   * and revealable — never `disabled` (which drops it from focus) and
+   * never gone for good. */
+  .archive-viewer-prev[aria-disabled='true'],
+  .archive-viewer-next[aria-disabled='true'] {
+    --arrow-op: 0.3;
+    cursor: default;
+  }
+
+  /* On a hover-capable pointer the arrows stay out of the way until the
+   * viewer is hovered OR an arrow is focused (keyboard/Tab) — so they
+   * always come back on focus instead of vanishing. Touch devices (no
+   * hover) keep them visible, since swipe + tap are the only inputs. */
+  @media (hover: hover) {
+    .archive-viewer-prev,
+    .archive-viewer-next,
+    .archive-viewer-prev[aria-disabled='true'],
+    .archive-viewer-next[aria-disabled='true'] {
+      --arrow-op: 0;
+    }
+
+    .archive-viewer:hover .archive-viewer-prev,
+    .archive-viewer:hover .archive-viewer-next,
+    .archive-viewer-stage:focus-within .archive-viewer-prev,
+    .archive-viewer-stage:focus-within .archive-viewer-next,
+    .archive-viewer-prev:focus-visible,
+    .archive-viewer-next:focus-visible {
+      --arrow-op: 1;
+    }
+
+    .archive-viewer:hover .archive-viewer-prev[aria-disabled='true'],
+    .archive-viewer:hover .archive-viewer-next[aria-disabled='true'],
+    .archive-viewer-stage:focus-within .archive-viewer-prev[aria-disabled='true'],
+    .archive-viewer-stage:focus-within .archive-viewer-next[aria-disabled='true'] {
+      --arrow-op: 0.3;
+    }
+  }
+
+  /* Holds the current item (image / doc / pictogram). On prev/next it
+   * slides + fades in from the travel direction — a scoped animation, not
+   * a top-layer View Transition (which janks inside a modal <dialog>). */
   .archive-viewer-content {
     position: relative;
     display: flex;
@@ -313,53 +358,33 @@ const imageOf = (asset: ArchiveAsset): ImageMetadata | undefined =>
     width: 100%;
     height: 100%;
     min-height: 0;
-    view-transition-name: archive-viewer-pane;
   }
 
-  /* Directional slide on left/right navigation; the nav direction is set
-   * on <html> just for the duration of the transition. */
-  @keyframes archive-vt-out-left {
-    to {
-      transform: translateX(-6%);
-      opacity: 0;
-    }
-  }
-
-  @keyframes archive-vt-in-right {
+  @keyframes archive-pane-next {
     from {
-      transform: translateX(6%);
       opacity: 0;
+      transform: translateX(28px);
     }
   }
 
-  @keyframes archive-vt-out-right {
-    to {
-      transform: translateX(6%);
-      opacity: 0;
-    }
-  }
-
-  @keyframes archive-vt-in-left {
+  @keyframes archive-pane-prev {
     from {
-      transform: translateX(-6%);
       opacity: 0;
+      transform: translateX(-28px);
     }
   }
 
-  :root[data-archive-nav='next']::view-transition-old(archive-viewer-pane) {
-    animation: archive-vt-out-left 0.22s ease both;
+  .archive-viewer-content.archive-anim-next {
+    animation: archive-pane-next 0.24s ease both;
   }
 
-  :root[data-archive-nav='next']::view-transition-new(archive-viewer-pane) {
-    animation: archive-vt-in-right 0.22s ease both;
+  .archive-viewer-content.archive-anim-prev {
+    animation: archive-pane-prev 0.24s ease both;
   }
 
-  :root[data-archive-nav='prev']::view-transition-old(archive-viewer-pane) {
-    animation: archive-vt-out-right 0.22s ease both;
-  }
-
-  :root[data-archive-nav='prev']::view-transition-new(archive-viewer-pane) {
-    animation: archive-vt-in-left 0.22s ease both;
+  .archive-viewer[data-reduced-motion] .archive-viewer-content.archive-anim-next,
+  .archive-viewer[data-reduced-motion] .archive-viewer-content.archive-anim-prev {
+    animation: none;
   }
 
   .archive-viewer-image {

--- a/src/features/archive/scripts/archive-lightbox.ts
+++ b/src/features/archive/scripts/archive-lightbox.ts
@@ -18,7 +18,8 @@
  * Accessibility: native `dialog.showModal()` provides the focus trap;
  * we restore focus to the invoking tile on close, announce the current
  * position via a polite live region, and wire ArrowLeft/Right + Escape.
- * A horizontal flick navigates; the visual is a View Transition.
+ * A horizontal flick navigates; the visual is a scoped slide animation
+ * on the pane (no top-layer View Transition, which janks in a dialog).
  */
 
 import type { DocKind } from './archive-renderers';
@@ -213,6 +214,12 @@ let viewer: Viewer | undefined;
 let activeItems: ReadonlyArray<GalleryItem> = [];
 let renderToken = 0;
 let programmaticClose = false;
+/*
+ * True when THIS open pushed a history entry (tile click) — so closing
+ * pops it. A deep-link open adds no entry, so closing just strips the
+ * hash in place instead of navigating off the page.
+ */
+let pushedOpen = false;
 const session: Session = { items: [], index: 0, invoker: undefined };
 
 let renderersPromise: Promise<typeof import('./archive-renderers')> | undefined;
@@ -280,8 +287,12 @@ const render = (v: Viewer): void => {
   const position = session.index + 1;
   v.counter.textContent = `${position} / ${total}`;
   v.live.textContent = `File ${position} of ${total}`;
-  v.prevBtn.disabled = session.index === 0;
-  v.nextBtn.disabled = session.index === total - 1;
+  /*
+   * aria-disabled (not the `disabled` property) so the arrow stays in
+   * the tab order and can be revealed on focus instead of vanishing.
+   */
+  v.prevBtn.setAttribute('aria-disabled', String(session.index === 0));
+  v.nextBtn.setAttribute('aria-disabled', String(session.index === total - 1));
   v.download.href = item.download;
   const mode = viewerMode(item);
   showMode(v, mode);
@@ -308,33 +319,42 @@ const setHash = (name: string, push: boolean): void => {
   else history.replaceState(null, '', url);
 };
 
+const clearHash = (): void => {
+  if (assetFromHash() !== undefined) {
+    history.replaceState(null, '', location.pathname + location.search);
+  }
+};
+
 const assetFromHash = (): string | undefined => {
   const match = location.hash.match(/(?:^#|&)asset=([^&]+)/);
   return match ? decodeURIComponent(match[1] ?? '') : undefined;
 };
 
 /*
- * Move to a neighbouring item through the View Transitions API so any
- * left/right change cross-fades / slides (direction set on <html> for
- * the duration). Browsers without the API — or reduced-motion — get an
- * instant swap. The open item is mirrored into the URL hash.
+ * Slide + fade the pane in from the travel direction. Re-triggerable:
+ * clear the class, then re-add it after two frames so the same animation
+ * replays on every step. Scoped to the pane — no top-layer View
+ * Transition, which janks inside a modal <dialog>.
+ */
+const animatePane = (v: Viewer, dir: number): void => {
+  if (prefersReducedMotion()) return;
+  const cls = dir > 0 ? 'archive-anim-next' : 'archive-anim-prev';
+  v.content.classList.remove('archive-anim-next', 'archive-anim-prev');
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => v.content.classList.add(cls));
+  });
+};
+
+/*
+ * Move to a neighbouring item, mirror it into the URL hash, and animate
+ * the pane in the travel direction.
  */
 const navigate = (delta: number): void => {
   if (!canGo(delta)) return;
   const target = session.items[session.index + delta]?.name;
-  const run = (): void => {
-    go(delta);
-    if (target !== undefined) setHash(target, false);
-  };
-  if (prefersReducedMotion() || typeof document.startViewTransition !== 'function') {
-    run();
-    return;
-  }
-  document.documentElement.setAttribute('data-archive-nav', delta > 0 ? 'next' : 'prev');
-  const transition = document.startViewTransition(run);
-  transition.finished.finally(() => {
-    document.documentElement.removeAttribute('data-archive-nav');
-  });
+  go(delta);
+  if (target !== undefined) setHash(target, false);
+  animatePane(getViewer(), delta);
 };
 
 const exitFullscreen = (): void => {
@@ -396,7 +416,12 @@ const open = (items: ReadonlyArray<GalleryItem>, index: number, fromUrl: boolean
   render(v);
   if (!v.dialog.open) v.dialog.showModal();
   const name = items[index]?.name;
-  if (!fromUrl && name !== undefined) setHash(name, true);
+  if (!fromUrl && name !== undefined) {
+    setHash(name, true);
+    pushedOpen = true;
+  } else {
+    pushedOpen = false;
+  }
 };
 
 const onPopState = (): void => {
@@ -440,10 +465,15 @@ const wireViewerOnce = (v: Viewer): void => {
   v.fullscreenBtn.addEventListener('click', () => toggleFullscreen(v));
   v.image.addEventListener('load', () => v.stage.classList.remove('is-loading'));
   v.image.addEventListener('error', () => v.stage.classList.remove('is-loading'));
+  v.content.addEventListener('animationend', () => {
+    v.content.classList.remove('archive-anim-next', 'archive-anim-prev');
+  });
   v.dialog.addEventListener('close', () => {
     exitFullscreen();
     session.invoker?.focus();
-    if (!programmaticClose && assetFromHash() !== undefined) history.back();
+    if (programmaticClose) return;
+    if (pushedOpen) history.back();
+    else clearHash();
   });
   wireSwipe(v);
   document.addEventListener('keydown', onKeydown);


### PR DESCRIPTION
Addresses on-device feedback. Full chromium E2E suite: 248 passed, 3 consecutive clean runs.

- Animation: scoped slide+fade on the pane instead of a top-layer View Transition (which janks inside a modal dialog).
- Arrows: never `disabled` (which dropped them from the tab order); aria-disabled at the ends but stay focusable, hide-until-hover/focus on desktop, visible on touch — so Tab always brings them back.
- Close: deep-link open strips the hash in place; tile-click open pops its pushed entry.
- New e2e/archive-viewer.pw.ts (9 tests): inline txt/pdf/docx render, deep-link open, Back closes, arrow-key nav + hash, arrows focus-reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)