### PR TITLE
fix(search): drop the box from the home page

### DIFF
--- a/e2e/search.pw.ts
+++ b/e2e/search.pw.ts
@@ -9,16 +9,18 @@ import { expect, expectVisible, test, visit } from '@prometheus/e2e-toolkit';
 
 /*
  * Several search boxes render on one page — the header bar, the burger
- * menu, and (on home and results) the wide one. Every selector below is
+ * menu, and (on the results page) the wide one. Every selector below is
  * scoped to ONE of them; an unscoped `.hit` would match whichever the DOM
  * happened to put first.
+ *
+ * The home page carries no box of its own: the header and the burger menu
+ * already reach it from every page, including that one.
  */
 const HEADER = '[data-testid="search-header"]';
 const HERO = '[data-testid="search-hero"]';
 const HEADER_INPUT = `${HEADER} [data-search-input]`;
 const HERO_INPUT = `${HERO} [data-search-input]`;
 const HEADER_HIT = `${HEADER} .hit`;
-const HERO_HIT = `${HERO} .hit`;
 const PAGE_HIT = '[data-testid="search-page-results"] .hit';
 
 /* Both terms misspelled, exactly as a hurried reader would type them. */
@@ -38,11 +40,11 @@ test.describe('Content search', () => {
 
   test('a misspelled query still reaches the article', async ({ page }) => {
     await visit(page, '/ru');
-    await page.locator(HERO_INPUT).fill(TYPO_QUERY);
-    await expectVisible(page, page.locator(HERO_HIT).first());
+    await page.locator(HEADER_INPUT).fill(TYPO_QUERY);
+    await expectVisible(page, page.locator(HEADER_HIT).first());
 
     const links = await page
-      .locator(`${HERO_HIT} a`)
+      .locator(`${HEADER_HIT} a`)
       .evaluateAll((nodes) => nodes.map((n) => n.getAttribute('href')));
     expect(links).toContain('/ru/blog/cyber-tool');
     expect(links).toContain('/ru/blog/international-review-april-2026');
@@ -56,9 +58,9 @@ test.describe('Content search', () => {
     page,
   }) => {
     await visit(page, '/ru');
-    await page.locator(HERO_INPUT).fill('нейросети');
-    await expectVisible(page, page.locator(`${HERO_HIT} mark`).first());
-    const marked = await page.locator(`${HERO_HIT} mark`).first().textContent();
+    await page.locator(HEADER_INPUT).fill('нейросети');
+    await expectVisible(page, page.locator(`${HEADER_HIT} mark`).first());
+    const marked = await page.locator(`${HEADER_HIT} mark`).first().textContent();
     expect(marked?.toLowerCase()).toContain('нейросет');
   });
 
@@ -99,26 +101,36 @@ test.describe('Content search', () => {
 
   test('a query that matches nothing says so', async ({ page }) => {
     await visit(page, '/ru');
-    await page.locator(HERO_INPUT).fill('квазипсевдонечто');
-    await expectVisible(page, page.locator(`${HERO} [data-testid="search-empty"]`));
-    await expect(page.locator(HERO_HIT)).toHaveCount(0);
+    await page.locator(HEADER_INPUT).fill('квазипсевдонечто');
+    await expectVisible(page, page.locator(`${HEADER} [data-testid="search-empty"]`));
+    await expect(page.locator(HEADER_HIT)).toHaveCount(0);
   });
 
   /* The box is a real GET form, so it works before — and without — JS. */
   test('the box is a form that points at the results page', async ({ page }) => {
     await visit(page, '/ru');
-    const form = page.locator(HERO);
+    const form = page.locator(HEADER);
     expect(await form.getAttribute('action')).toBe('/ru/search');
     expect(await form.getAttribute('method')).toBe('get');
   });
 
+  /*
+   * It is reachable from the header and the burger menu on every page —
+   * including this one — so a third box on the home page is noise.
+   */
+  test('the home page carries no box of its own', async ({ page }) => {
+    await visit(page, '/ru');
+    await expect(page.locator(HERO)).toHaveCount(0);
+    await expectVisible(page, page.locator(HEADER_INPUT));
+  });
+
   test('search reaches every section, not only the blog', async ({ page }) => {
     await visit(page, '/ru');
-    await page.locator(HERO_INPUT).fill('прометей');
-    await expectVisible(page, page.locator(HERO_HIT).first());
+    await page.locator(HEADER_INPUT).fill('прометей');
+    await expectVisible(page, page.locator(HEADER_HIT).first());
 
     const sections = await page
-      .locator(`${HERO_HIT} .hit-section`)
+      .locator(`${HEADER_HIT} .hit-section`)
       .evaluateAll((nodes) => nodes.map((n) => n.textContent));
     expect(sections.some((s) => s !== 'Блог')).toBe(true);
   });

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -6,7 +6,6 @@ import Hero from '@/features/home/components/Hero.astro';
 import NewsSection from '@/features/home/components/NewsSection.astro';
 import PositionsWidget from '@/features/positions/components/PositionsWidget.astro';
 import { getPositions } from '@/features/positions/helpers/getPositions';
-import SearchBox from '@/features/search/components/SearchBox.astro';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 
 export const getStaticPaths = () => SUPPORTED_LANGUAGES.map((lang) => ({ params: { lang } }));
@@ -38,7 +37,6 @@ const readMoreLabel = labels?.data.readMore ?? 'Read more';
 <BaseLayout title={title} {...(description ? { description } : {})} lang={lang}>
   <Hero title={heroTitle ?? ''}>
     {heroIntro ? <p>{heroIntro}</p> : null}
-    <SearchBox lang={lang} variant="hero" />
     <a class="button hero-cta" href={`/${lang}/about`}>{readMoreLabel} →</a>
   </Hero>
   <PositionsWidget lang={lang} positions={latestPositions} />


### PR DESCRIPTION
The header and the burger menu already reach search from every page, including the home page. A third box in the hero was one entry point too many, and it pushed the "Read more" call to action down for no gain.

The e2e cases that drove the hero box on `/ru` now drive the header one — same page, same behaviour, one fewer thing on screen. A new case pins the home page down: it must carry no box of its own, and the header's must still be there.

**256 e2e pass.** Search is unchanged everywhere else: header, burger menu, and `/{lang}/search?q=`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYqMuui8g6TV2zZdBZc8Mt