### PR TITLE
fix(i18n): unpublished article/issue version must 404, as if never created

### DIFF
--- a/src/config/seo.ts
+++ b/src/config/seo.ts
@@ -30,21 +30,32 @@ const hreflangByCode: Readonly<Record<string, string>> = {
 };
 
 /**
- * Build the full set of `<link rel="alternate" hreflang="…">` rows
- * for a given page. Each locale gets its own entry plus an
- * `x-default` pointing at the English variant so Google has a
- * fallback for regions without explicit targeting.
+ * Build the set of `<link rel="alternate" hreflang="…">` rows for a
+ * given page. Each locale gets its own entry plus an `x-default`
+ * pointing at the English variant (or the first available locale) so
+ * Google has a fallback for regions without explicit targeting.
+ *
+ * Pass `allowedLangs` on per-translation pages (blog/positions/
+ * newspaper/archive) to advertise ONLY the locales the content is
+ * actually published in — otherwise Google is pointed at locales that
+ * now 404, since an unpublished language version is no longer built.
  * @param currentPath - Astro.url.pathname for the page being rendered
+ * @param allowedLangs - optional whitelist of locales that exist for this page; defaults to every supported locale
  * @returns Alternates list ready to map into `<link>` tags
  */
-export const buildHreflangAlternates = (currentPath: string): readonly Alt[] => {
+export const buildHreflangAlternates = (
+  currentPath: string,
+  allowedLangs?: readonly string[],
+): readonly Alt[] => {
   const rest = ensureTrailingPath(localePath(currentPath));
-  const result: Alt[] = [];
-  for (const code of SUPPORTED_LANGUAGES) {
-    const tag = hreflangByCode[code] ?? code;
-    const href = `${SITE_URL}/${code}${rest === '/' ? '' : rest}`;
-    result.push({ hreflang: tag, href });
-  }
-  result.push({ hreflang: 'x-default', href: `${SITE_URL}/en${rest === '/' ? '' : rest}` });
-  return result;
+  const hrefFor = (code: string) => `${SITE_URL}/${code}${rest === '/' ? '' : rest}`;
+  const langs = allowedLangs
+    ? SUPPORTED_LANGUAGES.filter((code) => allowedLangs.includes(code))
+    : SUPPORTED_LANGUAGES;
+  const alts: Alt[] = langs.map((code) => ({
+    hreflang: hreflangByCode[code] ?? code,
+    href: hrefFor(code),
+  }));
+  const xDefault = langs.includes('en') ? 'en' : langs.at(0);
+  return xDefault ? [...alts, { hreflang: 'x-default', href: hrefFor(xDefault) }] : alts;
 };

--- a/src/features/navigation/components/Header.astro
+++ b/src/features/navigation/components/Header.astro
@@ -6,9 +6,10 @@ import Nav from './Nav.astro';
 
 interface Props {
   lang: Language;
+  availableLangs?: ReadonlyArray<Language> | undefined;
 }
 
-const { lang } = Astro.props;
+const { lang, availableLangs } = Astro.props;
 ---
 
 <header data-scroll-header>
@@ -23,7 +24,7 @@ const { lang } = Astro.props;
           <Nav lang={lang} />
         </div>
         <div class="desktop-only">
-          <LanguageSwitcher lang={lang} />
+          <LanguageSwitcher lang={lang} availableLangs={availableLangs} />
         </div>
         <div class="desktop-only">
           <ThemeToggle />

--- a/src/features/navigation/components/LanguageSwitcher.astro
+++ b/src/features/navigation/components/LanguageSwitcher.astro
@@ -5,9 +5,17 @@ import SmartDropdown from '@/features/ui/SmartDropdown/SmartDropdown.astro';
 
 interface Props {
   lang: Language;
+  /**
+   * Locales to offer. On per-translation detail pages this is the set
+   * the content is actually published in — offering a locale that now
+   * 404s (unpublished version) would be a dead link. Defaults to every
+   * supported locale on pages that exist in all of them.
+   */
+  availableLangs?: ReadonlyArray<Language> | undefined;
 }
 
-const { lang } = Astro.props;
+const { lang, availableLangs } = Astro.props;
+const codes = availableLangs && availableLangs.length > 0 ? availableLangs : SUPPORTED_LANGUAGES;
 
 // Build a per-language href that preserves the current path instead
 // of pointing at the bare `/{code}` root. Critical for middle-click,
@@ -49,7 +57,7 @@ const hrefFor = (code: string) => (rest === '' ? `/${code}` : `/${code}${rest}`)
     aria-label="Available languages"
     data-testid="language-dropdown"
   >
-    {SUPPORTED_LANGUAGES.map((code) => (
+    {codes.map((code) => (
       <li role="option" aria-selected={code === lang}>
         <a
           href={hrefFor(code)}

--- a/src/features/navigation/components/MobileMenu.astro
+++ b/src/features/navigation/components/MobileMenu.astro
@@ -6,9 +6,10 @@ import LanguageSwitcher from './LanguageSwitcher.astro';
 
 interface Props {
   lang: Language;
+  availableLangs?: ReadonlyArray<Language> | undefined;
 }
 
-const { lang } = Astro.props;
+const { lang, availableLangs } = Astro.props;
 
 const links = await getNavLinks(lang);
 const nav = await getMenuData(lang);
@@ -90,7 +91,7 @@ const menuLabel = nav?.data.menu ?? 'Menu';
       ))}
     </ul>
     <div class="popup-tools">
-      <LanguageSwitcher lang={lang} />
+      <LanguageSwitcher lang={lang} availableLangs={availableLangs} />
       <ThemeToggle />
     </div>
   </nav>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -23,9 +23,18 @@ interface Props {
    * explicitly because Astro 5 sometimes hands the build path here.
    */
   ogImage?: string;
+  /**
+   * Locales this specific page is published in. Passed by per-
+   * translation detail pages (blog/positions/newspaper/archive) so the
+   * language switcher + hreflang only advertise locales that exist —
+   * an unpublished language version now 404s rather than rendering a
+   * placeholder, so linking to it would be a dead link. Omitted on
+   * pages that exist in every locale (home, section indexes).
+   */
+  availableLangs?: ReadonlyArray<Language>;
 }
 
-const { title, description, lang, ogImage } = Astro.props;
+const { title, description, lang, ogImage, availableLangs } = Astro.props;
 
 /*
  * Open Graph + Twitter cards. Telegram picks `og:title`,
@@ -54,7 +63,7 @@ const absoluteImage = shareImage.startsWith('http') ? shareImage : `${SITE_URL}$
  * same query. Without them only one locale ranks per query and the
  * other six effectively don't exist for search.
  */
-const hreflangAlternates = buildHreflangAlternates(Astro.url.pathname);
+const hreflangAlternates = buildHreflangAlternates(Astro.url.pathname, availableLangs);
 const organizationLD = buildOrganizationLD();
 const websiteLD = buildWebSiteLD(lang);
 ---
@@ -132,7 +141,7 @@ const websiteLD = buildWebSiteLD(lang);
   </head>
   <body>
     <a href="#main-content" class="skip-link">Skip to main content</a>
-    <Header lang={lang} />
+    <Header lang={lang} availableLangs={availableLangs} />
     <main id="main-content">
       <slot />
     </main>
@@ -144,7 +153,7 @@ const websiteLD = buildWebSiteLD(lang);
       the wrapper hides itself (>=768px), so this only paints on
       mobile.
     */}
-    <MobileMenu lang={lang} />
+    <MobileMenu lang={lang} availableLangs={availableLangs} />
     {/*
       `floating` slot for body-level fixed-position chrome (article
       TOC overlay, etc.). Sibling of <main>, so a `position: fixed`

--- a/src/pages/[lang]/archive/[...slug].astro
+++ b/src/pages/[lang]/archive/[...slug].astro
@@ -28,15 +28,18 @@ export const getStaticPaths = async () => {
       SUPPORTED_LANGUAGES.filter((lang) => byKey.has(`${lang}/${slug}`)),
     );
   }
-  return SUPPORTED_LANGUAGES.flatMap((lang) =>
-    [...slugs].map((slug) => ({
-      params: { lang, slug },
-      props: {
-        entry: byKey.get(`${lang}/${slug}`),
-        availableLangs: slugToLangs.get(slug) ?? [],
-      },
-    })),
-  );
+  /*
+   * One path per PUBLISHED (lang, slug) only — an unpublished archive
+   * version gets no page (404), as if it was never created. No more
+   * "not translated" placeholder occupying a live URL.
+   */
+  return entries.map((entry) => ({
+    params: { lang: entry.data.lang, slug: getArchiveSlug(entry) },
+    props: {
+      entry,
+      availableLangs: slugToLangs.get(getArchiveSlug(entry)) ?? [],
+    },
+  }));
 };
 
 interface Props {
@@ -57,6 +60,7 @@ const pageDescription = entry ? deriveDescription(entry.data.description, entry.
   title={pageTitle}
   {...(pageDescription ? { description: pageDescription } : {})}
   lang={lang}
+  availableLangs={availableLangs}
 >
   <article class="section">
     <div class="container">

--- a/src/pages/[lang]/blog/[...slug].astro
+++ b/src/pages/[lang]/blog/[...slug].astro
@@ -37,15 +37,21 @@ export const getStaticPaths = async () => {
       SUPPORTED_LANGUAGES.filter((lang) => byKey.has(`${lang}/${slug}`)),
     );
   }
-  return SUPPORTED_LANGUAGES.flatMap((lang) =>
-    [...slugs].map((slug) => ({
-      params: { lang, slug },
-      props: {
-        post: byKey.get(`${lang}/${slug}`),
-        availableLangs: slugToLangs.get(slug) ?? [],
-      },
-    })),
-  );
+  /*
+   * One path per PUBLISHED (lang, slug) only. A language version that
+   * isn't published gets no page at all — the URL 404s, exactly as if
+   * the article had never been created in that language. (Previously
+   * every supported language was emitted for any published slug and a
+   * "not translated" placeholder rendered for the missing ones, so an
+   * unpublished article still occupied a live URL — the bug this fixes.)
+   */
+  return posts.map((post) => ({
+    params: { lang: post.data.lang, slug: getArticleSlug(post) },
+    props: {
+      post,
+      availableLangs: slugToLangs.get(getArticleSlug(post)) ?? [],
+    },
+  }));
 };
 
 interface Props {
@@ -97,7 +103,8 @@ const articleLD = post
  */
 const newspaperRef = await (async () => {
   if (!post || !slug) return undefined;
-  const issues = await getCollection('newspaper');
+  // Only link back to a published issue — same gate as everywhere else.
+  const issues = await getCollection('newspaper', ({ data }) => data.published === true);
   const issueSlug = resolveIssueSlug(issues, slug, post.data.newspaper);
   if (!issueSlug) return undefined;
   const slugFrom = (id: string) => id.split('/').at(0) ?? id;
@@ -116,6 +123,7 @@ const newspaperRef = await (async () => {
   title={pageTitle}
   {...(pageDescription ? { description: pageDescription } : {})}
   lang={lang}
+  availableLangs={availableLangs}
 >
   {articleLD && (
     <script

--- a/src/pages/[lang]/newspaper/[slug].astro
+++ b/src/pages/[lang]/newspaper/[slug].astro
@@ -28,15 +28,18 @@ export const getStaticPaths = async () => {
       SUPPORTED_LANGUAGES.filter((lang) => byKey.has(`${lang}/${slug}`)),
     );
   }
-  return SUPPORTED_LANGUAGES.flatMap((lang) =>
-    [...slugs].map((slug) => ({
-      params: { lang, slug },
-      props: {
-        issue: byKey.get(`${lang}/${slug}`),
-        availableLangs: slugToLangs.get(slug) ?? [],
-      },
-    })),
-  );
+  /*
+   * One path per PUBLISHED (lang, slug) only — an unpublished issue
+   * version gets no page (404), as if it was never created. No more
+   * "not translated" placeholder occupying a live URL.
+   */
+  return issues.map((issue) => ({
+    params: { lang: issue.data.lang, slug: slugFrom(issue.id) },
+    props: {
+      issue,
+      availableLangs: slugToLangs.get(slugFrom(issue.id)) ?? [],
+    },
+  }));
 };
 
 interface Props {
@@ -60,16 +63,26 @@ interface TocEntry {
 
 const tocEntries = await (async (): Promise<ReadonlyArray<TocEntry>> => {
   if (!issue?.data.articles?.length) return [];
-  const posts = await getCollection('blog');
+  /*
+   * Same publish gate as the blog index / article page: an article is
+   * listed in the issue TOC only when it is published in at least one
+   * language. Otherwise an unpublished (or fully unwritten) article
+   * still surfaced here with a live link — the one place the
+   * `published === true` filter was missing.
+   */
+  const posts = await getCollection('blog', ({ data }) => data.published === true);
   const byKey = new Map(posts.map((p) => [`${p.data.lang}/${getArticleSlug(p)}`, p] as const));
-  return issue.data.articles.map((articleSlug) => {
-    const localised = byKey.get(`${lang}/${articleSlug}`) ?? byKey.get(`en/${articleSlug}`);
-    return {
-      slug: articleSlug,
-      title: localised?.data.title ?? articleSlug,
-      href: `/${lang}/blog/${articleSlug}`,
-    };
-  });
+  const publishedSlugs = new Set(posts.map((p) => getArticleSlug(p)));
+  return issue.data.articles
+    .filter((articleSlug) => publishedSlugs.has(articleSlug))
+    .map((articleSlug) => {
+      const localised = byKey.get(`${lang}/${articleSlug}`) ?? byKey.get(`en/${articleSlug}`);
+      return {
+        slug: articleSlug,
+        title: localised?.data.title ?? articleSlug,
+        href: `/${lang}/blog/${articleSlug}`,
+      };
+    });
 })();
 
 const pdfAsset = issue ? findIssueAsset(slug, lang, '.pdf') : undefined;
@@ -84,6 +97,7 @@ const fb2Asset = issue ? findIssueAsset(slug, lang, '.fb2') : undefined;
     ? { description: issue.data.description }
     : {})}
   lang={lang}
+  availableLangs={availableLangs}
 >
   <div class="section">
     <div class="container">

--- a/src/pages/[lang]/positions/[...slug].astro
+++ b/src/pages/[lang]/positions/[...slug].astro
@@ -29,15 +29,18 @@ export const getStaticPaths = async () => {
       SUPPORTED_LANGUAGES.filter((lang) => byKey.has(`${lang}/${slug}`)),
     );
   }
-  return SUPPORTED_LANGUAGES.flatMap((lang) =>
-    [...slugs].map((slug) => ({
-      params: { lang, slug },
-      props: {
-        entry: byKey.get(`${lang}/${slug}`),
-        availableLangs: slugToLangs.get(slug) ?? [],
-      },
-    })),
-  );
+  /*
+   * One path per PUBLISHED (lang, slug) only — an unpublished position
+   * version gets no page (404), as if it was never created. No more
+   * "not translated" placeholder occupying a live URL.
+   */
+  return entries.map((entry) => ({
+    params: { lang: entry.data.lang, slug: slugFrom(entry.id) },
+    props: {
+      entry,
+      availableLangs: slugToLangs.get(slugFrom(entry.id)) ?? [],
+    },
+  }));
 };
 
 interface Props {
@@ -63,6 +66,7 @@ const pageDescription = entry ? deriveDescription(entry.data.description, entry.
   title={pageTitle}
   {...(pageDescription ? { description: pageDescription } : {})}
   lang={lang}
+  availableLangs={availableLangs}
 >
   {entry && Content ? (
     <article class="section">


### PR DESCRIPTION
## Problem

An article published only in one language still occupied **live, 200-OK URLs in every other language** — `/en/`, `/es/`, `/it/`, `/uk/`, `/bl/`, `/pl/` — showing a "Not translated yet" placeholder, and all six were submitted to the sitemap (6 thin pages per single-language article). More importantly, **unpublishing a language version did not remove it** — it just turned into that placeholder. Requirement from the owner: *if publish is off, the article must not reach the site at all — the site must behave as if it was never created.*

## Fix

Make the publish gate uniform across all four content detail routes: **a `(lang, slug)` page exists iff that exact language version is published.** Everything else 404s.

- **getStaticPaths** (blog / positions / newspaper / archive): emit one path per *published* `(lang, slug)` only — no placeholder pages, none in the sitemap.
- **Newspaper issue TOC** + **blog "published in" back-link**: apply the same `published === true` filter — the two spots that bypassed it, where an unpublished article still surfaced as a live link.
- **Language switcher + hreflang**: scoped to the locales the page is actually published in (`availableLangs` threaded through `BaseLayout → Header/MobileMenu → LanguageSwitcher` and into `buildHreflangAlternates`), so nothing links to a now-404 locale.

## Verification

Built against current content (`illuziya-socializma`, RU only):
- `/ru/…` builds; `/en,/es,/it,/uk,/bl,/pl` → **404**.
- sitemap lists **only** `/ru/…`.
- its switcher + hreflang offer **only RU**.
- a fully-translated article (`about-the-manifesto`) still offers all its languages.

Full gate green: `biome format` + `biome check` + `eslint` + `astro check` + `astro build` (118 pages).

Note: the now-unreachable `MissingTranslation` branches remain in the four templates (dead but harmless — keeps the build green); a follow-up can delete them and the component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)