### PR TITLE
release: latest magazine issue + manifest on the home page

### DIFF
--- a/e2e/home-widgets.pw.ts
+++ b/e2e/home-widgets.pw.ts
@@ -1,0 +1,69 @@
+import { expect, expectVisible, test, visit } from '@prometheus/e2e-toolkit';
+import { buildSectionAvailability, hasSection } from './helpers/content-coverage';
+
+/*
+ * The home page advertises the latest magazine issue and the manifest.
+ *
+ * Both blocks are conditional, and that is the part worth pinning: a
+ * language with no published issue must not be shown a cover, and a
+ * language with no manifest must not be offered a link into a 404. The
+ * old "every lang has every section" assumption is exactly how `/en/…`
+ * once shipped links to pages that did not exist.
+ */
+
+const MAGAZINE = '[data-testid="magazine-widget"]';
+const MAGAZINE_LINK = '[data-testid="magazine-widget-link"]';
+const MANIFEST = '[data-testid="manifest-widget"]';
+const MANIFEST_LINK = '[data-testid="manifest-widget-link"]';
+
+const availability = buildSectionAvailability();
+
+test.describe('Home — latest magazine issue', () => {
+  test('links to the newest issue and shows its cover', async ({ page }) => {
+    test.skip(!hasSection(availability, 'ru', 'magazine'), 'no Russian issue in this snapshot');
+
+    await visit(page, '/ru');
+    await expectVisible(page, page.locator(MAGAZINE));
+
+    const href = await page.locator(MAGAZINE_LINK).getAttribute('href');
+    expect(href).toMatch(/^\/ru\/magazine\/.+/);
+
+    /* The cover is the point of the block. */
+    await expectVisible(page, page.locator(`${MAGAZINE} img`).first());
+
+    /* Following it must land on a real issue page, not a 404. */
+    const res = await visit(page, href ?? '/ru/magazine');
+    expect(res?.status()).toBeLessThan(400);
+  });
+
+  test('is absent for a language with no published issue', async ({ page }) => {
+    test.skip(hasSection(availability, 'pl', 'magazine'), 'Polish now has an issue');
+
+    await visit(page, '/pl');
+    await expect(page.locator(MAGAZINE)).toHaveCount(0);
+  });
+});
+
+test.describe('Home — manifest', () => {
+  test('offers the manifest in its own section', async ({ page }) => {
+    test.skip(!hasSection(availability, 'ru', 'manifest'), 'no Russian manifest in this snapshot');
+
+    await visit(page, '/ru');
+    await expectVisible(page, page.locator(MANIFEST));
+    expect(await page.locator(MANIFEST_LINK).getAttribute('href')).toBe('/ru/manifest');
+
+    const res = await visit(page, '/ru/manifest');
+    expect(res?.status()).toBeLessThan(400);
+  });
+
+  /*
+   * `/{lang}/manifest` is only built for languages that have the page, so
+   * a link where it does not exist is a link into a 404.
+   */
+  test('is absent for a language with no manifest', async ({ page }) => {
+    test.skip(hasSection(availability, 'pl', 'manifest'), 'Polish now has a manifest');
+
+    await visit(page, '/pl');
+    await expect(page.locator(MANIFEST)).toHaveCount(0);
+  });
+});

--- a/src/features/home/components/MagazineWidget.astro
+++ b/src/features/home/components/MagazineWidget.astro
@@ -1,0 +1,162 @@
+---
+import { Picture } from 'astro:assets';
+import CpButton from '@/components/cp/CpButton.astro';
+import type { Language } from '@/config/i18n';
+import { getLabelsData, getMenuData } from '@/config/translations';
+import { deriveSummary } from '@/features/content/helpers/deriveSummary';
+import { formatArticleDate } from '@/features/i18n/format-date';
+import { getMagazineItems } from '@/features/magazine/helpers/getMagazineItems';
+
+interface Props {
+  readonly lang: Language;
+}
+
+const { lang } = Astro.props;
+
+/*
+ * The newest published issue in this language, or nothing. `getMagazineItems`
+ * already carries the publish gate and sorts newest first, so this widget
+ * cannot advertise a draft or an issue the build did not emit a page for.
+ */
+const [issue] = await getMagazineItems(lang);
+
+const menu = await getMenuData(lang);
+/* The menu already carries the localised section name — no new content field. */
+const heading = menu?.data.magazine ?? menu?.data.newspaper ?? 'Magazine';
+
+const labels = await getLabelsData(lang);
+const readMore = labels?.data.readMore ?? 'Read more';
+const viewAll = labels?.data.viewAll ?? 'View all';
+
+const slug = issue ? (issue.id.split('/').at(0) ?? issue.id) : '';
+const href = `/${lang}/magazine/${slug}`;
+const summary = issue ? (issue.data.description ?? deriveSummary(issue.body) ?? '') : '';
+
+/*
+ * Issues ship with no description and an empty body, so without the date
+ * the panel is a tall cover next to a title and nothing else. The date is
+ * what a reader actually wants to know about an issue anyway.
+ */
+const published = issue?.data.publishDate ?? issue?.data.pubDate;
+---
+
+{
+  issue && (
+    <section class="magazine-widget" data-testid="magazine-widget">
+      <div class="container">
+        <div class="widget-header">
+          <h2>{heading}</h2>
+          <a href={`/${lang}/magazine`}>
+            <CpButton variant="secondary">{viewAll}</CpButton>
+          </a>
+        </div>
+        <a class="issue" href={href} data-testid="magazine-widget-link">
+          {issue.data.image && (
+            <div class="cover">
+              <Picture
+                src={issue.data.image}
+                widths={[200, 400]}
+                sizes="(max-width: 640px) 40vw, 200px"
+                formats={['avif', 'webp']}
+                alt=""
+              />
+            </div>
+          )}
+          <div class="body">
+            <h3>{issue.data.title}</h3>
+            {published && (
+              <time class="date" datetime={published.toISOString()}>
+                {formatArticleDate(published, lang)}
+              </time>
+            )}
+            {summary && <p class="summary">{summary}</p>}
+            <span class="cta">{readMore} →</span>
+          </div>
+        </a>
+      </div>
+    </section>
+  )
+}
+
+<style>
+  .magazine-widget {
+    padding-block: var(--spacing-2xl);
+  }
+
+  .widget-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--spacing-sm);
+    margin-bottom: var(--spacing-xl);
+  }
+
+  h2 {
+    font-size: clamp(1.5rem, 4vw, 2rem);
+    font-weight: 600;
+  }
+
+  .issue {
+    display: grid;
+    grid-template-columns: minmax(0, 200px) 1fr;
+    gap: clamp(var(--spacing-md), 4vw, var(--spacing-xl));
+    align-items: start;
+    padding: clamp(var(--spacing-sm), 3vw, var(--spacing-lg));
+    background: var(--color-surface-elevated);
+    border-left: 3px solid var(--color-warning, #ff9800);
+    border-radius: 0 var(--radius-md) var(--radius-md) 0;
+    color: var(--color-text-primary);
+    text-decoration: none;
+    transition: box-shadow var(--transition-fast);
+  }
+
+  .issue:hover {
+    box-shadow: var(--shadow-md);
+  }
+
+  .cover :global(img) {
+    inline-size: 100%;
+    block-size: auto;
+    border-radius: var(--radius-sm);
+    display: block;
+  }
+
+  .body {
+    display: grid;
+    gap: var(--spacing-sm);
+  }
+
+  h3 {
+    font-size: clamp(1.125rem, 3vw, 1.5rem);
+    font-weight: 600;
+    line-height: 1.3;
+  }
+
+  .date {
+    color: var(--color-text-secondary);
+    font-size: 0.875rem;
+  }
+
+  .summary {
+    color: var(--color-text-secondary);
+    line-height: 1.7;
+  }
+
+  .cta {
+    color: var(--color-accent);
+    font-weight: 500;
+  }
+
+  .issue:hover .cta {
+    color: var(--color-accent-hover);
+  }
+
+  /* The cover is the point of the block — keep it, but stop it dominating. */
+  @media (width < 640px) {
+    .issue {
+      grid-template-columns: minmax(0, 40%) 1fr;
+      gap: var(--spacing-md);
+    }
+  }
+</style>

--- a/src/features/home/components/ManifestWidget.astro
+++ b/src/features/home/components/ManifestWidget.astro
@@ -1,0 +1,71 @@
+---
+import CpButton from '@/components/cp/CpButton.astro';
+import type { Language } from '@/config/i18n';
+import { getLabelsData, getPageData } from '@/config/translations';
+import { deriveSummary } from '@/features/content/helpers/deriveSummary';
+
+interface Props {
+  readonly lang: Language;
+}
+
+const { lang } = Astro.props;
+
+/*
+ * No default-language fallback here, unlike the Hero. `/{lang}/manifest`
+ * only exists for languages that actually have the page (see
+ * `getSectionAvailability`), so offering the link where it does not would
+ * send the reader to a 404.
+ */
+const page = await getPageData('manifest', lang);
+
+const labels = await getLabelsData(lang);
+const readMore = labels?.data.readMore ?? 'Read more';
+
+const summary = page ? (page.data.description ?? deriveSummary(page.body) ?? '') : '';
+---
+
+{
+  page && (
+    <section class="manifest-widget" data-testid="manifest-widget">
+      <div class="container">
+        <div class="card">
+          {/* The document's real name, not a section label: this block IS the
+              manifesto, and the button is the way in, not the title. */}
+          <h2>{page.data.title}</h2>
+          {summary && <p class="summary">{summary}</p>}
+          <a href={`/${lang}/manifest`} data-testid="manifest-widget-link">
+            <CpButton variant="primary">{readMore} →</CpButton>
+          </a>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+<style>
+  .manifest-widget {
+    padding-block: var(--spacing-2xl);
+  }
+
+  .card {
+    display: grid;
+    justify-items: start;
+    gap: var(--spacing-md);
+    padding: clamp(var(--spacing-lg), 5vw, var(--spacing-2xl));
+    background: var(--color-surface);
+    border-left: 3px solid var(--color-accent);
+    border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  }
+
+  h2 {
+    font-size: clamp(1.5rem, 4vw, 2rem);
+    font-weight: 600;
+  }
+
+  .summary {
+    margin: 0;
+    max-inline-size: 60ch;
+    color: var(--color-text-secondary);
+    line-height: 1.7;
+  }
+</style>

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -3,6 +3,8 @@ import { DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES } from '@/config/i18n';
 import { getCommonData, getPageData } from '@/config/translations';
 import { getBlogPosts } from '@/features/blog/helpers/getBlogPosts';
 import Hero from '@/features/home/components/Hero.astro';
+import MagazineWidget from '@/features/home/components/MagazineWidget.astro';
+import ManifestWidget from '@/features/home/components/ManifestWidget.astro';
 import NewsSection from '@/features/home/components/NewsSection.astro';
 import PositionsWidget from '@/features/positions/components/PositionsWidget.astro';
 import { getPositions } from '@/features/positions/helpers/getPositions';
@@ -39,8 +41,10 @@ const readMoreLabel = labels?.data.readMore ?? 'Read more';
     {heroIntro ? <p>{heroIntro}</p> : null}
     <a class="button hero-cta" href={`/${lang}/about`}>{readMoreLabel} →</a>
   </Hero>
+  <MagazineWidget lang={lang} />
   <PositionsWidget lang={lang} positions={latestPositions} />
   <NewsSection posts={latestPosts} lang={lang} latestNewsLabel={latestNews ?? ''} viewAllLabel={viewAllPosts ?? ''} />
+  <ManifestWidget lang={lang} />
 </BaseLayout>
 
 <style>


### PR DESCRIPTION
Ships #174.

The home page now leads with the newest magazine issue (cover, title, date) and closes with the manifest in a section of its own.

Both blocks are conditional: the issue comes from `getMagazineItems` (publish gate, newest first), and the manifest link renders only for languages that actually have the page — `/{lang}/manifest` is not built for the others.

## Verified on dev.comprom.org

| | magazine | manifest |
|---|---|---|
| `/ru` | ✔ | ✔ |
| `/en` | ✔ | ✔ |
| `/pl` | — (no issue published) | ✔ |

259 e2e pass. Home stays **100/100/100/100** on Lighthouse with the cover on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYqMuui8g6TV2zZdBZc8Mt