### PR TITLE
fix(search): draw the reindex plan once — Vectorize answers late

### DIFF
--- a/scripts/reindex.ts
+++ b/scripts/reindex.ts
@@ -3,13 +3,13 @@
  *
  * The Worker does the actual work — it reads the freshly deployed index
  * through its own ASSETS binding, so it can never embed a version of an
- * article that is not the one being served. This script only drives it:
- * one call per batch, until the Worker says nothing is left.
+ * article that is not the one being served. This script only drives it.
  *
- * It is bounded on purpose. The Worker embeds a couple of documents per
- * call to stay inside its CPU budget, so a first run over a fresh index
- * takes many calls — but a normal deploy, where one article changed,
- * takes one.
+ * It asks ONCE what is stale, then walks that list. It does not re-ask
+ * between batches: Vectorize is eventually consistent, so for a few
+ * seconds after a write the store still reports the old state, and a job
+ * that re-plans between batches keeps re-embedding what it has just done —
+ * which is exactly what it did, in a circle, on dev.
  *
  * Run: bun scripts/reindex.ts --base https://dev.comprom.org
  * Needs REINDEX_SECRET in the environment; without it the Worker answers
@@ -18,17 +18,16 @@
 import { existsSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 
-interface Progress {
+interface Plan {
   readonly total: number;
-  readonly indexed: number;
-  readonly remaining: number;
+  readonly stale: readonly string[];
 }
 
 /*
- * A runaway guard, not a budget: at 2 documents a call this is far more
- * than a full cold rebuild of every language would ever need.
+ * The Worker embeds at most this many documents per call — see its own
+ * MAX_DOCS_PER_CALL. Asking for more would silently drop the rest.
  */
-const MAX_CALLS = 400;
+const DOCS_PER_CALL = 2;
 
 const arg = (name: string): string | undefined => {
   const at = process.argv.indexOf(`--${name}`);
@@ -46,53 +45,66 @@ const languagesIn = (dist: string): readonly string[] =>
     .map((e) => e.name)
     .filter((name) => existsSync(join(dist, name, 'search-index.json')));
 
-const post = async (base: string, secret: string, lang: string): Promise<Response> =>
-  fetch(`${base}/api/reindex`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Reindex-Key': secret,
-    },
-    body: JSON.stringify({ lang }),
-  });
-
-const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+const sleep = (ms: number): Promise<void> => new Promise((done) => setTimeout(done, ms));
 
 /*
  * A deploy does not become live everywhere the moment wrangler returns.
  * Until it does, the edge still answers `/api/*` from the asset store —
  * and a POST at a static file is a 405. That is the deploy still landing,
  * not a broken Worker, so wait it out rather than fail the pipeline.
+ *
+ * A 5xx gets the same patience but much less of it: the model and the
+ * vector store are remote services, and one blip should not fail a deploy
+ * that is otherwise fine. Three tries, then say so.
  */
 const NOT_LIVE_YET = new Set([404, 405]);
 const LIVE_TRIES = 20;
 const LIVE_WAIT_MS = 6000;
+const SERVER_TRIES = 3;
+const SERVER_WAIT_MS = 5000;
 
-const callOnce = async (base: string, secret: string, lang: string): Promise<Progress> => {
+const post = async (
+  base: string,
+  secret: string,
+  body: Record<string, unknown>,
+): Promise<Response> =>
+  fetch(`${base}/api/reindex`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-Reindex-Key': secret },
+    body: JSON.stringify(body),
+  });
+
+const call = async <T>(base: string, secret: string, body: Record<string, unknown>): Promise<T> => {
+  let serverTries = 0;
   for (let attempt = 0; attempt < LIVE_TRIES; attempt += 1) {
-    const res = await post(base, secret, lang);
-    if (res.ok) return (await res.json()) as Progress;
-    if (!NOT_LIVE_YET.has(res.status)) {
-      throw new Error(`reindex ${lang}: ${res.status} ${await res.text()}`);
+    const res = await post(base, secret, body);
+    if (res.ok) return (await res.json()) as T;
+
+    if (NOT_LIVE_YET.has(res.status)) {
+      console.log(`[reindex] worker not live yet (${res.status}), waiting…`);
+      await sleep(LIVE_WAIT_MS);
+      continue;
     }
-    console.log(`[reindex] worker not live yet (${res.status}), waiting…`);
-    await sleep(LIVE_WAIT_MS);
+    if (res.status >= 500 && serverTries < SERVER_TRIES) {
+      serverTries += 1;
+      console.log(`[reindex] ${res.status} from the worker, retry ${serverTries}`);
+      await sleep(SERVER_WAIT_MS);
+      continue;
+    }
+    throw new Error(`reindex: ${res.status} ${(await res.text()).slice(0, 200)}`);
   }
-  throw new Error(`reindex ${lang}: worker never came up`);
+  throw new Error('reindex: worker never came up');
 };
 
 const reindexLanguage = async (base: string, secret: string, lang: string): Promise<void> => {
-  for (let call = 0; call < MAX_CALLS; call += 1) {
-    const { total, indexed, remaining } = await callOnce(base, secret, lang);
-    console.log(`[reindex] ${lang}: ${indexed} embedded, ${remaining} left of ${total}`);
-    if (remaining === 0) return;
-    /*
-     * Nothing left to do but nothing got done either: the Worker is not
-     * making progress, and looping MAX_CALLS times would only hide it.
-     */
-    if (indexed === 0) throw new Error(`reindex ${lang}: stuck`);
+  const { total, stale } = await call<Plan>(base, secret, { lang });
+  console.log(`[reindex] ${lang}: ${stale.length} stale of ${total}`);
+
+  for (let at = 0; at < stale.length; at += DOCS_PER_CALL) {
+    const docs = stale.slice(at, at + DOCS_PER_CALL);
+    await call(base, secret, { lang, docs });
+    console.log(`[reindex] ${lang}: embedded ${docs.join(', ')}`);
   }
-  throw new Error(`reindex ${lang}: gave up after ${MAX_CALLS} calls`);
 };
 
 const main = async (): Promise<void> => {

--- a/src/worker/reindex.ts
+++ b/src/worker/reindex.ts
@@ -15,17 +15,32 @@ import { type Env, json } from './env';
  * The Worker reads the index through the ASSETS binding — the same file
  * the browser downloads, from the deploy that is already live — so there
  * is no separate content pipeline to drift from what readers see.
+ *
+ * Two shapes, and the split matters:
+ *
+ *   { lang }             → PLAN: which documents are stale
+ *   { lang, docs: [id] } → INDEX exactly these, no questions asked
+ *
+ * Vectorize is eventually consistent: for a few seconds after an upsert,
+ * `getByIds` still answers with what was there before. Re-planning after
+ * every batch therefore keeps handing back documents that were just done,
+ * and the job re-embeds them in a circle. So the plan is drawn ONCE, by
+ * the caller, and the batches that follow name their documents.
  */
 
 /*
- * An article here can be 72 000 characters — about 90 passages. Two per
- * request keeps a single call well inside the Worker's limits; the caller
- * loops until `remaining` reaches zero.
+ * An article here can be 72 000 characters — about 90 passages, five model
+ * calls. Two documents a request keeps a single call well inside the
+ * Worker's budget; the caller walks the plan.
  */
-const DOCS_PER_CALL = 2;
+const MAX_DOCS_PER_CALL = 2;
+
+/* Vectorize takes at most 100 ids in one lookup. */
+const LOOKUP_LIMIT = 100;
 
 interface Body {
   readonly lang?: unknown;
+  readonly docs?: unknown;
 }
 
 const chunkId = (docId: string, at: number): string => `${docId}#${at}`;
@@ -40,18 +55,28 @@ interface Head {
   readonly chunks: number;
 }
 
-const headOf = async (env: Env, docId: string): Promise<Head | undefined> => {
-  const found = await env.VECTORIZE.getByIds([chunkId(docId, 0)]);
-  const { hash, chunks } = (found.at(0)?.metadata ?? {}) as Partial<Record<keyof Head, unknown>>;
-  if (typeof hash !== 'string' || typeof chunks !== 'number') return undefined;
-  return { hash, chunks };
+const headsOf = async (
+  env: Env,
+  docs: readonly SearchDoc[],
+): Promise<ReadonlyMap<string, Head>> => {
+  const found = new Map<string, Head>();
+  for (let at = 0; at < docs.length; at += LOOKUP_LIMIT) {
+    const batch = docs.slice(at, at + LOOKUP_LIMIT);
+    const vectors = await env.VECTORIZE.getByIds(batch.map((doc) => chunkId(doc.id, 0)));
+    for (const vector of vectors) {
+      const { hash, chunks } = (vector.metadata ?? {}) as Partial<Record<keyof Head, unknown>>;
+      if (typeof hash === 'string' && typeof chunks === 'number') {
+        found.set(vector.id, { hash, chunks });
+      }
+    }
+  }
+  return found;
 };
 
-const indexDoc = async (env: Env, doc: SearchDoc): Promise<void> => {
-  const head = await headOf(env, doc.id);
-  if (head !== undefined && head.hash === doc.hash) return;
-
+const indexDoc = async (env: Env, doc: SearchDoc, head?: Head): Promise<void> => {
   const chunks = chunkBody(doc.body);
+  if (chunks.length === 0) return;
+
   /*
    * The title and description carry the article's subject more plainly
    * than any single paragraph does — prepend them to the first passage so
@@ -93,15 +118,40 @@ const loadIndex = async (env: Env, lang: string): Promise<readonly SearchDoc[]> 
   return body.docs ?? [];
 };
 
+const wanted = (body: Body): readonly string[] | undefined =>
+  Array.isArray(body.docs)
+    ? body.docs.filter((id): id is string => typeof id === 'string')
+    : undefined;
+
+const plan = async (env: Env, lang: string, docs: readonly SearchDoc[]): Promise<Response> => {
+  const heads = await headsOf(env, docs);
+  const stale = docs
+    .filter((doc) => heads.get(chunkId(doc.id, 0))?.hash !== doc.hash)
+    .map((doc) => doc.id);
+  return json({ lang, total: docs.length, stale });
+};
+
+const indexBatch = async (
+  env: Env,
+  lang: string,
+  docs: readonly SearchDoc[],
+  ids: readonly string[],
+): Promise<Response> => {
+  const batch = docs.filter((doc) => ids.includes(doc.id)).slice(0, MAX_DOCS_PER_CALL);
+  const heads = await headsOf(env, batch);
+  for (const doc of batch) {
+    await indexDoc(env, doc, heads.get(chunkId(doc.id, 0)));
+  }
+  return json({ lang, indexed: batch.map((doc) => doc.id) });
+};
+
 /**
- * `POST /api/reindex` — re-embed the documents whose content changed.
+ * `POST /api/reindex` — plan, or re-embed a named batch.
  *
- * Guarded by a shared secret and driven by CI after a deploy. Processes a
- * bounded batch and reports what is left, so the caller loops rather than
- * asking one request to embed the whole site.
+ * Guarded by a shared secret and driven by CI after a deploy.
  * @param request Incoming request.
  * @param env Worker bindings.
- * @returns How many documents were re-embedded, and how many remain.
+ * @returns The stale list, or what this call embedded.
  */
 export const handleReindex = async (request: Request, env: Env): Promise<Response> => {
   if (request.method !== 'POST') return json({ error: 'method' }, 405);
@@ -110,25 +160,11 @@ export const handleReindex = async (request: Request, env: Env): Promise<Respons
     return json({ error: 'forbidden' }, 403);
   }
 
-  const body = (await request.json().catch(() => undefined)) as Body | undefined;
-  const lang = typeof body?.lang === 'string' ? body.lang : '';
+  const body = ((await request.json().catch(() => undefined)) ?? {}) as Body;
+  const lang = typeof body.lang === 'string' ? body.lang : '';
   if (lang === '') return json({ error: 'lang' }, 400);
 
   const docs = await loadIndex(env, lang);
-
-  const stale: SearchDoc[] = [];
-  for (const doc of docs) {
-    const head = await headOf(env, doc.id);
-    if (head === undefined || head.hash !== doc.hash) stale.push(doc);
-  }
-
-  const batch = stale.slice(0, DOCS_PER_CALL);
-  for (const doc of batch) await indexDoc(env, doc);
-
-  return json({
-    lang,
-    total: docs.length,
-    indexed: batch.length,
-    remaining: stale.length - batch.length,
-  });
+  const ids = wanted(body);
+  return ids === undefined ? plan(env, lang, docs) : indexBatch(env, lang, docs, ids);
 };


### PR DESCRIPTION
Работа переэмбеддивала одни и те же статьи по кругу: девятнадцать вызовов подряд «2 embedded, 2 left» на dev — и 500 в конце.

**Vectorize консистентен не сразу.** Несколько секунд после upsert `getByIds` продолжает отвечать тем, что было раньше. Значит, работа, которая спрашивает «что несвежее?» после каждой партии, получает в ответ ровно те статьи, которые только что сделала, — и ходит по кругу, сжигая вызовы модели, пока хранилище не догонит. Хэш был правильный; вопрос был задан слишком рано.

Поэтому **план составляется один раз**, а последующие партии называют свои документы поимённо:

```
{ lang }             → какие документы несвежие
{ lang, docs: [id] } → заэмбеддить ровно эти
```

Воркер больше не решает, что пропустить, — он не в том положении, чтобы это знать. Вызывающий идёт по выданному списку, и статья эмбеддится ровно один раз на тот деплой, который её изменил.

Заодно: один запрос за всеми «головами» вместо запроса на документ, и 5xx ретраится трижды, а не валит деплой, с которым в остальном всё в порядке.

🤖 Generated with [Claude Code](https://claude.com/claude-code)