### PR TITLE
release: fuzzy full-text search

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "dependencies": {
         "@astrojs/rss": "^4.0.18",
         "@astrojs/sitemap": "^3.7.2",
+        "@prometheus/search-core": "workspace:*",
         "@web-file-reader/core": "workspace:*",
         "@web-file-reader/file-grid": "workspace:*",
         "@web-file-reader/navigation": "workspace:*",
@@ -45,6 +46,10 @@
         "typescript": "^6.0.3",
         "vitest": "^4.1.10",
       },
+    },
+    "packages/search-core": {
+      "name": "@prometheus/search-core",
+      "version": "0.1.0",
     },
     "packages/wfr-core": {
       "name": "@web-file-reader/core",
@@ -460,6 +465,8 @@
     "@playwright/test": ["@playwright/test@1.58.2", "", { "dependencies": { "playwright": "1.58.2" }, "bin": { "playwright": "cli.js" } }, "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA=="],
 
     "@prisma/instrumentation": ["@prisma/instrumentation@6.11.1", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0 || ^0.57.0" }, "peerDependencies": { "@opentelemetry/api": "^1.8" } }, "sha512-mrZOev24EDhnefmnZX7WVVT7v+r9LttPRqf54ONvj6re4XMF7wFTpK2tLJi4XHB7fFp/6xhYbgRel8YV7gQiyA=="],
+
+    "@prometheus/search-core": ["@prometheus/search-core@workspace:packages/search-core"],
 
     "@puppeteer/browsers": ["@puppeteer/browsers@2.12.1", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.4", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-fXa6uXLxfslBlus3MEpW8S6S9fe5RwmAE5Gd8u3krqOwnkZJV3/lQJiY3LaFdTctLLqJtyMgEUGkbDnRNf6vbQ=="],
 

--- a/e2e/search.pw.ts
+++ b/e2e/search.pw.ts
@@ -1,0 +1,125 @@
+import { expect, expectVisible, test, visit } from '@prometheus/e2e-toolkit';
+
+/*
+ * The site had no search, so finding the articles about AI meant grepping
+ * the content repo. These assertions are that story, turned into a gate:
+ * a reader who half-remembers a word — and misspells it — has to land on
+ * the right article.
+ */
+
+/*
+ * Several search boxes render on one page — the header bar, the burger
+ * menu, and (on home and results) the wide one. Every selector below is
+ * scoped to ONE of them; an unscoped `.hit` would match whichever the DOM
+ * happened to put first.
+ */
+const HEADER = '[data-testid="search-header"]';
+const HERO = '[data-testid="search-hero"]';
+const HEADER_INPUT = `${HEADER} [data-search-input]`;
+const HERO_INPUT = `${HERO} [data-search-input]`;
+const HEADER_HIT = `${HEADER} .hit`;
+const HERO_HIT = `${HERO} .hit`;
+const PAGE_HIT = '[data-testid="search-page-results"] .hit';
+
+/* Both terms misspelled, exactly as a hurried reader would type them. */
+const TYPO_QUERY = 'искуственный интелект';
+
+test.describe('Content search', () => {
+  test('the header box finds an article by a word in its body', async ({ page }) => {
+    await visit(page, '/ru/blog');
+    await page.locator(HEADER_INPUT).fill('нейросети');
+    await expectVisible(page, page.locator(HEADER_HIT).first());
+
+    const links = await page
+      .locator(`${HEADER_HIT} a`)
+      .evaluateAll((nodes) => nodes.map((n) => n.getAttribute('href')));
+    expect(links).toContain('/ru/blog/cyber-tool');
+  });
+
+  test('a misspelled query still reaches the article', async ({ page }) => {
+    await visit(page, '/ru');
+    await page.locator(HERO_INPUT).fill(TYPO_QUERY);
+    await expectVisible(page, page.locator(HERO_HIT).first());
+
+    const links = await page
+      .locator(`${HERO_HIT} a`)
+      .evaluateAll((nodes) => nodes.map((n) => n.getAttribute('href')));
+    expect(links).toContain('/ru/blog/cyber-tool');
+    expect(links).toContain('/ru/blog/international-review-april-2026');
+  });
+
+  /*
+   * The highlight has to cover the word the reader meant — see the offset
+   * map in search-core: the fold does not preserve character positions.
+   */
+  test('the snippet marks the word the reader meant, spelled as the article spells it', async ({
+    page,
+  }) => {
+    await visit(page, '/ru');
+    await page.locator(HERO_INPUT).fill('нейросети');
+    await expectVisible(page, page.locator(`${HERO_HIT} mark`).first());
+    const marked = await page.locator(`${HERO_HIT} mark`).first().textContent();
+    expect(marked?.toLowerCase()).toContain('нейросет');
+  });
+
+  test('keyboard drives the dropdown', async ({ page }) => {
+    await visit(page, '/ru/blog');
+    const input = page.locator(HEADER_INPUT);
+    await input.fill('нейросети');
+    await expectVisible(page, page.locator(HEADER_HIT).first());
+
+    await input.press('ArrowDown');
+    await expect(page.locator(`${HEADER} [aria-selected="true"]`)).toHaveCount(1);
+    expect(await input.getAttribute('aria-activedescendant')).toBe('search-hit-0');
+
+    await input.press('Escape');
+    expect(await input.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  test('Enter with nothing selected lands on the results page', async ({ page }) => {
+    await visit(page, '/ru/blog');
+    await page.locator(HEADER_INPUT).fill('нейросети');
+    await page.locator(HEADER_INPUT).press('Enter');
+    await page.waitForURL(/\/ru\/search\?q=/);
+    await expectVisible(page, page.locator(PAGE_HIT).first());
+  });
+
+  test('the results page is addressable — a search can be sent to someone', async ({ page }) => {
+    await visit(page, `/ru/search?q=${encodeURIComponent(TYPO_QUERY)}`);
+    await expectVisible(page, page.locator(PAGE_HIT).first());
+
+    /* The box shows what was searched for, so the reader can refine it. */
+    expect(await page.locator(HERO_INPUT).inputValue()).toBe(TYPO_QUERY);
+
+    const links = await page
+      .locator(`${PAGE_HIT} a`)
+      .evaluateAll((nodes) => nodes.map((n) => n.getAttribute('href')));
+    expect(links).toContain('/ru/blog/cyber-tool');
+  });
+
+  test('a query that matches nothing says so', async ({ page }) => {
+    await visit(page, '/ru');
+    await page.locator(HERO_INPUT).fill('квазипсевдонечто');
+    await expectVisible(page, page.locator(`${HERO} [data-testid="search-empty"]`));
+    await expect(page.locator(HERO_HIT)).toHaveCount(0);
+  });
+
+  /* The box is a real GET form, so it works before — and without — JS. */
+  test('the box is a form that points at the results page', async ({ page }) => {
+    await visit(page, '/ru');
+    const form = page.locator(HERO);
+    expect(await form.getAttribute('action')).toBe('/ru/search');
+    expect(await form.getAttribute('method')).toBe('get');
+  });
+
+  test('search reaches every section, not only the blog', async ({ page }) => {
+    await visit(page, '/ru');
+    await page.locator(HERO_INPUT).fill('прометей');
+    await expectVisible(page, page.locator(HERO_HIT).first());
+
+    const sections = await page
+      .locator(`${HERO_HIT} .hit-section`)
+      .evaluateAll((nodes) => nodes.map((n) => n.textContent));
+    expect(sections.some((s) => s !== 'Блог')).toBe(true);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -30,10 +30,7 @@
   "dependencies": {
     "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.2",
-    "esbuild": "^0.25.0",
-    "js-yaml": "^4.1.0",
-    "sharp": "^0.34.0",
-    "vite": "^6.4.1",
+    "@prometheus/search-core": "workspace:*",
     "@web-file-reader/core": "workspace:*",
     "@web-file-reader/file-grid": "workspace:*",
     "@web-file-reader/navigation": "workspace:*",
@@ -46,7 +43,11 @@
     "@web-file-reader/provider-pdf": "workspace:*",
     "@web-file-reader/settings": "workspace:*",
     "@web-file-reader/viewer": "workspace:*",
-    "astro": "^5.17.1"
+    "astro": "^5.17.1",
+    "esbuild": "^0.25.0",
+    "js-yaml": "^4.1.0",
+    "sharp": "^0.34.0",
+    "vite": "^6.4.1"
   },
   "packageManager": "bun@latest",
   "devDependencies": {

--- a/packages/search-core/package.json
+++ b/packages/search-core/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@prometheus/search-core",
+  "version": "0.1.0",
+  "description": "Dependency-free fuzzy search over the site's content: document model, stable ids + content hashes for incremental re-indexing, and a typo-tolerant scorer.",
+  "type": "module",
+  "license": "MIT",
+  "keywords": ["search", "fuzzy", "levenshtein", "static-site"],
+  "sideEffects": false,
+  "main": "./src/index.ts",
+  "module": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "private": true
+}

--- a/packages/search-core/src/index.ts
+++ b/packages/search-core/src/index.ts
@@ -1,0 +1,16 @@
+export type { SearchDoc, SearchIndex, SearchSection } from './model/doc';
+export { contentHash } from './model/hash';
+export {
+  editDistanceWithin,
+  maxEditsFor,
+  prefixDistanceWithin,
+} from './query/distance';
+export type {
+  Mark,
+  PreparedDoc,
+  PreparedIndex,
+  SearchHit,
+  Snippet,
+} from './query/search';
+export { prepare, search } from './query/search';
+export { normalize, tokenize } from './text/normalize';

--- a/packages/search-core/src/model/doc.ts
+++ b/packages/search-core/src/model/doc.ts
@@ -1,0 +1,44 @@
+/** Sections a document can belong to; drives the label on a result row. */
+export type SearchSection =
+  | 'blog'
+  | 'positions'
+  | 'magazine'
+  | 'archive'
+  | 'page';
+
+/** One indexed document. */
+export interface SearchDoc {
+  /**
+   * `${lang}/${section}/${slug}` — stable across builds.
+   *
+   * This is the shared key between the index the browser downloads and
+   * the vector store the semantic search will keep. Nothing else about a
+   * document is stable enough to key on: titles get edited, bodies get
+   * rewritten, and positions in the list shift on every publish.
+   */
+  readonly id: string;
+  readonly lang: string;
+  readonly section: SearchSection;
+  readonly slug: string;
+  /** Where a result row points. */
+  readonly url: string;
+  readonly title: string;
+  readonly description: string;
+  /** Markdown stripped to plain text — what the body search runs over. */
+  readonly body: string;
+  /**
+   * Fingerprint of the text above.
+   *
+   * The semantic pass (a later iteration) re-embeds a document only when
+   * its hash moves, so publishing one article does not pay to re-embed
+   * the whole site. It costs nothing to emit now and cannot be
+   * reconstructed later without re-reading every article.
+   */
+  readonly hash: string;
+}
+
+/** A whole language's index, as served to the browser. */
+export interface SearchIndex {
+  readonly lang: string;
+  readonly docs: readonly SearchDoc[];
+}

--- a/packages/search-core/src/model/hash.test.ts
+++ b/packages/search-core/src/model/hash.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { contentHash } from './hash';
+
+describe('contentHash', () => {
+  /*
+   * The semantic pass re-embeds a document only when its hash moves. So
+   * the hash has to be stable across builds and processes — anything
+   * seeded by time, iteration order or a random salt would re-embed the
+   * entire site on every deploy.
+   */
+  it('is stable for the same content', () => {
+    expect(contentHash('a', 'b', 'c')).toBe(contentHash('a', 'b', 'c'));
+  });
+
+  it('moves when any part of the content moves', () => {
+    const base = contentHash('title', 'description', 'body');
+    expect(contentHash('title!', 'description', 'body')).not.toBe(base);
+    expect(contentHash('title', 'description!', 'body')).not.toBe(base);
+    expect(contentHash('title', 'description', 'body!')).not.toBe(base);
+  });
+
+  /* Otherwise moving a word from the title to the body would look unchanged. */
+  it('does not confuse a field boundary with content', () => {
+    expect(contentHash('ab', '', '')).not.toBe(contentHash('a', 'b', ''));
+  });
+
+  it('is a short hex string', () => {
+    expect(contentHash('a', 'b', 'c')).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it('handles an empty document', () => {
+    expect(contentHash('', '', '')).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it('handles Cyrillic and emoji without collapsing them', () => {
+    expect(contentHash('Маркс', '', '')).not.toBe(contentHash('Энгельс', '', ''));
+  });
+});

--- a/packages/search-core/src/model/hash.ts
+++ b/packages/search-core/src/model/hash.ts
@@ -1,0 +1,42 @@
+/*
+ * FNV-1a, 32-bit.
+ *
+ * Not a security hash — a change detector. It must be stable across
+ * builds and processes, because the semantic pass (a later iteration)
+ * re-embeds a document only when its hash moves: anything seeded by
+ * time, iteration order or a salt would re-embed the whole site on every
+ * deploy. A crypto hash would do the same job, but not without pulling
+ * `node:crypto` into a package that has to run in the browser too.
+ */
+
+const OFFSET_BASIS = 0x811c9dc5;
+const PRIME = 0x01000193;
+
+/* Cannot occur in content, so it cannot be confused with a field's text. */
+const FIELD_SEPARATOR = '\u001f';
+
+const fnv1a = (text: string): number => {
+  let hash = OFFSET_BASIS;
+  for (let i = 0; i < text.length; i += 1) {
+    hash ^= text.charCodeAt(i);
+    /* Multiply by the prime in 32-bit space without overflowing to float. */
+    hash = Math.imul(hash, PRIME);
+  }
+  return hash >>> 0;
+};
+
+/**
+ * Fingerprint a document's searchable text.
+ * @param title - Document title.
+ * @param description - Document description (may be empty).
+ * @param body - Plain-text body.
+ * @returns Eight hex characters, stable for identical input.
+ */
+export const contentHash = (
+  title: string,
+  description: string,
+  body: string,
+): string =>
+  fnv1a([title, description, body].join(FIELD_SEPARATOR))
+    .toString(16)
+    .padStart(8, '0');

--- a/packages/search-core/src/query/distance.test.ts
+++ b/packages/search-core/src/query/distance.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import {
+  editDistanceWithin,
+  maxEditsFor,
+  prefixDistanceWithin,
+} from './distance';
+
+describe('editDistanceWithin', () => {
+  it('reports zero for identical words', () => {
+    expect(editDistanceWithin('маркс', 'маркс', 2)).toBe(0);
+  });
+
+  it('counts a substitution', () => {
+    expect(editDistanceWithin('маркс', 'марск', 2)).toBe(2);
+  });
+
+  it('counts a deletion', () => {
+    expect(editDistanceWithin('интеллект', 'интелект', 2)).toBe(1);
+  });
+
+  it('counts an insertion', () => {
+    expect(editDistanceWithin('труд', 'трудд', 2)).toBe(1);
+  });
+
+  /*
+   * The bound is the whole point: the scorer runs this against every
+   * unique token of every document, so a word that is obviously too far
+   * away must be rejected without paying for the full matrix.
+   */
+  it('gives up rather than measure a distance beyond the bound', () => {
+    expect(editDistanceWithin('нейросеть', 'империализм', 2)).toBeUndefined();
+  });
+
+  it('rejects on the length gap alone, before comparing a character', () => {
+    expect(editDistanceWithin('ии', 'интернационализм', 2)).toBeUndefined();
+  });
+
+  it('measures across alphabets without special-casing them', () => {
+    expect(editDistanceWithin('engels', 'engles', 2)).toBe(2);
+  });
+
+  it('treats an empty word as the length of the other', () => {
+    expect(editDistanceWithin('', 'ии', 2)).toBe(2);
+    expect(editDistanceWithin('', 'труд', 2)).toBeUndefined();
+  });
+});
+
+describe('maxEditsFor', () => {
+  /*
+   * Typo tolerance has to scale with word length. Allowing an edit on a
+   * three-letter word makes every three-letter word match every other
+   * one; withholding it from a long word means a single slip hides the
+   * article the reader is looking for.
+   */
+  it('allows no edits on a short word — everything would match everything', () => {
+    expect(maxEditsFor('ии')).toBe(0);
+    expect(maxEditsFor('его')).toBe(0);
+  });
+
+  it('allows one edit on a medium word', () => {
+    expect(maxEditsFor('труд')).toBe(1);
+    expect(maxEditsFor('маркса')).toBe(1);
+  });
+
+  it('allows two edits on a long word', () => {
+    expect(maxEditsFor('интеллект')).toBe(2);
+    expect(maxEditsFor('политика')).toBe(2);
+  });
+
+  /*
+   * A Russian word can be off by an inflection AND a typo at once —
+   * «искуственный» is four edits from «искусственного». Two would hide
+   * the article from exactly the reader who cannot spell it.
+   */
+  it('allows three edits on a very long word', () => {
+    expect(maxEditsFor('искусственный')).toBe(3);
+    expect(maxEditsFor('интернационализм')).toBe(3);
+  });
+});
+
+describe('prefixDistanceWithin', () => {
+  /*
+   * Inflection lives at the end of a Russian word and meaning at the
+   * front, so the ending is allowed to diverge for free while the stem
+   * still has to match.
+   */
+  it('reaches an inflected form the whole-word distance cannot', () => {
+    expect(editDistanceWithin('искусственный', 'искусственного', 2)).toBeUndefined();
+    expect(prefixDistanceWithin('искусственный', 'искусственного', 2)).toBe(2);
+  });
+
+  it('absorbs a typo and an inflection together', () => {
+    expect(prefixDistanceWithin('искуственный', 'искусственного', 3)).toBe(3);
+  });
+
+  it('still requires the stem to match', () => {
+    expect(prefixDistanceWithin('нейросеть', 'империализм', 3)).toBeUndefined();
+  });
+
+  /*
+   * «искуственный» and «собственный» share the ending «-ственный», and a
+   * budget of three is wide enough to cross the gap — edit distance cannot
+   * see that the stems are unrelated. Anchoring the first two characters
+   * rules it out, and costs nothing: readers mistype the middle and the
+   * end of a word, almost never its opening.
+   */
+  it('refuses a word that only shares an ending', () => {
+    expect(prefixDistanceWithin('искуственный', 'собственный', 3)).toBeUndefined();
+    expect(prefixDistanceWithin('искуственный', 'искусственного', 3)).toBe(3);
+  });
+
+  it('handles a token shorter than the term', () => {
+    expect(prefixDistanceWithin('нейросетями', 'нейросеть', 3)).toBe(3);
+  });
+
+  it('reports an exact prefix as zero', () => {
+    expect(prefixDistanceWithin('нейросет', 'нейросетями', 2)).toBe(0);
+  });
+});

--- a/packages/search-core/src/query/distance.ts
+++ b/packages/search-core/src/query/distance.ts
@@ -1,0 +1,123 @@
+/*
+ * Bounded Levenshtein.
+ *
+ * The scorer runs this against every unique token of every document, so
+ * the bound is not an optimisation — it is what makes the whole approach
+ * affordable. Two words that are obviously far apart must be rejected
+ * without paying for the full matrix, and a word whose length alone puts
+ * it out of reach must be rejected before a single character is read.
+ */
+
+/** Typo budget by word length; see {@link maxEditsFor}. */
+const SHORT = 3;
+const MEDIUM = 6;
+const LONG = 9;
+
+/**
+ * How many edits a term of this length may absorb.
+ *
+ * Tolerance has to scale with length. One edit on a three-letter word
+ * makes every three-letter word match every other one; no edits on a
+ * long word means a single slip hides the article the reader wants.
+ *
+ * The top tier is three, not two, because a Russian word can be off by
+ * an inflection AND a typo at once: «искуственный» reaches
+ * «искусственного» only across four edits, and a reader who cannot spell
+ * it is exactly the reader who needs the search.
+ * @param term - A normalized query word.
+ * @returns Maximum edit distance that still counts as a match.
+ */
+export const maxEditsFor = (term: string): number => {
+  if (term.length <= SHORT) return 0;
+  if (term.length <= MEDIUM) return 1;
+  return term.length <= LONG ? 2 : 3;
+};
+
+/**
+ * Edit distance between two words, abandoned as soon as it exceeds
+ * `max`.
+ * @param a - First word (normalized).
+ * @param b - Second word (normalized).
+ * @param max - Bound; beyond it the answer is not worth computing.
+ * @returns The distance, or undefined when it exceeds `max`.
+ */
+export const editDistanceWithin = (
+  a: string,
+  b: string,
+  max: number,
+): number | undefined => {
+  if (Math.abs(a.length - b.length) > max) return undefined;
+  if (a === b) return 0;
+
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  for (let i = 1; i <= a.length; i += 1) {
+    const row = [i, ...new Array<number>(b.length).fill(0)];
+    let best = i;
+    for (let j = 1; j <= b.length; j += 1) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      const value = Math.min(
+        (row[j - 1] ?? 0) + 1,
+        (prev[j] ?? 0) + 1,
+        (prev[j - 1] ?? 0) + cost,
+      );
+      row[j] = value;
+      best = Math.min(best, value);
+    }
+    /* Every path through this row already costs more than the bound. */
+    if (best > max) return undefined;
+    prev = row;
+  }
+  const distance = prev[b.length] ?? Number.POSITIVE_INFINITY;
+  return distance > max ? undefined : distance;
+};
+
+/*
+ * How many leading characters must match exactly before a fuzzy match is
+ * even considered.
+ *
+ * Without an anchor, a budget of three lets «искуственный» reach
+ * «собственный» — they share the ending «-ственный», and edit distance
+ * cannot see that the stems have nothing to do with each other. Readers
+ * mistype the middle and the end of a word, almost never its first two
+ * letters, so anchoring there costs recall nothing and buys back the
+ * precision the wide budget spends. Search engines call this
+ * `prefix_length`.
+ */
+const ANCHOR = 2;
+
+/**
+ * Distance from a term to the closest PREFIX of a token.
+ *
+ * Inflection is why this exists. Russian carries the meaning at the front
+ * of a word and the grammar at the back, so «искусственный» and
+ * «искусственного» are the same word wearing a different ending — but
+ * measured whole they are three edits apart, and with a typo on top the
+ * reader's spelling never reaches the article's. Comparing the term
+ * against the token's prefixes lets the ending diverge for free while the
+ * stem still has to match.
+ *
+ * The token being shorter than the term is handled by the plain distance
+ * (the full token is one of the prefixes considered).
+ * @param term - A normalized query word.
+ * @param token - A normalized word from the document.
+ * @param max - Edit budget.
+ * @returns The best distance within budget, or undefined.
+ */
+export const prefixDistanceWithin = (
+  term: string,
+  token: string,
+  max: number,
+): number | undefined => {
+  const anchor = Math.min(ANCHOR, term.length);
+  if (token.slice(0, anchor) !== term.slice(0, anchor)) return undefined;
+  const shortest = Math.max(1, term.length - max);
+  const longest = Math.min(token.length, term.length + max);
+  let best: number | undefined;
+  for (let length = shortest; length <= longest; length += 1) {
+    const distance = editDistanceWithin(term, token.slice(0, length), max);
+    if (distance === undefined) continue;
+    if (distance === 0) return 0;
+    best = best === undefined ? distance : Math.min(best, distance);
+  }
+  return best;
+};

--- a/packages/search-core/src/query/prepared.ts
+++ b/packages/search-core/src/query/prepared.ts
@@ -1,0 +1,52 @@
+import type { SearchDoc, SearchIndex } from '../model/doc';
+import { normalize, tokenize } from '../text/normalize';
+
+/**
+ * A document with everything the scorer needs precomputed.
+ *
+ * Normalising a body on every keystroke would cost more than the search
+ * itself, so it is done once per index. `tokens` is the set of UNIQUE
+ * words: fuzzy matching walks it, and a document of 5 000 words holds
+ * perhaps 1 500 distinct ones — that ratio is what keeps typing
+ * responsive.
+ */
+export interface PreparedDoc {
+  readonly doc: SearchDoc;
+  readonly title: string;
+  readonly description: string;
+  readonly body: string;
+  readonly tokens: ReadonlySet<string>;
+}
+
+/** An index with its documents prepared for scoring. */
+export interface PreparedIndex {
+  readonly lang: string;
+  readonly docs: readonly PreparedDoc[];
+}
+
+const prepareDoc = (doc: SearchDoc): PreparedDoc => {
+  const title = normalize(doc.title);
+  const description = normalize(doc.description);
+  const body = normalize(doc.body);
+  return {
+    doc,
+    title,
+    description,
+    body,
+    tokens: new Set([
+      ...tokenize(title),
+      ...tokenize(description),
+      ...tokenize(body),
+    ]),
+  };
+};
+
+/**
+ * Normalise an index once, so each keystroke only has to score it.
+ * @param index - The index as downloaded.
+ * @returns The same documents, ready to search.
+ */
+export const prepare = (index: SearchIndex): PreparedIndex => ({
+  lang: index.lang,
+  docs: index.docs.map(prepareDoc),
+});

--- a/packages/search-core/src/query/score.ts
+++ b/packages/search-core/src/query/score.ts
@@ -1,0 +1,86 @@
+import type { PreparedDoc } from './prepared';
+import { maxEditsFor, prefixDistanceWithin } from './distance';
+
+/*
+ * A title match means the article is ABOUT the term; a body match means
+ * it merely says the word. The weights say so, and the gap has to be
+ * wide enough that no amount of repetition in a body outranks a title.
+ */
+const TITLE = 10;
+const DESCRIPTION = 4;
+const BODY = 2;
+
+/* A fuzzy hit is a guess. It must never outrank something spelled right. */
+const FUZZY_PENALTY = 0.4;
+
+const fieldScore = (field: string, term: string, weight: number): number => {
+  const at = field.indexOf(term);
+  if (at < 0) return 0;
+  /* A whole-word hit beats a hit buried inside a longer word. */
+  const before = at === 0 ? ' ' : field[at - 1];
+  const after = field[at + term.length] ?? ' ';
+  const whole = before === ' ' && after === ' ';
+  return whole ? weight : weight * 0.6;
+};
+
+const exactScore = (doc: PreparedDoc, term: string): number =>
+  fieldScore(doc.title, term, TITLE) +
+  fieldScore(doc.description, term, DESCRIPTION) +
+  fieldScore(doc.body, term, BODY);
+
+/*
+ * Only reached when the term appears nowhere verbatim — so this walks the
+ * document's unique tokens, not its text, and each comparison is
+ * abandoned the moment it exceeds the budget.
+ *
+ * Prefix distance, not whole-word: a Russian word carries its meaning at
+ * the front and its grammar at the back, so the ending has to be allowed
+ * to diverge while the stem still has to match.
+ */
+const fuzzyScore = (doc: PreparedDoc, term: string): number => {
+  const budget = maxEditsFor(term);
+  if (budget === 0) return 0;
+  let best = 0;
+  for (const token of doc.tokens) {
+    const distance = prefixDistanceWithin(term, token, budget);
+    if (distance === undefined) continue;
+    const closeness = 1 - distance / (budget + 1);
+    best = Math.max(best, closeness);
+    if (distance === 0) break;
+  }
+  return best * BODY * FUZZY_PENALTY;
+};
+
+/**
+ * Score one document against one query term.
+ * @param doc - A prepared document.
+ * @param term - A normalized query word.
+ * @returns Score, or 0 when the term is absent — which drops the document.
+ */
+export const scoreTerm = (doc: PreparedDoc, term: string): number => {
+  const exact = exactScore(doc, term);
+  return exact > 0 ? exact : fuzzyScore(doc, term);
+};
+
+/**
+ * Score one document against the whole query.
+ *
+ * Every term must land somewhere (AND, not OR): a reader who types two
+ * words means both, and a document that only knows one of them is not
+ * what they asked for.
+ * @param doc - A prepared document.
+ * @param terms - Normalized query words.
+ * @returns Total score, or 0 when any term is missing.
+ */
+export const scoreDoc = (
+  doc: PreparedDoc,
+  terms: readonly string[],
+): number => {
+  let total = 0;
+  for (const term of terms) {
+    const score = scoreTerm(doc, term);
+    if (score === 0) return 0;
+    total += score;
+  }
+  return total;
+};

--- a/packages/search-core/src/query/search.test.ts
+++ b/packages/search-core/src/query/search.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+import type { SearchDoc, SearchIndex } from '../model/doc';
+import { prepare, search } from './search';
+
+const doc = (over: Partial<SearchDoc> & Pick<SearchDoc, 'slug'>): SearchDoc => ({
+  id: `ru/blog/${over.slug}`,
+  lang: 'ru',
+  section: 'blog',
+  url: `/ru/blog/${over.slug}`,
+  title: '',
+  description: '',
+  body: '',
+  hash: '00000000',
+  ...over,
+});
+
+const index = (docs: readonly SearchDoc[]): SearchIndex => ({ lang: 'ru', docs });
+
+const CYBER = doc({
+  slug: 'cyber-tool',
+  title: 'Орудие труда и кибернетический мастерок',
+  description: 'О месте нейросетей в производстве.',
+  body: 'Современные нейросети созданы корпорациями ради прибыли.',
+});
+
+const REVIEW = doc({
+  slug: 'international-review',
+  title: 'Международный обзор: апрель 2026',
+  description: 'Обзор мировой экономики.',
+  body: 'Развитие искусственного интеллекта и зелёной энергетики.',
+});
+
+const MANIFESTO = doc({
+  slug: 'manifesto',
+  title: 'Манифест',
+  description: 'Программные положения.',
+  body: 'Пролетарии всех стран, соединяйтесь.',
+});
+
+const ALL = index([CYBER, REVIEW, MANIFESTO]);
+
+const slugs = (query: string, from: SearchIndex = ALL): readonly string[] =>
+  search(prepare(from), query).map(hit => hit.doc.slug);
+
+describe('search', () => {
+  it('finds a document by a word in its body', () => {
+    expect(slugs('корпорациями')).toEqual(['cyber-tool']);
+  });
+
+  it('finds a document by a word in its title', () => {
+    expect(slugs('мастерок')).toEqual(['cyber-tool']);
+  });
+
+  /*
+   * The whole reason for the feature: a reader who cannot spell
+   * "искусственный интеллект" must still land on the article about it.
+   */
+  it('survives typos', () => {
+    expect(slugs('искуственный интелект')).toEqual(['international-review']);
+    expect(slugs('нейросиети')).toEqual(['cyber-tool']);
+  });
+
+  it('does not fuzz a short word into everything', () => {
+    expect(slugs('оба')).toEqual([]);
+  });
+
+  /* AND, not OR: every term has to land somewhere, or the doc is out. */
+  it('requires every term to match', () => {
+    expect(slugs('нейросети прибыли')).toEqual(['cyber-tool']);
+    expect(slugs('нейросети империализм')).toEqual([]);
+  });
+
+  it('ranks a title match above a body-only match', () => {
+    const titled = doc({ slug: 'titled', title: 'Энергетика' });
+    const buried = doc({ slug: 'buried', body: 'много слов про энергетику и ещё' });
+    expect(slugs('энергетика', index([buried, titled]))).toEqual([
+      'titled',
+      'buried',
+    ]);
+  });
+
+  it('ranks an exact match above a fuzzy one', () => {
+    const exact = doc({ slug: 'exact', title: 'нейросеть' });
+    const typo = doc({ slug: 'typo', title: 'нейросети' });
+    const [first] = slugs('нейросеть', index([typo, exact]));
+    expect(first).toBe('exact');
+  });
+
+  it('returns nothing for a blank query rather than everything', () => {
+    expect(slugs('')).toEqual([]);
+    expect(slugs('   ')).toEqual([]);
+  });
+
+  it('matches across the ё/е split', () => {
+    expect(slugs('зелёной')).toEqual(['international-review']);
+    expect(slugs('зеленой')).toEqual(['international-review']);
+  });
+
+  it('honours the result limit', () => {
+    const many = index(
+      Array.from({ length: 30 }, (_, i) =>
+        doc({ slug: `s${i}`, title: 'нейросеть' }),
+      ),
+    );
+    expect(search(prepare(many), 'нейросеть', 5)).toHaveLength(5);
+  });
+});
+
+describe('search — snippets', () => {
+  /*
+   * The fold collapses a run of punctuation into one space, so an offset
+   * in the folded text means nothing in the source. Assuming otherwise
+   * put the highlight on whatever happened to sit at the same index — the
+   * reader saw a random half-word marked. The mark must cover the word
+   * that was searched for, and nothing else.
+   */
+  it('marks the searched word itself, not whatever sits at the same offset', () => {
+    const punctuated = doc({
+      slug: 'punctuated',
+      body: 'Итак, — вот, наконец: нейросети, товарищи!',
+    });
+    const hit = search(prepare(index([punctuated])), 'нейросети')[0];
+    const marks = hit?.snippet.marks ?? [];
+    expect(marks).toHaveLength(1);
+    const [mark] = marks;
+    expect(hit?.snippet.text.slice(mark?.start, mark?.end)).toBe('нейросети');
+  });
+
+  it('marks through case and ё, quoting the source spelling', () => {
+    const cased = doc({ slug: 'cased', body: 'Здесь НЕЙРОСЁТИ важны.' });
+    const hit = search(prepare(index([cased])), 'нейросети')[0];
+    const [mark] = hit?.snippet.marks ?? [];
+    expect(hit?.snippet.text.slice(mark?.start, mark?.end)).toBe('НЕЙРОСЁТИ');
+  });
+
+  /*
+   * A misspelled term is not in the document at all, so there is nothing
+   * to mark literally. Show the reader the word they meant, spelled the
+   * way the article spells it.
+   */
+  it('marks the word the reader meant when they misspelled it', () => {
+    const hit = search(prepare(ALL), 'нейросиети')[0];
+    const [mark] = hit?.snippet.marks ?? [];
+    expect(hit?.snippet.text.slice(mark?.start, mark?.end)?.toLowerCase()).toContain(
+      'нейросет',
+    );
+  });
+
+  it('quotes the body around the match, not from the top', () => {
+    const hit = search(prepare(ALL), 'корпорациями')[0];
+    expect(hit?.snippet.text).toContain('корпорациями');
+  });
+
+  /*
+   * Ranges, not HTML. The renderer escapes the text and wraps the ranges
+   * itself, so a body containing `<img onerror=…>` can never reach the
+   * DOM as markup.
+   */
+  it('reports highlight ranges rather than emitting markup', () => {
+    const hit = search(prepare(ALL), 'корпорациями')[0];
+    const marks = hit?.snippet.marks ?? [];
+    expect(marks.length).toBeGreaterThan(0);
+    const [first] = marks;
+    const quoted = hit?.snippet.text.slice(first?.start, first?.end);
+    expect(quoted?.toLowerCase()).toContain('корпорациями');
+    expect(hit?.snippet.text).not.toContain('<');
+  });
+
+  it('falls back to the description when the match is in the title', () => {
+    const hit = search(prepare(ALL), 'мастерок')[0];
+    expect(hit?.snippet.text.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/search-core/src/query/search.ts
+++ b/packages/search-core/src/query/search.ts
@@ -1,0 +1,48 @@
+import type { SearchDoc } from '../model/doc';
+import { tokenize } from '../text/normalize';
+import type { PreparedIndex } from './prepared';
+import { scoreDoc } from './score';
+import { buildSnippet, type Snippet } from './snippet';
+
+export type { PreparedDoc, PreparedIndex } from './prepared';
+export { prepare } from './prepared';
+export type { Mark, Snippet } from './snippet';
+
+/** One result row. */
+export interface SearchHit {
+  readonly doc: SearchDoc;
+  readonly score: number;
+  readonly snippet: Snippet;
+}
+
+const DEFAULT_LIMIT = 20;
+
+/**
+ * Rank a prepared index against a query.
+ *
+ * A blank query returns nothing rather than everything — an empty search
+ * box is not a request to list the site.
+ * @param index - A prepared index (see `prepare`).
+ * @param query - Raw text as typed.
+ * @param limit - Maximum rows to return.
+ * @returns Hits, best first.
+ */
+export const search = (
+  index: PreparedIndex,
+  query: string,
+  limit: number = DEFAULT_LIMIT,
+): readonly SearchHit[] => {
+  const terms = tokenize(query);
+  if (terms.length === 0) return [];
+
+  return index.docs
+    .map(doc => ({ doc, score: scoreDoc(doc, terms) }))
+    .filter(scored => scored.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map(scored => ({
+      doc: scored.doc.doc,
+      score: scored.score,
+      snippet: buildSnippet(scored.doc, terms),
+    }));
+};

--- a/packages/search-core/src/query/snippet.ts
+++ b/packages/search-core/src/query/snippet.ts
@@ -1,0 +1,113 @@
+import { foldWithMap } from '../text/fold';
+import { prefixDistanceWithin, maxEditsFor } from './distance';
+import type { PreparedDoc } from './prepared';
+
+/** A character range in {@link Snippet.text} that matched the query. */
+export interface Mark {
+  readonly start: number;
+  readonly end: number;
+}
+
+/**
+ * A quote from the document, and where inside it the query landed.
+ *
+ * Ranges, not HTML. The renderer escapes `text` and wraps `marks` itself,
+ * so a body carrying `<img src=x onerror=…>` can never reach the DOM as
+ * markup. Handing back a pre-highlighted string would put that one
+ * forgotten `escape()` away.
+ */
+export interface Snippet {
+  readonly text: string;
+  readonly marks: readonly Mark[];
+}
+
+const RADIUS = 90;
+
+/*
+ * What to actually look for in the text.
+ *
+ * A term the reader misspelled is not IN the document — «искуственный»
+ * never appears in an article that says «искусственного». Highlighting
+ * nothing there would be honest but useless, so fall back to the token
+ * the scorer matched: the reader sees the word they meant, spelled the
+ * way the article spells it.
+ */
+/* One term can be spelled several ways in one article — «искусственный»,
+ * «искусственного» — and marking only the closest of them leaves the
+ * other sitting unmarked in the very same sentence. Take every token
+ * within budget, capped so a loose match cannot paint the whole quote. */
+const MAX_FORMS = 6;
+
+const formsFor = (doc: PreparedDoc, terms: readonly string[]): readonly string[] =>
+  terms.flatMap(term => {
+    if (doc.body.includes(term) || doc.description.includes(term)) return [term];
+    const budget = maxEditsFor(term);
+    if (budget === 0) return [];
+    const near: { token: string; distance: number }[] = [];
+    for (const token of doc.tokens) {
+      const distance = prefixDistanceWithin(term, token, budget);
+      if (distance !== undefined) near.push({ token, distance });
+    }
+    return near
+      .sort((a, b) => a.distance - b.distance)
+      .slice(0, MAX_FORMS)
+      .map(x => x.token);
+  });
+
+const findAll = (haystack: string, needle: string): readonly Mark[] => {
+  const marks: Mark[] = [];
+  let at = haystack.indexOf(needle);
+  while (at >= 0) {
+    marks.push({ start: at, end: at + needle.length });
+    at = haystack.indexOf(needle, at + needle.length);
+  }
+  return marks;
+};
+
+const wordEdge = (text: string, at: number, forward: boolean): number => {
+  const space = forward ? text.indexOf(' ', at) : text.lastIndexOf(' ', at);
+  if (space < 0) return forward ? text.length : 0;
+  return space;
+};
+
+/**
+ * Quote the document around the first term that appears in it, and say
+ * where inside that quote the query landed.
+ * @param doc - A prepared document.
+ * @param terms - Normalized query words.
+ * @returns A quote plus the ranges inside it that matched.
+ */
+export const buildSnippet = (
+  doc: PreparedDoc,
+  terms: readonly string[],
+): Snippet => {
+  const source = doc.doc.body.trim() === '' ? doc.doc.description : doc.doc.body;
+  const { text: folded, map } = foldWithMap(source);
+  const forms = formsFor(doc, terms);
+
+  /* Every hit, as a range in the SOURCE — the fold does not preserve offsets. */
+  const inSource = forms
+    .flatMap(form => findAll(folded, form))
+    .map(m => ({
+      start: map[m.start] ?? 0,
+      end: (map[m.end - 1] ?? 0) + 1,
+    }))
+    .sort((a, b) => a.start - b.start);
+
+  const first = inSource.at(0);
+  if (first === undefined) {
+    return { text: source.slice(0, RADIUS * 2).trim(), marks: [] };
+  }
+
+  const from = wordEdge(source, Math.max(0, first.start - RADIUS), false);
+  const to = wordEdge(source, Math.min(source.length, first.end + RADIUS), true);
+  const quoted = source.slice(from, to);
+  const lead = quoted.length - quoted.trimStart().length;
+  const text = quoted.trim();
+  const offset = from + lead;
+
+  const marks = inSource
+    .map(m => ({ start: m.start - offset, end: m.end - offset }))
+    .filter(m => m.start >= 0 && m.end <= text.length);
+  return { text, marks };
+};

--- a/packages/search-core/src/text/fold.ts
+++ b/packages/search-core/src/text/fold.ts
@@ -1,0 +1,68 @@
+/*
+ * Folding, with a way back.
+ *
+ * Matching happens on folded text; the snippet has to be quoted from the
+ * ORIGINAL, with the highlight over the characters the reader actually
+ * wrote. Those two texts do not line up — folding collapses a run of
+ * punctuation into one space and drops combining marks entirely — so an
+ * offset found in the folded text means nothing in the source unless we
+ * record where each folded character came from.
+ *
+ * Assuming the fold was length-preserving is exactly the bug this exists
+ * to prevent: the highlight lands on whatever happened to sit at the same
+ * index, and the reader sees a random half-word marked.
+ */
+
+/* Combining marks left behind by the NFD decomposition. */
+const COMBINING = /\p{M}+/gu;
+
+/* A letter or a digit survives folding; anything else is a separator. */
+const KEEPS = /[\p{L}\p{N}]/u;
+
+/** Folded text, plus where each of its characters came from. */
+export interface Folded {
+  readonly text: string;
+  /** `source[map[i]]` is the character `text[i]` was folded from. */
+  readonly map: readonly number[];
+}
+
+/*
+ * `й` is a LETTER, not an accented `и` — but NFD decomposes it into `и`
+ * plus a combining breve, and the strip below would then eat it, quietly
+ * folding «нейросеть» into «неиросеть» and «война» into «воина».
+ *
+ * `ё → е` is the opposite case, and deliberate: a spelling variant readers
+ * substitute freely, so folding the two together is the point.
+ */
+const foldChar = (ch: string): string => {
+  const lower = ch.toLowerCase();
+  if (lower === 'ё') return 'е';
+  if (lower === 'й') return 'й';
+  return lower.normalize('NFD').replace(COMBINING, '');
+};
+
+/**
+ * Fold text for matching, keeping a map back to the source.
+ * @param raw - Any user- or content-supplied text.
+ * @returns The folded text and, per character, its source offset.
+ */
+export const foldWithMap = (raw: string): Folded => {
+  const out: string[] = [];
+  const map: number[] = [];
+  for (let at = 0; at < raw.length; at += 1) {
+    const folded = foldChar(raw[at] ?? '');
+    if (folded === '') continue;
+    if (!KEEPS.test(folded)) {
+      /* Collapse a run of separators into a single space. */
+      if (out.at(-1) === ' ') continue;
+      out.push(' ');
+      map.push(at);
+      continue;
+    }
+    for (const ch of folded) {
+      out.push(ch);
+      map.push(at);
+    }
+  }
+  return { text: out.join(''), map };
+};

--- a/packages/search-core/src/text/normalize.test.ts
+++ b/packages/search-core/src/text/normalize.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { normalize, tokenize } from './normalize';
+
+describe('normalize', () => {
+  it('folds case', () => {
+    expect(normalize('Маркс ENGELS')).toBe('маркс engels');
+  });
+
+  /*
+   * Readers type `е` for `ё` far more often than not — a query for
+   * "нейросети" must still reach a body that spells it "нейросётка".
+   * The fold is one-way and lossy on purpose.
+   */
+  it('folds ё to е so the two spellings collide', () => {
+    expect(normalize('нейросёть')).toBe(normalize('нейросеть'));
+  });
+
+  /*
+   * NFD decomposes `й` into `и` + a combining breve, so a blanket
+   * diacritic strip silently turns «война» into «воина». It is a letter,
+   * not an accent.
+   */
+  it('keeps й — it is a letter, not an accented и', () => {
+    expect(normalize('нейросеть')).toBe('нейросеть');
+    expect(normalize('ВОЙНА')).toBe('война');
+    expect(normalize('война')).not.toBe(normalize('воина'));
+  });
+
+  it('strips diacritics so Italian and Spanish queries survive a plain keyboard', () => {
+    expect(normalize('perché')).toBe('perche');
+    expect(normalize('revolución')).toBe('revolucion');
+  });
+
+  it('collapses punctuation and whitespace into single spaces', () => {
+    expect(normalize('  «Капитал»,\n\tтом  I. ')).toBe('капитал том i');
+  });
+
+  it('keeps digits — issue numbers and years are searchable', () => {
+    expect(normalize('Обзор 2026')).toBe('обзор 2026');
+  });
+
+  it('survives an empty string', () => {
+    expect(normalize('')).toBe('');
+  });
+});
+
+describe('tokenize', () => {
+  it('splits a normalized string into words', () => {
+    expect(tokenize('искусственный интеллект и труд')).toEqual([
+      'искусственный',
+      'интеллект',
+      'и',
+      'труд',
+    ]);
+  });
+
+  it('returns nothing for a blank query', () => {
+    expect(tokenize('   ')).toEqual([]);
+  });
+
+  it('normalizes before splitting', () => {
+    expect(tokenize('Нейросёти, ИИ!')).toEqual(['нейросети', 'ии']);
+  });
+});

--- a/packages/search-core/src/text/normalize.ts
+++ b/packages/search-core/src/text/normalize.ts
@@ -1,0 +1,28 @@
+import { foldWithMap } from './fold';
+
+/*
+ * One fold, used for both the query and the indexed text, so the two are
+ * always compared in the same alphabet.
+ *
+ * Defined in terms of `foldWithMap` on purpose: the snippet builder needs
+ * the offsets back, and if matching used a second, separately-written
+ * fold the two could drift apart — a term found by one would be missing
+ * from the other, and the highlight would land nowhere.
+ */
+
+/**
+ * Fold a string into the alphabet the index and the query share.
+ * @param raw - Any user- or content-supplied text.
+ * @returns Lower-case, diacritic-free, single-spaced text.
+ */
+export const normalize = (raw: string): string => foldWithMap(raw).text.trim();
+
+/**
+ * Split text into searchable words, normalising first.
+ * @param raw - Any user- or content-supplied text.
+ * @returns Words, in order; empty for text with no letters or digits.
+ */
+export const tokenize = (raw: string): readonly string[] => {
+  const normalized = normalize(raw);
+  return normalized === '' ? [] : normalized.split(' ');
+};

--- a/packages/search-core/tsconfig.json
+++ b/packages/search-core/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.base.json",
+  "include": ["src"]
+}

--- a/src/features/content/helpers/deriveSummary.ts
+++ b/src/features/content/helpers/deriveSummary.ts
@@ -6,35 +6,12 @@
  * - Strip markdown decorations (headings, lists, bold, italic, …).
  * - Take the first non-trivial paragraph.
  * - Truncate on a word boundary at ~MAX_LEN characters; append …
+ *
+ * The stripper itself lives in `stripMarkdown` — the search index needs
+ * exactly the same "words a reader can actually see", and one copy of
+ * that rule is enough.
  */
-
-/* Patterns that drop the match entirely (no capture group). */
-const DROP_PATTERNS: ReadonlyArray<RegExp> = [
-  /^---[\s\S]*?\n---\s*/,
-  /^#{1,6}\s+.*$/gm,
-  /^>\s*/gm,
-  /^\s*[-*+]\s+/gm,
-  /^\s*\d+\.\s+/gm,
-  /<\/?[a-z][^>]*>/gi,
-  /!\[[^\]]*\]\([^)]*\)/g,
-];
-
-/* Patterns that keep the visible text inside the capture group. */
-const KEEP_PATTERNS: ReadonlyArray<RegExp> = [
-  /\*\*([^*]+)\*\*/g,
-  /__([^_]+)__/g,
-  /\*([^*]+)\*/g,
-  /_([^_]+)_/g,
-  /`([^`]+)`/g,
-  /\[([^\]]+)\]\([^)]*\)/g,
-];
-
-const stripMarkdown = (raw: string): string => {
-  let out = raw;
-  for (const re of DROP_PATTERNS) out = out.replace(re, '');
-  for (const re of KEEP_PATTERNS) out = out.replace(re, (_, captured: string) => captured);
-  return out;
-};
+import { stripMarkdown } from './stripMarkdown';
 
 const MAX_LEN = 320;
 

--- a/src/features/content/helpers/stripMarkdown.ts
+++ b/src/features/content/helpers/stripMarkdown.ts
@@ -1,0 +1,48 @@
+/*
+ * Markdown → plain text.
+ *
+ * Shared by the listing-card summary (`deriveSummary`) and the search
+ * index: both want the words a reader would actually see, without the
+ * syntax that puts them on the page. Kept in one place so a query can
+ * never match a heading marker or an image URL that no reader can see.
+ */
+
+/* Patterns that drop the match entirely (no capture group). */
+const DROP_PATTERNS: ReadonlyArray<RegExp> = [
+  /^---[\s\S]*?\n---\s*/,
+  /^#{1,6}\s+.*$/gm,
+  /^>\s*/gm,
+  /^\s*[-*+]\s+/gm,
+  /^\s*\d+\.\s+/gm,
+  /<\/?[a-z][^>]*>/gi,
+  /!\[[^\]]*\]\([^)]*\)/g,
+];
+
+/* Patterns that keep the visible text inside the capture group. */
+const KEEP_PATTERNS: ReadonlyArray<RegExp> = [
+  /\*\*([^*]+)\*\*/g,
+  /__([^_]+)__/g,
+  /\*([^*]+)\*/g,
+  /_([^_]+)_/g,
+  /`([^`]+)`/g,
+  /\[([^\]]+)\]\([^)]*\)/g,
+];
+
+/**
+ * Strip markdown decoration, keeping the visible words.
+ * @param raw Raw markdown body.
+ * @returns The same text with the syntax removed.
+ */
+export const stripMarkdown = (raw: string): string => {
+  let out = raw;
+  for (const re of DROP_PATTERNS) out = out.replace(re, '');
+  for (const re of KEEP_PATTERNS) out = out.replace(re, (_, captured: string) => captured);
+  return out;
+};
+
+/**
+ * Flatten a markdown body into one line of searchable prose.
+ * @param raw Raw markdown body.
+ * @returns Plain text with runs of whitespace collapsed.
+ */
+export const toPlainText = (raw: string): string => stripMarkdown(raw).replace(/\s+/g, ' ').trim();

--- a/src/features/navigation/components/Header.astro
+++ b/src/features/navigation/components/Header.astro
@@ -1,5 +1,6 @@
 ---
 import type { Language } from '@/config/i18n';
+import SearchBox from '@/features/search/components/SearchBox.astro';
 import ThemeToggle from '@/features/theme/components/ThemeToggle.astro';
 import LanguageSwitcher from './LanguageSwitcher.astro';
 import Nav from './Nav.astro';
@@ -22,6 +23,9 @@ const { lang, availableLangs } = Astro.props;
       <div class="header-actions">
         <div class="desktop-only" data-testid="desktop-nav">
           <Nav lang={lang} />
+        </div>
+        <div class="desktop-only">
+          <SearchBox lang={lang} variant="header" />
         </div>
         <div class="desktop-only">
           <LanguageSwitcher lang={lang} availableLangs={availableLangs} />

--- a/src/features/navigation/components/MobileMenu.astro
+++ b/src/features/navigation/components/MobileMenu.astro
@@ -1,6 +1,7 @@
 ---
 import type { Language } from '@/config/i18n';
 import { getMenuData, getNavLinks } from '@/config/translations';
+import SearchBox from '@/features/search/components/SearchBox.astro';
 import ThemeToggle from '@/features/theme/components/ThemeToggle.astro';
 import LanguageSwitcher from './LanguageSwitcher.astro';
 
@@ -85,6 +86,9 @@ const menuLabel = nav?.data.menu ?? 'Menu';
     aria-modal="true"
     aria-label={menuLabel}
   >
+    <div class="popup-search">
+      <SearchBox lang={lang} variant="mobile" />
+    </div>
     <ul class="popup-links">
       {links.map(({ href, label }) => (
         <li><a href={href}>{label}</a></li>

--- a/src/features/search/components/SearchBox.astro
+++ b/src/features/search/components/SearchBox.astro
@@ -1,0 +1,208 @@
+---
+import { searchStrings } from '../i18n';
+
+interface Props {
+  readonly lang: string;
+  /**
+   * `header` is the compact bar in the top bar, `hero` the wide box on the
+   * home and results pages, `mobile` the one inside the burger menu.
+   *
+   * `mobile` looks like `hero` but is its own variant so the two are
+   * addressable apart: several of these render on the same page, and a
+   * test — or a script — that cannot tell them apart grabs the wrong one.
+   */
+  readonly variant?: 'header' | 'hero' | 'mobile';
+}
+
+const { lang, variant = 'header' } = Astro.props;
+const t = searchStrings(lang);
+const id = `search-${variant}`;
+
+/*
+ * A real <form> pointing at the search page, so the box works with no JS
+ * at all: type, press Enter, land on /{lang}/search?q=… server-rendered.
+ * The script below upgrades it into a live combobox; it never becomes the
+ * only way in.
+ */
+---
+
+<form
+  class:list={['search', variant]}
+  role="search"
+  action={`/${lang}/search`}
+  method="get"
+  data-search
+  data-lang={lang}
+  data-testid={`search-${variant}`}
+>
+  <label class="sr-only" for={id}>{t.label}</label>
+  <input
+    id={id}
+    class="input"
+    type="search"
+    name="q"
+    autocomplete="off"
+    placeholder={t.placeholder}
+    role="combobox"
+    aria-expanded="false"
+    aria-controls={`${id}-listbox`}
+    aria-autocomplete="list"
+    data-search-input
+    data-testid={`search-input-${variant}`}
+  />
+  <div class="panel" data-search-panel hidden>
+    <ul
+      id={`${id}-listbox`}
+      class="list"
+      role="listbox"
+      aria-label={t.resultsTitle}
+      data-search-list
+      data-testid="search-results"
+    ></ul>
+    <p class="empty" data-search-empty hidden data-testid="search-empty">
+      {t.noResults}
+    </p>
+  </div>
+  <p class="sr-only" aria-live="polite" data-search-status></p>
+</form>
+
+<script>
+  import { setupSearch } from '../search-client';
+
+  const init = (): void => {
+    document
+      .querySelectorAll<HTMLFormElement>('[data-search]')
+      .forEach(setupSearch);
+  };
+
+  init();
+  document.addEventListener('astro:after-swap', init);
+</script>
+
+<style>
+  .search {
+    position: relative;
+  }
+
+  .input {
+    inline-size: 100%;
+    padding: var(--spacing-xs) var(--spacing-sm);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text-primary);
+    font-size: 0.875rem;
+  }
+
+  .input:focus-visible {
+    outline: 2px solid var(--color-focus-ring);
+    outline-offset: 1px;
+  }
+
+  .header .input {
+    inline-size: clamp(9rem, 16vw, 15rem);
+  }
+
+  .hero .input,
+  .mobile .input {
+    padding: var(--spacing-sm) var(--spacing-md);
+    font-size: 1rem;
+  }
+
+  /*
+   * `absolute`, never `fixed`: the header takes a `transform` when it
+   * retracts on scroll, and a fixed child of a transformed ancestor is
+   * positioned against that ancestor instead of the viewport.
+   */
+  .panel {
+    position: absolute;
+    z-index: 300;
+    inset-inline: 0;
+    inset-block-start: calc(100% + 0.35rem);
+    max-block-size: min(60vh, 28rem);
+    overflow-y: auto;
+    background: var(--color-surface-elevated);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-md);
+  }
+
+  .hero .panel,
+  .mobile .panel {
+    inline-size: 100%;
+  }
+
+  .list {
+    list-style: none;
+    margin: 0;
+    padding: 0.25rem;
+  }
+
+  .empty {
+    margin: 0;
+    padding: var(--spacing-sm);
+    color: var(--color-text-secondary);
+    font-size: 0.875rem;
+  }
+
+  /*
+   * Result rows are built by the script, so Astro's scoping never reaches
+   * them — they carry no scope attribute. Style them through :global,
+   * nested under .panel so the rules stay confined to this component.
+   */
+  .panel :global(.hit-link) {
+    display: grid;
+    gap: 0.15rem;
+    padding: var(--spacing-xs) var(--spacing-sm);
+    border-radius: var(--radius-sm);
+    color: var(--color-text-primary);
+    text-decoration: none;
+  }
+
+  .panel :global(.hit-link:hover),
+  .panel :global([aria-selected='true'] .hit-link) {
+    background: var(--color-surface);
+  }
+
+  .panel :global(.hit-section) {
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-text-secondary);
+  }
+
+  .panel :global(.hit-title) {
+    font-weight: 600;
+    font-size: 0.9375rem;
+  }
+
+  .panel :global(.hit-snippet) {
+    margin: 0;
+    font-size: 0.8125rem;
+    line-height: 1.5;
+    color: var(--color-text-secondary);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .panel :global(.hit-mark) {
+    background: var(--color-warning, #ff9800);
+    color: var(--color-text-primary);
+    border-radius: 2px;
+    padding-inline: 0.1em;
+  }
+
+  .sr-only {
+    position: absolute;
+    inline-size: 1px;
+    block-size: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+  }
+</style>

--- a/src/features/search/helpers/buildIndex.ts
+++ b/src/features/search/helpers/buildIndex.ts
@@ -1,0 +1,112 @@
+import type { SearchDoc, SearchSection } from '@prometheus/search-core';
+import { contentHash } from '@prometheus/search-core';
+import { features } from '@/config/features';
+import type { Language } from '@/config/i18n';
+import { getPageData } from '@/config/translations';
+import { getArchiveItems, getArchiveSlug } from '@/features/archive/helpers/getArchiveItems';
+import { getArticleSlug, getBlogPosts } from '@/features/blog/helpers/getBlogPosts';
+import { toPlainText } from '@/features/content/helpers/stripMarkdown';
+import { getMagazineItems } from '@/features/magazine/helpers/getMagazineItems';
+import { getPositions } from '@/features/positions/helpers/getPositions';
+
+/*
+ * The search index is built from the same helpers the pages are built
+ * from — `getBlogPosts`, `getPositions`, `getMagazineItems`,
+ * `getArchiveItems` — and never from the collections directly. That is
+ * deliberate: those helpers carry the `published === true` gate, so a
+ * draft cannot leak into the index, and a result can never point at a URL
+ * the build did not emit.
+ */
+
+/** Minimum a section entry has to expose to be indexable. */
+interface Indexable {
+  readonly id: string;
+  readonly body?: string | undefined;
+  readonly data: {
+    readonly title: string;
+    readonly description?: string | undefined;
+  };
+}
+
+const slugOf = (id: string): string => id.split('/').at(0) ?? id;
+
+const toDoc = (
+  lang: Language,
+  section: SearchSection,
+  slug: string,
+  entry: Indexable,
+  url: string,
+): SearchDoc => {
+  const title = entry.data.title;
+  const description = entry.data.description ?? '';
+  const body = toPlainText(entry.body ?? '');
+  return {
+    id: `${lang}/${section}/${slug}`,
+    lang,
+    section,
+    slug,
+    url,
+    title,
+    description,
+    body,
+    hash: contentHash(title, description, body),
+  };
+};
+
+const sectionDocs = async (lang: Language): Promise<readonly SearchDoc[]> => {
+  const [posts, positions, issues] = await Promise.all([
+    getBlogPosts(lang),
+    getPositions(lang),
+    getMagazineItems(lang),
+  ]);
+  return [
+    ...posts.map((p) =>
+      toDoc(lang, 'blog', getArticleSlug(p), p, `/${lang}/blog/${getArticleSlug(p)}`),
+    ),
+    ...positions.map((p) =>
+      toDoc(lang, 'positions', slugOf(p.id), p, `/${lang}/positions/${slugOf(p.id)}`),
+    ),
+    ...issues.map((i) =>
+      toDoc(lang, 'magazine', slugOf(i.id), i, `/${lang}/magazine/${slugOf(i.id)}`),
+    ),
+  ];
+};
+
+/*
+ * Archive is behind a build flag and ships OFF in production. Indexing it
+ * regardless would offer the reader results whose pages do not exist.
+ */
+const archiveDocs = async (lang: Language): Promise<readonly SearchDoc[]> => {
+  if (!features.archive) return [];
+  const items = await getArchiveItems(lang);
+  return items.map((item) => {
+    const slug = getArchiveSlug(item);
+    return toDoc(lang, 'archive', slug, item, `/${lang}/archive/${slug}`);
+  });
+};
+
+/*
+ * Only the prose pages. `home` and the `*-listing` entries are carriers
+ * for headings and CTA labels, not documents — indexing them would put
+ * "Latest news" in the results.
+ */
+const PROSE_PAGES = ['about', 'manifest'] as const;
+
+const pageDocs = async (lang: Language): Promise<readonly SearchDoc[]> => {
+  const entries = await Promise.all(
+    PROSE_PAGES.map(async (slug) => ({ slug, entry: await getPageData(slug, lang) })),
+  );
+  return entries.flatMap(({ slug, entry }) =>
+    entry === undefined ? [] : [toDoc(lang, 'page', slug, entry, `/${lang}/${slug}`)],
+  );
+};
+
+/**
+ * Every published document one language can search.
+ * @param lang Target language.
+ * @returns Documents, ready to serialise into the index.
+ */
+export const buildIndex = async (lang: Language): Promise<readonly SearchDoc[]> => {
+  const groups = await Promise.all([sectionDocs(lang), archiveDocs(lang), pageDocs(lang)]);
+  return groups.flat();
+};

--- a/src/features/search/i18n.ts
+++ b/src/features/search/i18n.ts
@@ -1,0 +1,85 @@
+import type { SearchSection } from '@prometheus/search-core';
+
+/*
+ * Search chrome lives here rather than in the `common` collection on
+ * purpose. That collection's field set is mirrored by admin-website and
+ * policed by a cross-repo drift guard, so four UI labels would cost a
+ * content-repo commit and an admin release before the feature could ship
+ * at all. `links.astro` sets the precedent for a page that localises its
+ * own chrome. Moving these into the content repo later is additive.
+ */
+
+/** The strings the search UI needs, per language. */
+export interface SearchStrings {
+  readonly label: string;
+  readonly placeholder: string;
+  readonly noResults: string;
+  readonly resultsTitle: string;
+  readonly sections: Readonly<Record<SearchSection, string>>;
+}
+
+const EN: SearchStrings = {
+  label: 'Search',
+  placeholder: 'Search articles…',
+  noResults: 'Nothing found.',
+  resultsTitle: 'Search',
+  sections: {
+    blog: 'Blog',
+    positions: 'Positions',
+    magazine: 'Magazine',
+    archive: 'Archive',
+    page: 'Page',
+  },
+};
+
+const STRINGS: Readonly<Record<string, SearchStrings>> = {
+  en: EN,
+  ru: {
+    label: 'Поиск',
+    placeholder: 'Искать по статьям…',
+    noResults: 'Ничего не найдено.',
+    resultsTitle: 'Поиск',
+    sections: {
+      blog: 'Блог',
+      positions: 'Позиции',
+      magazine: 'Журнал',
+      archive: 'Архив',
+      page: 'Страница',
+    },
+  },
+  it: {
+    label: 'Cerca',
+    placeholder: 'Cerca negli articoli…',
+    noResults: 'Nessun risultato.',
+    resultsTitle: 'Ricerca',
+    sections: {
+      blog: 'Blog',
+      positions: 'Posizioni',
+      magazine: 'Rivista',
+      archive: 'Archivio',
+      page: 'Pagina',
+    },
+  },
+  es: {
+    label: 'Buscar',
+    placeholder: 'Buscar artículos…',
+    noResults: 'No se encontró nada.',
+    resultsTitle: 'Búsqueda',
+    sections: {
+      blog: 'Blog',
+      positions: 'Posiciones',
+      magazine: 'Revista',
+      archive: 'Archivo',
+      page: 'Página',
+    },
+  },
+};
+
+/**
+ * Search chrome for a language, falling back to English when the
+ * language has no translation yet — the same contract every other label
+ * on this site follows.
+ * @param lang Active page language.
+ * @returns The strings to render.
+ */
+export const searchStrings = (lang: string): SearchStrings => STRINGS[lang] ?? EN;

--- a/src/features/search/render-hit.test.ts
+++ b/src/features/search/render-hit.test.ts
@@ -1,0 +1,76 @@
+import type { SearchHit } from '@prometheus/search-core';
+import { describe, expect, it } from 'vitest';
+import { snippetParts } from './render-hit';
+
+const hit = (text: string, marks: readonly { start: number; end: number }[]): SearchHit =>
+  ({
+    doc: {
+      id: 'ru/blog/x',
+      lang: 'ru',
+      section: 'blog',
+      slug: 'x',
+      url: '/ru/blog/x',
+      title: 't',
+      description: '',
+      body: '',
+      hash: '00000000',
+    },
+    score: 1,
+    snippet: { text, marks },
+  }) satisfies SearchHit;
+
+describe('snippetParts', () => {
+  it('splits the snippet around a match', () => {
+    expect(snippetParts(hit('про нейросети тут', [{ start: 4, end: 13 }]))).toEqual([
+      { text: 'про ', marked: false },
+      { text: 'нейросети', marked: true },
+      { text: ' тут', marked: false },
+    ]);
+  });
+
+  it('marks a match at the very start', () => {
+    expect(snippetParts(hit('маркс писал', [{ start: 0, end: 5 }]))).toEqual([
+      { text: 'маркс', marked: true },
+      { text: ' писал', marked: false },
+    ]);
+  });
+
+  it('merges overlapping ranges rather than repeating characters', () => {
+    const parts = snippetParts(
+      hit('нейросети', [
+        { start: 0, end: 5 },
+        { start: 3, end: 9 },
+      ]),
+    );
+    expect(parts.map((p) => p.text).join('')).toBe('нейросети');
+    expect(parts).toHaveLength(1);
+    expect(parts[0]?.marked).toBe(true);
+  });
+
+  it('rebuilds the snippet exactly — no character is lost or doubled', () => {
+    const text = 'слово другое третье';
+    const parts = snippetParts(
+      hit(text, [
+        { start: 0, end: 5 },
+        { start: 13, end: 19 },
+      ]),
+    );
+    expect(parts.map((p) => p.text).join('')).toBe(text);
+  });
+
+  /*
+   * The reason the scorer returns ranges instead of HTML: the caller sets
+   * `textContent` on each part, so a body carrying an <img onerror> tag
+   * comes back as characters, never as markup.
+   */
+  it('leaves markup in the content as inert text', () => {
+    const parts = snippetParts(hit('<img src=x onerror=alert(1)>', []));
+    expect(parts).toEqual([{ text: '<img src=x onerror=alert(1)>', marked: false }]);
+  });
+
+  it('handles a snippet with no matches', () => {
+    expect(snippetParts(hit('без совпадений', []))).toEqual([
+      { text: 'без совпадений', marked: false },
+    ]);
+  });
+});

--- a/src/features/search/render-hit.ts
+++ b/src/features/search/render-hit.ts
@@ -1,0 +1,56 @@
+import type { Mark, SearchHit } from '@prometheus/search-core';
+
+/*
+ * Rendering a hit means putting content-derived text into the DOM, so it
+ * is the one place a body containing `<img src=x onerror=…>` could become
+ * markup. The scorer hands over a plain string plus character RANGES, and
+ * this splits the string on those ranges into parts the caller sets with
+ * `textContent`. No HTML is ever assembled from content.
+ */
+
+/** A run of snippet text, and whether the query landed on it. */
+export interface SnippetPart {
+  readonly text: string;
+  readonly marked: boolean;
+}
+
+const byStart = (a: Mark, b: Mark): number => a.start - b.start;
+
+/* Overlapping ranges would produce parts that repeat the same characters. */
+const merge = (marks: readonly Mark[]): readonly Mark[] => {
+  const sorted = [...marks].sort(byStart);
+  const out: Mark[] = [];
+  for (const mark of sorted) {
+    const last = out.at(-1);
+    if (last !== undefined && mark.start <= last.end) {
+      out[out.length - 1] = {
+        start: last.start,
+        end: Math.max(last.end, mark.end),
+      };
+      continue;
+    }
+    out.push(mark);
+  }
+  return out;
+};
+
+/**
+ * Split a hit's snippet into plain and matched runs.
+ * @param hit A search hit.
+ * @returns Runs in order; concatenating their text rebuilds the snippet.
+ */
+export const snippetParts = (hit: SearchHit): readonly SnippetPart[] => {
+  const { text, marks } = hit.snippet;
+  const merged = merge(marks);
+  const parts: SnippetPart[] = [];
+  let at = 0;
+  for (const mark of merged) {
+    if (mark.start > at) {
+      parts.push({ text: text.slice(at, mark.start), marked: false });
+    }
+    parts.push({ text: text.slice(mark.start, mark.end), marked: true });
+    at = mark.end;
+  }
+  if (at < text.length) parts.push({ text: text.slice(at), marked: false });
+  return parts;
+};

--- a/src/features/search/render-list.ts
+++ b/src/features/search/render-list.ts
@@ -1,0 +1,77 @@
+import type { SearchHit, SearchSection } from '@prometheus/search-core';
+import { snippetParts } from './render-hit';
+
+/*
+ * Every string that came from content is written with `textContent`, and
+ * the highlight is built by splitting on the scorer's character ranges.
+ * Nothing here concatenates HTML, so a body carrying `<img onerror=…>`
+ * lands in the page as characters — the way the reader wrote them.
+ */
+
+const el = <K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  className: string,
+): HTMLElementTagNameMap[K] => {
+  const node = document.createElement(tag);
+  node.className = className;
+  return node;
+};
+
+const snippetOf = (hit: SearchHit): HTMLParagraphElement => {
+  const p = el('p', 'hit-snippet');
+  for (const part of snippetParts(hit)) {
+    const node = part.marked ? el('mark', 'hit-mark') : document.createTextNode('');
+    node.textContent = part.text;
+    p.append(node);
+  }
+  return p;
+};
+
+const rowOf = (
+  hit: SearchHit,
+  at: number,
+  sections: Readonly<Record<SearchSection, string>>,
+  asOption: boolean,
+): HTMLLIElement => {
+  const li = el('li', 'hit');
+  /*
+   * `role="option"` is only meaningful inside a listbox. The dropdown is
+   * one; the results page is a plain list of links, and claiming the role
+   * there would lie to a screen reader about what it can do.
+   */
+  if (asOption) {
+    li.id = `search-hit-${at}`;
+    li.setAttribute('role', 'option');
+    li.setAttribute('aria-selected', 'false');
+  }
+
+  const link = el('a', 'hit-link');
+  link.href = hit.doc.url;
+
+  const section = el('span', 'hit-section');
+  section.textContent = sections[hit.doc.section];
+
+  const title = el('span', 'hit-title');
+  title.textContent = hit.doc.title;
+
+  link.append(section, title, snippetOf(hit));
+  li.append(link);
+  return li;
+};
+
+/**
+ * Replace a list's contents with the given hits.
+ * @param list The `<ul>` to fill.
+ * @param hits Ranked hits.
+ * @param sections Localised section labels.
+ * @param asOptions Whether the list is a combobox listbox (the dropdown)
+ * rather than a plain list of links (the results page).
+ */
+export const renderHits = (
+  list: HTMLElement,
+  hits: readonly SearchHit[],
+  sections: Readonly<Record<SearchSection, string>>,
+  asOptions = true,
+): void => {
+  list.replaceChildren(...hits.map((hit, at) => rowOf(hit, at, sections, asOptions)));
+};

--- a/src/features/search/search-client.ts
+++ b/src/features/search/search-client.ts
@@ -1,0 +1,152 @@
+import type { PreparedIndex, SearchHit } from '@prometheus/search-core';
+import { prepare, search } from '@prometheus/search-core';
+import { searchStrings } from './i18n';
+import { renderHits } from './render-list';
+
+/*
+ * The index is the largest thing this site serves, and most visits never
+ * search — so it is fetched on the FIRST keystroke, not on page load, and
+ * the prepared result is cached at module scope. `<ClientRouter />` swaps
+ * the DOM on every navigation but keeps the module graph, so the cache
+ * survives; hanging it off a DOM node would not.
+ */
+const cache = new Map<string, Promise<PreparedIndex>>();
+
+const DEBOUNCE_MS = 120;
+const MAX_HITS = 8;
+
+const loadIndex = (lang: string): Promise<PreparedIndex> => {
+  const hit = cache.get(lang);
+  if (hit !== undefined) return hit;
+  const pending = fetch(`/${lang}/search-index.json`)
+    .then((res) => res.json())
+    .then(prepare)
+    .catch((error: unknown) => {
+      /*
+       * A rejected promise left in the cache would be handed to every
+       * later keystroke — one flaky fetch and search is dead until the
+       * page is reloaded. Drop it so the next attempt starts clean.
+       */
+      cache.delete(lang);
+      throw error;
+    });
+  cache.set(lang, pending);
+  return pending;
+};
+
+/* Fire-and-forget: a failed index leaves the box inert, never throwing. */
+const ignore = (): undefined => undefined;
+
+interface Refs {
+  readonly form: HTMLFormElement;
+  readonly input: HTMLInputElement;
+  readonly panel: HTMLElement;
+  readonly list: HTMLElement;
+  readonly empty: HTMLElement;
+  readonly status: HTMLElement;
+}
+
+const refsOf = (form: HTMLFormElement): Refs | undefined => {
+  const input = form.querySelector<HTMLInputElement>('[data-search-input]');
+  const panel = form.querySelector<HTMLElement>('[data-search-panel]');
+  const list = form.querySelector<HTMLElement>('[data-search-list]');
+  const empty = form.querySelector<HTMLElement>('[data-search-empty]');
+  const status = form.querySelector<HTMLElement>('[data-search-status]');
+  if (!input || !panel || !list || !empty || !status) return undefined;
+  return { form, input, panel, list, empty, status };
+};
+
+const close = (r: Refs): void => {
+  r.panel.hidden = true;
+  r.input.setAttribute('aria-expanded', 'false');
+  r.input.removeAttribute('aria-activedescendant');
+};
+
+const activeOption = (r: Refs): HTMLElement | null =>
+  r.list.querySelector<HTMLElement>('[aria-selected="true"]');
+
+const move = (r: Refs, delta: number): void => {
+  const options = [...r.list.querySelectorAll<HTMLElement>('[role="option"]')];
+  if (options.length === 0) return;
+  const current = activeOption(r);
+  const at = current === null ? -1 : options.indexOf(current);
+  const next = options[(at + delta + options.length) % options.length];
+  if (next === undefined) return;
+  for (const option of options) option.setAttribute('aria-selected', 'false');
+  next.setAttribute('aria-selected', 'true');
+  r.input.setAttribute('aria-activedescendant', next.id);
+  next.scrollIntoView({ block: 'nearest' });
+};
+
+const show = (r: Refs, lang: string, hits: readonly SearchHit[]): void => {
+  const t = searchStrings(lang);
+  renderHits(r.list, hits, t.sections);
+  r.empty.hidden = hits.length > 0;
+  r.panel.hidden = false;
+  r.input.setAttribute('aria-expanded', 'true');
+  r.input.removeAttribute('aria-activedescendant');
+  r.status.textContent = hits.length === 0 ? t.noResults : `${hits.length}`;
+};
+
+const run = async (r: Refs, lang: string): Promise<void> => {
+  const query = r.input.value.trim();
+  if (query === '') {
+    close(r);
+    return;
+  }
+  const index = await loadIndex(lang);
+  /* The reader kept typing while the index was in flight — that run wins. */
+  if (r.input.value.trim() !== query) return;
+  show(r, lang, search(index, query, MAX_HITS));
+};
+
+const onKeydown = (event: KeyboardEvent, r: Refs): void => {
+  if (event.key === 'Escape') {
+    close(r);
+    return;
+  }
+  if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+    event.preventDefault();
+    move(r, event.key === 'ArrowDown' ? 1 : -1);
+    return;
+  }
+  if (event.key !== 'Enter') return;
+  const selected = activeOption(r)?.querySelector('a');
+  /* No selection: let the form submit and land on the full results page. */
+  if (selected === null || selected === undefined) return;
+  event.preventDefault();
+  selected.click();
+};
+
+/**
+ * Upgrade a search form into a live combobox. Idempotent — re-runs on
+ * every view transition, and re-wiring a form it already owns is a no-op.
+ * @param form The `<form data-search>` element.
+ */
+export const setupSearch = (form: HTMLFormElement): void => {
+  /*
+   * Attributes, not `dataset`: TypeScript wants bracket access on an index
+   * signature and Biome wants dot access, and they cannot both be right.
+   * `getAttribute` sidesteps the argument entirely.
+   */
+  if (form.getAttribute('data-search-init') === 'true') return;
+  const r = refsOf(form);
+  if (r === undefined) return;
+  form.setAttribute('data-search-init', 'true');
+  const lang = form.getAttribute('data-lang') ?? 'en';
+
+  let timer: ReturnType<typeof globalThis.setTimeout> | undefined;
+  r.input.addEventListener('input', () => {
+    globalThis.clearTimeout(timer);
+    timer = globalThis.setTimeout(() => {
+      run(r, lang).catch(ignore);
+    }, DEBOUNCE_MS);
+  });
+  r.input.addEventListener('keydown', (event) => onKeydown(event, r));
+  r.input.addEventListener('focus', () => {
+    loadIndex(lang).catch(ignore);
+  });
+  document.addEventListener('click', (event) => {
+    if (!form.contains(event.target as Node)) close(r);
+  });
+};

--- a/src/features/search/search-page.ts
+++ b/src/features/search/search-page.ts
@@ -1,0 +1,56 @@
+import { prepare, search } from '@prometheus/search-core';
+import { searchStrings } from './i18n';
+import { renderHits } from './render-list';
+
+/*
+ * The results page renders from the same index the dropdown uses.
+ *
+ * With no `?q=` it fetches NOTHING. That is not just an optimisation: the
+ * Lighthouse gate (100 across the board) audits `/en/search` as an
+ * ordinary page, and an index download it never needed would be counted
+ * against it. It is also the honest behaviour — an empty search box is
+ * not a request to download the site.
+ */
+
+const MAX_HITS = 40;
+
+const queryOf = (): string => new URL(globalThis.location.href).searchParams.get('q')?.trim() ?? '';
+
+/**
+ * Render the results for `?q=` into the page.
+ * @param root The container element, carrying `data-lang`.
+ */
+export const setupSearchPage = async (root: HTMLElement): Promise<void> => {
+  const query = queryOf();
+  if (query === '') return;
+
+  const lang = root.getAttribute('data-lang') ?? 'en';
+  const t = searchStrings(lang);
+
+  /*
+   * Several boxes render on this page — the header bar, the burger menu,
+   * and the page's own. Seed them all: picking "the first one" quietly
+   * seeds whichever happens to come first in the DOM, which is the header,
+   * not the one the reader is looking at.
+   */
+  for (const input of document.querySelectorAll<HTMLInputElement>('[data-search-input]')) {
+    input.value = query;
+  }
+
+  const res = await fetch(`/${lang}/search-index.json`);
+  const hits = search(prepare(await res.json()), query, MAX_HITS);
+
+  if (hits.length === 0) {
+    const empty = document.createElement('p');
+    empty.className = 'search-page-empty';
+    empty.textContent = t.noResults;
+    root.replaceChildren(empty);
+    return;
+  }
+
+  const list = document.createElement('ul');
+  list.className = 'search-page-list';
+  list.setAttribute('aria-label', t.resultsTitle);
+  root.replaceChildren(list);
+  renderHits(list, hits, t.sections, false);
+};

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -6,6 +6,7 @@ import Hero from '@/features/home/components/Hero.astro';
 import NewsSection from '@/features/home/components/NewsSection.astro';
 import PositionsWidget from '@/features/positions/components/PositionsWidget.astro';
 import { getPositions } from '@/features/positions/helpers/getPositions';
+import SearchBox from '@/features/search/components/SearchBox.astro';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
 export const getStaticPaths = () => SUPPORTED_LANGUAGES.map((lang) => ({ params: { lang } }));
@@ -37,6 +38,7 @@ const readMoreLabel = labels?.data.readMore ?? 'Read more';
 <BaseLayout title={title} {...(description ? { description } : {})} lang={lang}>
   <Hero title={heroTitle ?? ''}>
     {heroIntro ? <p>{heroIntro}</p> : null}
+    <SearchBox lang={lang} variant="hero" />
     <a class="button hero-cta" href={`/${lang}/about`}>{readMoreLabel} →</a>
   </Hero>
   <PositionsWidget lang={lang} positions={latestPositions} />

--- a/src/pages/[lang]/search-index.json.ts
+++ b/src/pages/[lang]/search-index.json.ts
@@ -1,0 +1,38 @@
+import type { SearchIndex } from '@prometheus/search-core';
+import type { APIContext } from 'astro';
+import { DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES } from '@/config/i18n';
+import { buildIndex } from '@/features/search/helpers/buildIndex';
+
+/**
+ * Per-locale search index at `/<lang>/search-index.json`.
+ *
+ * Emitted as a static file at build time and fetched by the browser only
+ * when a reader actually touches the search box — it is the largest thing
+ * this site serves, and most visits never search.
+ *
+ * Staleness takes care of itself: the service worker caches same-origin
+ * GETs cache-first, and its cache version is bumped on every build (see
+ * `src/integrations/sw-manifest.ts`), so a deploy retires the old index
+ * along with the old pages.
+ *
+ * @returns one index per supported language.
+ */
+export const getStaticPaths = () => SUPPORTED_LANGUAGES.map((lang) => ({ params: { lang } }));
+
+interface Params {
+  readonly lang?: string;
+}
+
+/**
+ * Serialise one language's index.
+ * @param context - Astro endpoint context carrying `params.lang`.
+ * @returns JSON response.
+ */
+export const GET = async (context: APIContext) => {
+  const params: Params = context.params;
+  const lang = params.lang ?? DEFAULT_LANGUAGE;
+  const index: SearchIndex = { lang, docs: await buildIndex(lang) };
+  return new Response(JSON.stringify(index), {
+    headers: { 'Content-Type': 'application/json; charset=utf-8' },
+  });
+};

--- a/src/pages/[lang]/search.astro
+++ b/src/pages/[lang]/search.astro
@@ -1,0 +1,108 @@
+---
+import { SUPPORTED_LANGUAGES } from '@/config/i18n';
+import SearchBox from '@/features/search/components/SearchBox.astro';
+import { searchStrings } from '@/features/search/i18n';
+import BaseLayout from '@/layouts/BaseLayout.astro';
+
+/*
+ * Full results, addressable by URL — a search worth sharing survives
+ * being pasted into a chat. It is also where the header form lands when
+ * JavaScript never arrives: the box is a real GET form, so pressing Enter
+ * always gets the reader here.
+ *
+ * The results themselves are rendered client-side from the same index the
+ * dropdown uses. Rendering them at build time is not an option: there is
+ * no server, and one static page per possible query does not exist.
+ */
+export const getStaticPaths = async () => SUPPORTED_LANGUAGES.map((lang) => ({ params: { lang } }));
+
+const { lang } = Astro.params;
+const t = searchStrings(lang);
+---
+
+<BaseLayout title={t.resultsTitle} description={t.placeholder} lang={lang}>
+  <div class="section">
+    <div class="container">
+      <h1>{t.resultsTitle}</h1>
+      <SearchBox lang={lang} variant="hero" />
+      <div class="page-results" data-search-page data-lang={lang} data-testid="search-page-results"></div>
+    </div>
+  </div>
+</BaseLayout>
+
+<script>
+  import { setupSearchPage } from '@/features/search/search-page';
+
+  const init = (): void => {
+    const root = document.querySelector<HTMLElement>('[data-search-page]');
+    if (root !== null) setupSearchPage(root).catch(() => undefined);
+  };
+
+  init();
+  document.addEventListener('astro:after-swap', init);
+</script>
+
+<style>
+  h1 {
+    font-size: clamp(1.75rem, 5vw, 2.5rem);
+    font-weight: 700;
+    margin-bottom: var(--spacing-lg);
+  }
+
+  .page-results {
+    margin-block-start: var(--spacing-xl);
+  }
+
+  /* Rows are created by the script — see the note in SearchBox.astro. */
+  .page-results :global(.search-page-list) {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: var(--spacing-md);
+  }
+
+  .page-results :global(.hit-link) {
+    display: grid;
+    gap: 0.2rem;
+    padding: var(--spacing-md);
+    border-left: 3px solid var(--color-border);
+    color: var(--color-text-primary);
+    text-decoration: none;
+  }
+
+  .page-results :global(.hit-link:hover) {
+    border-left-color: var(--color-accent);
+    background: var(--color-surface);
+  }
+
+  .page-results :global(.hit-section) {
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-text-secondary);
+  }
+
+  .page-results :global(.hit-title) {
+    font-weight: 600;
+    font-size: 1.0625rem;
+  }
+
+  .page-results :global(.hit-snippet) {
+    margin: 0;
+    font-size: 0.9375rem;
+    line-height: 1.6;
+    color: var(--color-text-secondary);
+  }
+
+  .page-results :global(.hit-mark) {
+    background: var(--color-warning, #ff9800);
+    color: var(--color-text-primary);
+    border-radius: 2px;
+    padding-inline: 0.1em;
+  }
+
+  .page-results :global(.search-page-empty) {
+    color: var(--color-text-secondary);
+  }
+</style>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,12 @@ export default defineConfig({
     },
   },
   test: {
-    include: ['src/**/*.test.ts'],
+    /*
+     * `packages/*` are workspace libraries (search-core, the web-file-reader
+     * set). Their tests never ran until this was added — the pure logic they
+     * hold is exactly what unit tests are for.
+     */
+    include: ['src/**/*.test.ts', 'packages/*/src/**/*.test.ts'],
     exclude: ['node_modules/**', 'dist/**', 'e2e/**'],
   },
 });


### PR DESCRIPTION
Ships #170.

Client-side fuzzy search across blog, positions, magazine, archive and the prose pages, in the header, the burger menu and the home hero. `/{lang}/search?q=` is addressable. The box is a real GET form, so it works without JavaScript.

## Verified on dev.comprom.org

A query with **two typos** — `искуственный интелект` — returns exactly the four articles that discuss AI, each with the right word highlighted:

| | |
|---|---|
| `/ru/blog/anatomia-della-putrefazione` | искусственный · интеллект |
| `/ru/blog/international-review-april-2026` | искусственно |
| `/ru/blog/cyber-tool` | искусственного · интеллекта |
| `/ru/blog/from-manchester-to-global` | искусственного |

That is the same set I could previously only get by grepping the content repo.

- 104 unit tests, 255 e2e, `/en/search` scores 100/100/100/100 on Lighthouse
- The index is fetched on the first keystroke, never on page load

## Pre-existing, unrelated

`/en/magazine/magazine-1-mai-2026` scores SEO 92 — on `develop` too, without this branch. The issue carries no `description`, so the page ships without a meta description. A content fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYqMuui8g6TV2zZdBZc8Mt