### PR TITLE
fix(search): index a magazine issue by what it has — a title and a blurb

### DIFF
--- a/src/features/search/semantic-client.test.ts
+++ b/src/features/search/semantic-client.test.ts
@@ -54,6 +54,13 @@ describe('semanticSearch', () => {
     });
   });
 
+  it('quotes the blurb when there is no body to quote — a magazine issue', async () => {
+    reply([{ doc: 'a', score: 0.6, start: 0, end: 0 }]);
+    const issue = { ...doc('a', ''), description: 'Первый номер' };
+    const hits = await semanticSearch('ru', 'журнал', [issue]);
+    expect(hits[0]?.snippet.text).toBe('Первый номер');
+  });
+
   it('throws when the Worker refuses, so the caller can say so', async () => {
     vi.stubGlobal(
       'fetch',

--- a/src/features/search/semantic-client.ts
+++ b/src/features/search/semantic-client.ts
@@ -49,12 +49,9 @@ export const semanticSearch = async (
   return (body.hits ?? []).flatMap((hit) => {
     const doc = byId.get(hit.doc);
     if (doc === undefined) return [];
-    return [
-      {
-        doc,
-        score: hit.score,
-        snippet: passageSnippet(doc.body, hit.start, hit.end),
-      },
-    ];
+    const passage = passageSnippet(doc.body, hit.start, hit.end);
+    /* A magazine issue has a cover and a blurb, and no body to quote. */
+    const snippet = passage.text === '' ? { text: doc.description, marks: [] } : passage;
+    return [{ doc, score: hit.score, snippet }];
   });
 };

--- a/src/worker/reindex.ts
+++ b/src/worker/reindex.ts
@@ -1,4 +1,4 @@
-import type { SearchDoc } from '@prometheus/search-core';
+import type { Chunk, SearchDoc } from '@prometheus/search-core';
 import { chunkBody } from '@prometheus/search-core';
 import { embed } from './embed';
 import { type Env, json } from './env';
@@ -73,8 +73,22 @@ const headsOf = async (
   return found;
 };
 
-const indexDoc = async (env: Env, doc: SearchDoc, head?: Head): Promise<void> => {
+/*
+ * A magazine issue is a cover, a title and a blurb — its body is empty.
+ * Skipping it would leave it forever unindexed AND forever "stale", since
+ * the hash lives in chunk 0 and there would be no chunk 0 to hold it: it
+ * would be re-planned on every deploy, for ever, and never done. It also
+ * has a subject a reader can ask for. One passage, from what it does have.
+ */
+const passagesOf = (doc: SearchDoc): readonly Chunk[] => {
   const chunks = chunkBody(doc.body);
+  if (chunks.length > 0) return chunks;
+  const text = `${doc.title}. ${doc.description}`.trim();
+  return text === '' ? [] : [{ text, start: 0, end: 0 }];
+};
+
+const indexDoc = async (env: Env, doc: SearchDoc, head?: Head): Promise<void> => {
+  const chunks = passagesOf(doc);
   if (chunks.length === 0) return;
 
   /*


### PR DESCRIPTION
Номер журнала — это обложка, заголовок и аннотация; тела у него нет. Индексатор его пропускал, и следствие было хуже, чем «не находится»: хэш контента живёт в чанке №0, а без чанка №0 негде записать, что номер вообще видели. Он возвращался несвежим на каждом деплое — навсегда — и никогда не индексировался. Лог реиндекса после каждого прогона писал «1 stale», и ничего не менялось.

У номера есть и содержание, о котором читатель может спросить. Индексируем тот единственный пассаж, который у него есть, и цитируем аннотацию, когда цитировать нечего.

E2E 16 passed, юнитов 132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)