### PR TITLE
release: issue cover + "back to list" label

### DIFF
--- a/e2e/magazine-route.pw.ts
+++ b/e2e/magazine-route.pw.ts
@@ -14,6 +14,7 @@ import { buildSectionAvailability, hasSection } from './helpers/content-coverage
  * and the back-link to the listing.
  */
 const LISTING_HEADING = 'h1';
+const ISSUE_COVER = '[data-testid="issue-cover"]';
 const ISSUE_CARD = '[data-testid="magazine-card"]';
 const PDF_LINK = '[data-testid="magazine-pdf"]';
 const BACK_LINK = '.back-link';
@@ -42,6 +43,19 @@ test.describe('Magazine section', () => {
 
     const back = await page.locator(BACK_LINK).getAttribute('href');
     expect(back).toBe('/ru/magazine');
+
+    /*
+     * The cover is how a reader recognises an issue — it belongs on the
+     * issue's own page, not only on the card that links to it.
+     */
+    await expectVisible(page, page.locator(ISSUE_COVER).first());
+
+    /*
+     * "Back" says nothing about where it goes. The label's own field is
+     * called `backToList`; the copy now says so.
+     */
+    const label = await page.locator(BACK_LINK).textContent();
+    expect(label?.toLowerCase()).toContain('к списку');
   });
 
   test('the per-locale RSS feed is served at magazine.xml', async ({ request }) => {

--- a/src/pages/[lang]/magazine/[slug].astro
+++ b/src/pages/[lang]/magazine/[slug].astro
@@ -1,4 +1,5 @@
 ---
+import { Picture } from 'astro:assets';
 import { getCollection } from 'astro:content';
 import { type Language, SUPPORTED_LANGUAGES } from '@/config/i18n';
 import { getLabelsData } from '@/config/translations';
@@ -53,7 +54,8 @@ const { issue, availableLangs } = Astro.props as Props;
 const { lang, slug } = Astro.params;
 
 const labels = (await getLabelsData(lang)) ?? (await getLabelsData('en'));
-const backLabel = labels?.data.backToList ?? '← Back';
+/* The field is `backToList` — the copy should say so, not just "Back". */
+const backLabel = labels?.data.backToList ?? '← Back to list';
 const pdfLabel = labels?.data.downloadPdf ?? 'Download PDF';
 const fb2Label = labels?.data.downloadFb2 ?? 'Download FB2';
 
@@ -87,6 +89,15 @@ const tocEntries = await (async (): Promise<ReadonlyArray<TocEntry>> => {
     });
 })();
 
+/*
+ * Issues ship with no `description` and an empty body, so the page went out
+ * with no meta description at all — Lighthouse SEO 92, and a search result
+ * with nothing under the title. Fall back to the issue's own name: it is
+ * the honest minimum, and an editorial description in the content repo
+ * still wins over it the moment one is written.
+ */
+const metaDescription = issue?.data.description ?? issue?.data.title;
+
 const pdfAsset = issue ? findIssueAsset(slug, lang, '.pdf') : undefined;
 const fb2Asset = issue ? findIssueAsset(slug, lang, '.fb2') : undefined;
 ---
@@ -95,9 +106,7 @@ const fb2Asset = issue ? findIssueAsset(slug, lang, '.fb2') : undefined;
   title={issue
     ? `${issue.data.title} - Communist Prometheus`
     : 'Communist Prometheus'}
-  {...(issue?.data.description
-    ? { description: issue.data.description }
-    : {})}
+  {...(metaDescription ? { description: metaDescription } : {})}
   lang={lang}
   availableLangs={availableLangs}
 >
@@ -107,6 +116,18 @@ const fb2Asset = issue ? findIssueAsset(slug, lang, '.fb2') : undefined;
       {issue ? (
         <article class="issue">
           <header class="issue-header">
+            {issue.data.image && (
+              <div class="cover">
+                <Picture
+                  src={issue.data.image}
+                  widths={[320, 640]}
+                  sizes="(max-width: 640px) 70vw, 320px"
+                  formats={['avif', 'webp']}
+                  alt=""
+                  data-testid="issue-cover"
+                />
+              </div>
+            )}
             <h1>{issue.data.title}</h1>
             <p class="issue-description">{issue.data.description}</p>
             <div class="downloads">
@@ -179,6 +200,25 @@ const fb2Asset = issue ? findIssueAsset(slug, lang, '.fb2') : undefined;
   .issue-header {
     margin-bottom: var(--spacing-2xl);
     text-align: center;
+  }
+
+  /*
+   * The cover is the issue's identity — the reader recognises it before
+   * they read the title. `alt=""` on purpose: the title sits right below
+   * it, so announcing the cover again would only repeat it.
+   */
+  .cover {
+    max-inline-size: 320px;
+    margin-inline: auto;
+    margin-block-end: var(--spacing-lg);
+  }
+
+  .cover :global(img) {
+    inline-size: 100%;
+    block-size: auto;
+    display: block;
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-md);
   }
 
   h1 {

--- a/src/pages/[lang]/positions/[...slug].astro
+++ b/src/pages/[lang]/positions/[...slug].astro
@@ -54,7 +54,8 @@ const rendered = entry ? await entry.render() : undefined;
 const Content = rendered?.Content;
 const headings = rendered?.headings ?? [];
 const labels = (await getLabelsData(lang)) ?? (await getLabelsData(DEFAULT_LANGUAGE));
-const backLabel = labels?.data.backToList ?? '← Back';
+/* The field is `backToList` — the copy should say so, not just "Back". */
+const backLabel = labels?.data.backToList ?? '← Back to list';
 const tocLabel = labels?.data.tableOfContents ?? 'Contents';
 
 const pageTitle = entry ? `${entry.data.title} - Communist Prometheus` : 'Communist Prometheus';


### PR DESCRIPTION
Ships #176 (and the copy from public-website-content#25).

- The **cover** now leads the magazine issue page — it was only ever on the card that links to the issue.
- **"← Назад" → "← К списку"** on issues and positions: the field was already called `backToList`, the copy now says so.
- The issue page shipped with **no meta description** (issues carry none, and their body is empty) — Lighthouse SEO 92, on `develop` too. It falls back to the issue's own name. **The page now scores 100/100/100/100.**

## Verified on dev.comprom.org

`/ru/magazine/magazine-1-mai-2026` — cover present, back link reads "← К списку".

259 e2e pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYqMuui8g6TV2zZdBZc8Mt