### PR TITLE
fix(search): embed a long article in batches the model will take

### DIFF
--- a/scripts/reindex.ts
+++ b/scripts/reindex.ts
@@ -46,8 +46,8 @@ const languagesIn = (dist: string): readonly string[] =>
     .map((e) => e.name)
     .filter((name) => existsSync(join(dist, name, 'search-index.json')));
 
-const callOnce = async (base: string, secret: string, lang: string): Promise<Progress> => {
-  const res = await fetch(`${base}/api/reindex`, {
+const post = async (base: string, secret: string, lang: string): Promise<Response> =>
+  fetch(`${base}/api/reindex`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -55,10 +55,30 @@ const callOnce = async (base: string, secret: string, lang: string): Promise<Pro
     },
     body: JSON.stringify({ lang }),
   });
-  if (!res.ok) {
-    throw new Error(`reindex ${lang}: ${res.status} ${await res.text()}`);
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/*
+ * A deploy does not become live everywhere the moment wrangler returns.
+ * Until it does, the edge still answers `/api/*` from the asset store —
+ * and a POST at a static file is a 405. That is the deploy still landing,
+ * not a broken Worker, so wait it out rather than fail the pipeline.
+ */
+const NOT_LIVE_YET = new Set([404, 405]);
+const LIVE_TRIES = 20;
+const LIVE_WAIT_MS = 6000;
+
+const callOnce = async (base: string, secret: string, lang: string): Promise<Progress> => {
+  for (let attempt = 0; attempt < LIVE_TRIES; attempt += 1) {
+    const res = await post(base, secret, lang);
+    if (res.ok) return (await res.json()) as Progress;
+    if (!NOT_LIVE_YET.has(res.status)) {
+      throw new Error(`reindex ${lang}: ${res.status} ${await res.text()}`);
+    }
+    console.log(`[reindex] worker not live yet (${res.status}), waiting…`);
+    await sleep(LIVE_WAIT_MS);
   }
-  return (await res.json()) as Progress;
+  throw new Error(`reindex ${lang}: worker never came up`);
 };
 
 const reindexLanguage = async (base: string, secret: string, lang: string): Promise<void> => {

--- a/src/worker/embed.test.ts
+++ b/src/worker/embed.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import { embed } from './embed';
+import type { Env } from './env';
+
+/*
+ * The model refuses a call over 60 000 tokens — and it refuses the WHOLE
+ * call, so one long article took the whole reindex down with it (AiError
+ * 3030, on dev, with 90 passages in one request). These tests hold the
+ * fix: the batch is what is bounded, not the article.
+ */
+
+const fakeEnv = (run: (model: string, input: { text: string[] }) => Promise<unknown>): Env =>
+  ({ AI: { run } }) as unknown as Env;
+
+const vectorsFor = (texts: readonly string[]) => ({
+  data: texts.map((text) => [text.length]),
+});
+
+describe('embed', () => {
+  it('splits a long article into calls the model will accept', async () => {
+    const sizes: number[] = [];
+    const env = fakeEnv(async (_model, input) => {
+      sizes.push(input.text.length);
+      return vectorsFor(input.text);
+    });
+
+    const texts = Array.from({ length: 45 }, (_, at) => `passage ${at}`);
+    await embed(env, texts);
+
+    expect(sizes).toEqual([20, 20, 5]);
+  });
+
+  it('keeps the vectors in the order the passages were given', async () => {
+    const env = fakeEnv(async (_model, input) => vectorsFor(input.text));
+    const texts = ['a', 'bb', 'ccc', ...Array.from({ length: 20 }, () => 'dddd')];
+
+    const vectors = await embed(env, texts);
+
+    expect(vectors.map((v) => v[0])).toEqual(texts.map((t) => t.length));
+  });
+
+  it('embeds nothing without calling the model', async () => {
+    const run = vi.fn();
+    expect(await embed(fakeEnv(run), [])).toEqual([]);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('refuses a short answer rather than misalign passages and vectors', async () => {
+    const env = fakeEnv(async () => ({ data: [[1]] }));
+    await expect(embed(env, ['a', 'b'])).rejects.toThrow('got 1');
+  });
+});

--- a/src/worker/embed.ts
+++ b/src/worker/embed.ts
@@ -10,6 +10,31 @@ interface EmbeddingResponse {
   readonly data?: readonly (readonly number[])[];
 }
 
+/*
+ * The model takes 60 000 tokens per CALL, not per text. The longest
+ * article here is 72 000 characters — about 90 passages — and handing all
+ * of them over at once asked for 63 054 tokens and was refused outright.
+ *
+ * 20 passages is roughly 8 000 tokens of Russian prose: comfortably under
+ * the ceiling even if an article turns out to be denser than any we have.
+ * Indexing is a background job; there is nothing to gain by crowding it.
+ */
+const BATCH = 20;
+
+const runBatch = async (
+  env: Env,
+  texts: readonly string[],
+): Promise<readonly (readonly number[])[]> => {
+  const res = (await env.AI.run(EMBEDDING_MODEL, {
+    text: [...texts],
+  })) as EmbeddingResponse;
+  const vectors = res.data ?? [];
+  if (vectors.length !== texts.length) {
+    throw new Error(`embedding: asked for ${texts.length} vectors, got ${vectors.length}`);
+  }
+  return vectors;
+};
+
 /**
  * Embed a batch of texts.
  * @param env - Worker bindings.
@@ -21,13 +46,9 @@ export const embed = async (
   env: Env,
   texts: readonly string[],
 ): Promise<readonly (readonly number[])[]> => {
-  if (texts.length === 0) return [];
-  const res = (await env.AI.run(EMBEDDING_MODEL, {
-    text: [...texts],
-  })) as EmbeddingResponse;
-  const vectors = res.data ?? [];
-  if (vectors.length !== texts.length) {
-    throw new Error(`embedding: asked for ${texts.length} vectors, got ${vectors.length}`);
+  const out: (readonly number[])[] = [];
+  for (let at = 0; at < texts.length; at += BATCH) {
+    out.push(...(await runBatch(env, texts.slice(at, at + BATCH))));
   }
-  return vectors;
+  return out;
 };


### PR DESCRIPTION
Живая проверка на dev: реиндекс упал на русском.

```
AiError 3030: Max context reached 63054 tokens but model supports only 60000
```

60 000 токенов — это лимит **на вызов**, а не на текст. Самая длинная статья — 72 000 символов, её 90 пассажей ушли в модель одним запросом, и она отказала целиком. Одной статьи хватило, чтобы положить весь язык.

Ограничиваем **партию, а не статью**: 20 пассажей за вызов, около 8 000 токенов русской прозы. Индексация — фоновая работа, толпиться в одном запросе было незачем.

Заодно: `scripts/reindex.ts` теперь ждёт, пока новый Worker разъедется по краю. Первый прогон в CI получил 405 — деплой ещё не встал, и POST на `/api/*` обслужила статика. Это деплой в процессе, а не сломанный воркер, поэтому нужно подождать, а не валить пайплайн.

Юниты: 131 (4 новых на батчинг — порядок векторов, размер партий, отказ на неполный ответ модели).

🤖 Generated with [Claude Code](https://claude.com/claude-code)