### PR TITLE
release: semantic search

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -7,3 +7,7 @@ GITHUB_TOKEN=your_github_token_here
 
 # Webhook secret for validating incoming requests
 WEBHOOK_SECRET=your_webhook_secret_here
+
+# Shared with the CI job that re-embeds changed articles after a deploy.
+# Any long random string; must match the Worker secret of the same name.
+REINDEX_SECRET=your_reindex_secret_here

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,8 +38,10 @@ jobs:
         run: |
           if [ "$GITHUB_REF_NAME" = "develop" ]; then
             echo "WRANGLER_COMMAND=deploy --env develop" >> "$GITHUB_ENV"
+            echo "SITE_BASE=https://dev.comprom.org" >> "$GITHUB_ENV"
           else
             echo "WRANGLER_COMMAND=deploy" >> "$GITHUB_ENV"
+            echo "SITE_BASE=https://comprom.org" >> "$GITHUB_ENV"
           fi
 
       - name: Installing tools and dependencies
@@ -88,3 +90,16 @@ jobs:
           # WRANGLER_COMMAND was resolved by the "Resolve branch env"
           # step (deploy --env develop on develop, deploy on master).
           command: ${{ env.WRANGLER_COMMAND }}
+
+      # Semantic search reads a vector store, and a vector store is only
+      # as true as its last update. The Worker re-embeds ONLY the articles
+      # whose content hash moved, so an ordinary deploy costs one call and
+      # a few seconds; a fresh index costs a few minutes, once.
+      #
+      # It runs after the deploy because the Worker indexes what the
+      # deploy is actually serving — it reads the index through its own
+      # ASSETS binding.
+      - name: Re-embedding changed articles
+        run: bun scripts/reindex.ts --base "$SITE_BASE"
+        env:
+          REINDEX_SECRET: ${{ secrets.REINDEX_SECRET }}

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ public/favicons/
 
 # npm lockfile — bun.lock is the single source of dependency truth
 package-lock.json
+
+# Wrangler build scratch
+.wrangler/

--- a/biome.json
+++ b/biome.json
@@ -8,7 +8,7 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "includes": ["**", "!!e2e-toolkit", "!packages"]
+    "includes": ["**", "!!e2e-toolkit", "!packages", "!.wrangler"]
   },
   "formatter": {
     "enabled": true,

--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,7 @@
       "devDependencies": {
         "@astrojs/check": "^0.9.6",
         "@biomejs/biome": "^2.3.14",
+        "@cloudflare/workers-types": "^5.20260712.1",
         "@lhci/cli": "^0.15.1",
         "@playwright/test": "^1.58.2",
         "@resvg/resvg-js": "^2.6.2",
@@ -191,6 +192,8 @@
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-oizCjdyQ3WJEswpb3Chdngeat56rIdSYK12JI3iI11Mt5T5EXcZ7WLuowzEaFPNJ3zmOQFliMN8QY1Pi+qsfdQ=="],
 
     "@capsizecss/unpack": ["@capsizecss/unpack@4.0.0", "", { "dependencies": { "fontkitten": "^1.0.0" } }, "sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA=="],
+
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260712.1", "", {}, "sha512-tkQ18Lz41EPXLzh4cSuIGQzztDVueuGfTcjlP4M7Qa0rfHpVBNItf3GRkd9O0JgiXs9csAwz/kVv7sjYXSoF2w=="],
 
     "@emmetio/abbreviation": ["@emmetio/abbreviation@2.3.3", "", { "dependencies": { "@emmetio/scanner": "^1.0.4" } }, "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA=="],
 

--- a/e2e/semantic-search.pw.ts
+++ b/e2e/semantic-search.pw.ts
@@ -1,0 +1,127 @@
+import { expect, expectVisible, test, visit } from '@prometheus/e2e-toolkit';
+
+/*
+ * Meaning search runs on a Worker, and `astro preview` serves static files
+ * with no Worker behind them. So `/api/semantic` is stubbed here: what is
+ * under test is the CONTRACT — the browser sends a query and nothing else,
+ * gets coordinates back, and renders the article from the index it already
+ * holds. The Worker's own half is exercised against the deployed dev
+ * environment, where a real model and a real vector store exist.
+ */
+
+const BUTTON = '[data-testid="semantic-button"]';
+const STATUS = '[data-testid="semantic-status"]';
+const PAGE_HIT = '[data-testid="search-page-results"] .hit';
+
+/* A query no article spells out — the point of meaning search. */
+const QUERY = 'машины, которые думают за человека';
+const RESULTS = `/ru/search?q=${encodeURIComponent(QUERY)}`;
+
+/** The id and passage the Worker would answer with. */
+const CYBER_TOOL = { doc: 'ru/blog/cyber-tool', score: 0.71, start: 0, end: 400 };
+
+test.describe('Semantic search', () => {
+  test('the button hands the query — and only the query — to the Worker', async ({ page }) => {
+    const sent: unknown[] = [];
+    await page.route('**/api/semantic', async (route) => {
+      sent.push(JSON.parse(route.request().postData() ?? '{}'));
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ hits: [CYBER_TOOL] }),
+      });
+    });
+
+    await visit(page, RESULTS);
+    await expectVisible(page, page.locator(BUTTON));
+    await page.locator(BUTTON).click();
+
+    await expect(page.locator(PAGE_HIT)).toHaveCount(1);
+    expect(sent).toEqual([{ q: QUERY, lang: 'ru' }]);
+  });
+
+  test('a hit renders from the local index — the server sent no text', async ({ page }) => {
+    await page.route('**/api/semantic', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ hits: [CYBER_TOOL] }),
+      });
+    });
+
+    await visit(page, RESULTS);
+    await page.locator(BUTTON).click();
+
+    const hit = page.locator(PAGE_HIT).first();
+    await expectVisible(page, hit);
+    expect(await hit.locator('a').getAttribute('href')).toBe('/ru/blog/cyber-tool');
+    expect((await hit.locator('.hit-title').textContent())?.trim()).not.toBe('');
+    expect((await hit.locator('.hit-snippet').textContent())?.trim()).not.toBe('');
+  });
+
+  test('pressing again gives the word results back', async ({ page }) => {
+    await page.route('**/api/semantic', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ hits: [CYBER_TOOL] }),
+      });
+    });
+
+    await visit(page, `/ru/search?q=${encodeURIComponent('нейросети')}`);
+    await expectVisible(page, page.locator(PAGE_HIT).first());
+    const exact = await page.locator(PAGE_HIT).count();
+    expect(exact).toBeGreaterThan(1);
+
+    const button = page.locator(BUTTON);
+    await button.click();
+    await expect(page.locator(PAGE_HIT)).toHaveCount(1);
+    expect(await button.getAttribute('aria-pressed')).toBe('true');
+
+    await button.click();
+    await expect(page.locator(PAGE_HIT)).toHaveCount(exact);
+    expect(await button.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  /*
+   * The vector store lags a deploy by a minute. An article deleted in that
+   * minute must not surface: the index the browser holds is the deploy, and
+   * it wins.
+   */
+  test('an id the index does not know is dropped, not rendered', async ({ page }) => {
+    await page.route('**/api/semantic', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          hits: [{ doc: 'ru/blog/deleted-yesterday', score: 0.9, start: 0, end: 100 }, CYBER_TOOL],
+        }),
+      });
+    });
+
+    await visit(page, RESULTS);
+    await page.locator(BUTTON).click();
+    await expect(page.locator(PAGE_HIT)).toHaveCount(1);
+  });
+
+  /* Rate-limited or offline: say so, and leave the word results standing. */
+  test('a refusal is stated, and the exact results survive it', async ({ page }) => {
+    await page.route('**/api/semantic', async (route) => {
+      await route.fulfill({ status: 429, contentType: 'application/json', body: '{}' });
+    });
+
+    await visit(page, `/ru/search?q=${encodeURIComponent('нейросети')}`);
+    await expectVisible(page, page.locator(PAGE_HIT).first());
+    const exact = await page.locator(PAGE_HIT).count();
+
+    await page.locator(BUTTON).click();
+    await expect(page.locator(STATUS)).toHaveText('Поиск по смыслу сейчас недоступен.');
+    await expect(page.locator(PAGE_HIT)).toHaveCount(exact);
+  });
+
+  /* Nothing to search by meaning means nothing to press. */
+  test('no query, no button', async ({ page }) => {
+    await visit(page, '/ru/search');
+    await expect(page.locator(BUTTON)).toBeHidden();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "predev": "bun run fetch-content && bun run check-frontmatter && bun run fetch-favicons && bun run build-favicons",
     "prebuild": "bun run fetch-content && bun run check-frontmatter && bun run fetch-favicons && bun run build-favicons",
     "dev": "astro dev",
-    "build": "biome format . && biome check . && eslint . && astro check && astro build",
+    "build": "biome format . && biome check . && eslint . && astro check && bun run check:worker && astro build",
+    "check:worker": "tsc -p src/worker/tsconfig.json",
     "preview": "astro preview",
     "test:unit": "vitest run",
     "test:unit:watch": "vitest",
@@ -53,6 +54,7 @@
   "devDependencies": {
     "@astrojs/check": "^0.9.6",
     "@biomejs/biome": "^2.3.14",
+    "@cloudflare/workers-types": "^5.20260712.1",
     "@lhci/cli": "^0.15.1",
     "@playwright/test": "^1.58.2",
     "@resvg/resvg-js": "^2.6.2",

--- a/packages/search-core/src/index.ts
+++ b/packages/search-core/src/index.ts
@@ -13,4 +13,9 @@ export type {
   Snippet,
 } from './query/search';
 export { prepare, search } from './query/search';
+export type { Chunk } from './semantic/chunk';
+export { chunkBody } from './semantic/chunk';
+export { passageSnippet } from './semantic/passage';
+export type { PassageMatch } from './semantic/rank';
+export { bestPerDoc } from './semantic/rank';
 export { normalize, tokenize } from './text/normalize';

--- a/packages/search-core/src/semantic/chunk.test.ts
+++ b/packages/search-core/src/semantic/chunk.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { chunkBody } from './chunk';
+
+const words = (count: number, word = 'слово'): string =>
+  Array.from({ length: count }, () => word).join(' ');
+
+describe('chunkBody', () => {
+  /*
+   * Articles here run to 72 000 characters. Embedding one as a single
+   * vector averages the whole thing into something that is about nothing
+   * — the passage is the unit of meaning, not the article.
+   */
+  it('splits a long body into passages', () => {
+    const chunks = chunkBody(words(2000));
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.text.length).toBeLessThanOrEqual(1200);
+    }
+  });
+
+  it('keeps a short body whole', () => {
+    const chunks = chunkBody('Пролетарии всех стран, соединяйтесь.');
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]?.text).toBe('Пролетарии всех стран, соединяйтесь.');
+  });
+
+  it('returns nothing for an empty body', () => {
+    expect(chunkBody('')).toEqual([]);
+    expect(chunkBody('   ')).toEqual([]);
+  });
+
+  /*
+   * The offsets are what let the reader see WHERE in the article the
+   * match is: the browser already holds the body, so the server sends
+   * coordinates instead of text.
+   */
+  it('reports offsets that point back into the source', () => {
+    const body = words(600);
+    for (const chunk of chunkBody(body)) {
+      expect(body.slice(chunk.start, chunk.end)).toBe(chunk.text);
+    }
+  });
+
+  it('never cuts a word in half', () => {
+    const body = words(600);
+    for (const chunk of chunkBody(body)) {
+      expect(chunk.text.startsWith(' ')).toBe(false);
+      expect(chunk.text.endsWith(' ')).toBe(false);
+      expect(body[chunk.start - 1] ?? ' ').toBe(' ');
+    }
+  });
+
+  /*
+   * A sentence that straddles a boundary would otherwise be in neither
+   * passage — the overlap is what stops the answer falling into the gap.
+   */
+  it('overlaps consecutive passages', () => {
+    const chunks = chunkBody(words(600));
+    expect(chunks.length).toBeGreaterThan(1);
+    const [first, second] = chunks;
+    expect(second?.start).toBeLessThan(first?.end ?? 0);
+  });
+
+  it('covers the whole body — no passage of text is unreachable', () => {
+    const body = words(900, 'текст');
+    const chunks = chunkBody(body);
+    expect(chunks[0]?.start).toBe(0);
+    expect(chunks.at(-1)?.end).toBe(body.length);
+  });
+
+  it('always makes progress, even when a single word is longer than a chunk', () => {
+    const monster = 'а'.repeat(5000);
+    const chunks = chunkBody(monster);
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks.at(-1)?.end).toBe(monster.length);
+  });
+});

--- a/packages/search-core/src/semantic/chunk.ts
+++ b/packages/search-core/src/semantic/chunk.ts
@@ -1,0 +1,62 @@
+/*
+ * Passages, not articles.
+ *
+ * The articles here run to 72 000 characters. Embedding one as a single
+ * vector averages the whole of it into something that is about nothing in
+ * particular — it would match every query weakly and none of them well.
+ * The passage is the unit of meaning.
+ *
+ * Offsets travel with each passage because the browser already holds the
+ * body: the server can answer with coordinates instead of shipping the
+ * text back, which is what keeps a semantic query small.
+ */
+
+/** A passage of a document, and where it sits in the body. */
+export interface Chunk {
+  readonly text: string;
+  readonly start: number;
+  readonly end: number;
+}
+
+/* ~250 tokens of Russian prose: enough to hold an argument, small enough
+ * that the vector is still about one thing. */
+const SIZE = 1000;
+
+/* A sentence that straddles a boundary would otherwise belong to neither
+ * passage. The overlap is what stops the answer falling into the gap. */
+const OVERLAP = 200;
+
+const backToSpace = (text: string, at: number, floor: number): number => {
+  const space = text.lastIndexOf(' ', at);
+  return space > floor ? space : at;
+};
+
+/**
+ * Split a plain-text body into overlapping passages.
+ * @param body - Markdown-stripped body text.
+ * @returns Passages in order; empty when there is no text.
+ */
+export const chunkBody = (body: string): readonly Chunk[] => {
+  const text = body.trim();
+  if (text === '') return [];
+  if (text.length <= SIZE) {
+    return [{ text, start: 0, end: text.length }];
+  }
+
+  const chunks: Chunk[] = [];
+  let start = 0;
+  while (start < text.length) {
+    const limit = Math.min(start + SIZE, text.length);
+    /*
+     * Cut on a space so no word is halved — unless the "word" is longer
+     * than a whole chunk, in which case cutting mid-word is the only way
+     * to make progress at all.
+     */
+    const end = limit === text.length ? limit : backToSpace(text, limit, start);
+    chunks.push({ text: text.slice(start, end).trim(), start, end });
+    if (end >= text.length) break;
+    const next = end - OVERLAP;
+    start = next > start ? backToSpace(text, next, start) + 1 : end + 1;
+  }
+  return chunks;
+};

--- a/packages/search-core/src/semantic/passage.test.ts
+++ b/packages/search-core/src/semantic/passage.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { passageSnippet } from './passage';
+
+describe('passageSnippet', () => {
+  it('quotes the passage the coordinates point at', () => {
+    const body = 'alpha beta gamma delta';
+    expect(passageSnippet(body, 6, 16).text).toBe('beta gamma');
+  });
+
+  it('never highlights: a semantic hit matched no word the reader typed', () => {
+    expect(passageSnippet('alpha beta', 0, 10).marks).toEqual([]);
+  });
+
+  it('reads offsets against the trimmed body, as the chunker wrote them', () => {
+    expect(passageSnippet('\n\n  alpha beta', 0, 5).text).toBe('alpha');
+  });
+
+  it('cuts a long passage on a word boundary and marks the cut', () => {
+    const body = 'слово '.repeat(100).trim();
+    const { text } = passageSnippet(body, 0, body.length);
+    expect(text.endsWith('…')).toBe(true);
+    expect(text).not.toContain('слов…');
+    expect(text.length).toBeLessThanOrEqual(241);
+  });
+
+  it('clamps coordinates that outrun the body', () => {
+    expect(passageSnippet('alpha', 2, 900).text).toBe('pha');
+  });
+
+  it('falls back to the head of the body when the range is empty', () => {
+    expect(passageSnippet('alpha beta', 4, 4).text).toBe('alpha beta');
+  });
+});

--- a/packages/search-core/src/semantic/passage.ts
+++ b/packages/search-core/src/semantic/passage.ts
@@ -1,0 +1,48 @@
+import type { Snippet } from '../query/snippet';
+
+/*
+ * The vector store answers with coordinates, not text — the browser holds
+ * the body already, so the passage is quoted here, on the client.
+ *
+ * No marks. A semantic hit matched by MEANING: there is no word in the
+ * article that the reader typed, and painting one yellow anyway would
+ * claim a match that never happened.
+ */
+
+/* A passage is a whole ~1000-character chunk; a result row shows the head
+ * of it. The reader is choosing which article to open, not reading it. */
+const PREVIEW = 240;
+
+/*
+ * Offsets are into the TRIMMED body — `chunkBody` trims before it cuts,
+ * so anything reading them back must trim the same way or every quote
+ * after the first blank line slides.
+ */
+const cutAtWord = (text: string): string => {
+  if (text.length <= PREVIEW) return text;
+  const head = text.slice(0, PREVIEW);
+  const space = head.lastIndexOf(' ');
+  return `${(space > 0 ? head.slice(0, space) : head).trimEnd()}…`;
+};
+
+/**
+ * Quote the passage a semantic hit pointed at.
+ * @param body - The document body, as it sits in the index.
+ * @param start - Passage start, as returned by the vector store.
+ * @param end - Passage end.
+ * @returns A quote with no highlight ranges.
+ */
+export const passageSnippet = (
+  body: string,
+  start: number,
+  end: number,
+): Snippet => {
+  const text = body.trim();
+  const from = Math.min(Math.max(start, 0), text.length);
+  const to = Math.min(Math.max(end, from), text.length);
+  const quoted = text.slice(from, to).trim();
+  return {
+    text: cutAtWord(quoted === '' ? text.slice(0, PREVIEW) : quoted),
+    marks: [],
+  };
+};

--- a/packages/search-core/src/semantic/rank.test.ts
+++ b/packages/search-core/src/semantic/rank.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { bestPerDoc } from './rank';
+
+const match = (doc: string, score: number, start = 0, end = 100) => ({
+  doc,
+  score,
+  start,
+  end,
+});
+
+describe('bestPerDoc', () => {
+  /*
+   * The vector store answers in PASSAGES, and a long article contributes
+   * dozens of them. Handing those back untouched would fill the results
+   * with the same article ten times over. The reader asked about a topic,
+   * not about a paragraph.
+   */
+  it('collapses many passages of one article into one result', () => {
+    const hits = bestPerDoc([
+      match('ru/blog/a', 0.7),
+      match('ru/blog/a', 0.9),
+      match('ru/blog/a', 0.5),
+    ]);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.score).toBe(0.9);
+  });
+
+  /* The strongest passage is what the reader should be taken to. */
+  it('keeps the offsets of the best passage, not the first one', () => {
+    const hits = bestPerDoc([
+      match('ru/blog/a', 0.4, 0, 100),
+      match('ru/blog/a', 0.95, 900, 1000),
+    ]);
+    expect(hits[0]).toMatchObject({ start: 900, end: 1000 });
+  });
+
+  it('ranks articles by their best passage', () => {
+    const hits = bestPerDoc([
+      match('ru/blog/weak', 0.3),
+      match('ru/blog/strong', 0.8),
+      match('ru/blog/weak', 0.4),
+    ]);
+    expect(hits.map((h) => h.doc)).toEqual(['ru/blog/strong', 'ru/blog/weak']);
+  });
+
+  it('honours the limit', () => {
+    const hits = bestPerDoc(
+      Array.from({ length: 20 }, (_, i) => match(`ru/blog/${i}`, i / 20)),
+      3,
+    );
+    expect(hits).toHaveLength(3);
+  });
+
+  it('returns nothing for nothing', () => {
+    expect(bestPerDoc([])).toEqual([]);
+  });
+});

--- a/packages/search-core/src/semantic/rank.ts
+++ b/packages/search-core/src/semantic/rank.ts
@@ -1,0 +1,41 @@
+/*
+ * The vector store answers in PASSAGES. A long article contributes dozens
+ * of them, and a query about its subject will match several — so the raw
+ * answer is the same article over and over. The reader asked about a
+ * topic, not about a paragraph: collapse to one row per article, keeping
+ * the strongest passage, because that is where they should be taken.
+ */
+
+/** One passage returned by the vector store. */
+export interface PassageMatch {
+  /** The document id — `${lang}/${section}/${slug}`. */
+  readonly doc: string;
+  readonly score: number;
+  /** Where the passage sits in the document body. */
+  readonly start: number;
+  readonly end: number;
+}
+
+const DEFAULT_LIMIT = 10;
+
+/**
+ * Collapse passage matches into one row per document.
+ * @param matches - Passages, in any order.
+ * @param limit - Maximum documents to return.
+ * @returns Documents, best first, each carrying its strongest passage.
+ */
+export const bestPerDoc = (
+  matches: readonly PassageMatch[],
+  limit: number = DEFAULT_LIMIT,
+): readonly PassageMatch[] => {
+  const best = new Map<string, PassageMatch>();
+  for (const match of matches) {
+    const current = best.get(match.doc);
+    if (current === undefined || match.score > current.score) {
+      best.set(match.doc, match);
+    }
+  }
+  return [...best.values()]
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+};

--- a/scripts/reindex.ts
+++ b/scripts/reindex.ts
@@ -46,8 +46,8 @@ const languagesIn = (dist: string): readonly string[] =>
     .map((e) => e.name)
     .filter((name) => existsSync(join(dist, name, 'search-index.json')));
 
-const callOnce = async (base: string, secret: string, lang: string): Promise<Progress> => {
-  const res = await fetch(`${base}/api/reindex`, {
+const post = async (base: string, secret: string, lang: string): Promise<Response> =>
+  fetch(`${base}/api/reindex`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -55,10 +55,30 @@ const callOnce = async (base: string, secret: string, lang: string): Promise<Pro
     },
     body: JSON.stringify({ lang }),
   });
-  if (!res.ok) {
-    throw new Error(`reindex ${lang}: ${res.status} ${await res.text()}`);
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/*
+ * A deploy does not become live everywhere the moment wrangler returns.
+ * Until it does, the edge still answers `/api/*` from the asset store —
+ * and a POST at a static file is a 405. That is the deploy still landing,
+ * not a broken Worker, so wait it out rather than fail the pipeline.
+ */
+const NOT_LIVE_YET = new Set([404, 405]);
+const LIVE_TRIES = 20;
+const LIVE_WAIT_MS = 6000;
+
+const callOnce = async (base: string, secret: string, lang: string): Promise<Progress> => {
+  for (let attempt = 0; attempt < LIVE_TRIES; attempt += 1) {
+    const res = await post(base, secret, lang);
+    if (res.ok) return (await res.json()) as Progress;
+    if (!NOT_LIVE_YET.has(res.status)) {
+      throw new Error(`reindex ${lang}: ${res.status} ${await res.text()}`);
+    }
+    console.log(`[reindex] worker not live yet (${res.status}), waiting…`);
+    await sleep(LIVE_WAIT_MS);
   }
-  return (await res.json()) as Progress;
+  throw new Error(`reindex ${lang}: worker never came up`);
 };
 
 const reindexLanguage = async (base: string, secret: string, lang: string): Promise<void> => {

--- a/scripts/reindex.ts
+++ b/scripts/reindex.ts
@@ -96,14 +96,51 @@ const call = async <T>(base: string, secret: string, body: Record<string, unknow
   throw new Error('reindex: worker never came up');
 };
 
-const reindexLanguage = async (base: string, secret: string, lang: string): Promise<void> => {
-  const { total, stale } = await call<Plan>(base, secret, { lang });
-  console.log(`[reindex] ${lang}: ${stale.length} stale of ${total}`);
-
+const embedAll = async (
+  base: string,
+  secret: string,
+  lang: string,
+  stale: readonly string[],
+): Promise<void> => {
   for (let at = 0; at < stale.length; at += DOCS_PER_CALL) {
     const docs = stale.slice(at, at + DOCS_PER_CALL);
     await call(base, secret, { lang, docs });
     console.log(`[reindex] ${lang}: embedded ${docs.join(', ')}`);
+  }
+};
+
+/*
+ * Verify, because a write can go missing.
+ *
+ * On dev, four magazine issues were embedded, the Worker reported all
+ * four, and only one was in the store afterwards — a second attempt put
+ * the other three in. So an accepted upsert is not a stored one, and a
+ * job that never looks back would call that deploy a success while the
+ * search quietly ran on last week's text.
+ *
+ * The wait is for Vectorize itself: it applies writes asynchronously, so
+ * asking immediately would report as missing what is merely in flight.
+ */
+const SETTLE_MS = 30_000;
+
+const reindexLanguage = async (base: string, secret: string, lang: string): Promise<void> => {
+  const { total, stale } = await call<Plan>(base, secret, { lang });
+  console.log(`[reindex] ${lang}: ${stale.length} stale of ${total}`);
+  if (stale.length === 0) return;
+
+  await embedAll(base, secret, lang, stale);
+
+  await sleep(SETTLE_MS);
+  const missed = (await call<Plan>(base, secret, { lang })).stale;
+  if (missed.length === 0) return;
+
+  console.log(`[reindex] ${lang}: ${missed.length} did not land, retrying`);
+  await embedAll(base, secret, lang, missed);
+
+  await sleep(SETTLE_MS);
+  const lost = (await call<Plan>(base, secret, { lang })).stale;
+  if (lost.length > 0) {
+    throw new Error(`reindex ${lang}: not stored after two attempts: ${lost.join(', ')}`);
   }
 };
 

--- a/scripts/reindex.ts
+++ b/scripts/reindex.ts
@@ -1,0 +1,92 @@
+/*
+ * Re-embed the articles that changed, right after a deploy.
+ *
+ * The Worker does the actual work — it reads the freshly deployed index
+ * through its own ASSETS binding, so it can never embed a version of an
+ * article that is not the one being served. This script only drives it:
+ * one call per batch, until the Worker says nothing is left.
+ *
+ * It is bounded on purpose. The Worker embeds a couple of documents per
+ * call to stay inside its CPU budget, so a first run over a fresh index
+ * takes many calls — but a normal deploy, where one article changed,
+ * takes one.
+ *
+ * Run: bun scripts/reindex.ts --base https://dev.comprom.org
+ * Needs REINDEX_SECRET in the environment; without it the Worker answers
+ * 403 and this exits non-zero rather than pretending the index is fresh.
+ */
+import { existsSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+interface Progress {
+  readonly total: number;
+  readonly indexed: number;
+  readonly remaining: number;
+}
+
+/*
+ * A runaway guard, not a budget: at 2 documents a call this is far more
+ * than a full cold rebuild of every language would ever need.
+ */
+const MAX_CALLS = 400;
+
+const arg = (name: string): string | undefined => {
+  const at = process.argv.indexOf(`--${name}`);
+  return at < 0 ? undefined : process.argv[at + 1];
+};
+
+/*
+ * The languages are whatever the build emitted, not a list kept in step
+ * by hand — `languages.json` lives in the content repo and editors add to
+ * it without touching this repo.
+ */
+const languagesIn = (dist: string): readonly string[] =>
+  readdirSync(dist, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .filter((name) => existsSync(join(dist, name, 'search-index.json')));
+
+const callOnce = async (base: string, secret: string, lang: string): Promise<Progress> => {
+  const res = await fetch(`${base}/api/reindex`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Reindex-Key': secret,
+    },
+    body: JSON.stringify({ lang }),
+  });
+  if (!res.ok) {
+    throw new Error(`reindex ${lang}: ${res.status} ${await res.text()}`);
+  }
+  return (await res.json()) as Progress;
+};
+
+const reindexLanguage = async (base: string, secret: string, lang: string): Promise<void> => {
+  for (let call = 0; call < MAX_CALLS; call += 1) {
+    const { total, indexed, remaining } = await callOnce(base, secret, lang);
+    console.log(`[reindex] ${lang}: ${indexed} embedded, ${remaining} left of ${total}`);
+    if (remaining === 0) return;
+    /*
+     * Nothing left to do but nothing got done either: the Worker is not
+     * making progress, and looping MAX_CALLS times would only hide it.
+     */
+    if (indexed === 0) throw new Error(`reindex ${lang}: stuck`);
+  }
+  throw new Error(`reindex ${lang}: gave up after ${MAX_CALLS} calls`);
+};
+
+const main = async (): Promise<void> => {
+  const base = arg('base');
+  const { REINDEX_SECRET: secret } = process.env;
+  if (base === undefined) throw new Error('missing --base');
+  if (secret === undefined || secret === '') {
+    throw new Error('missing REINDEX_SECRET');
+  }
+
+  const dist = resolve('dist');
+  for (const lang of languagesIn(dist)) {
+    await reindexLanguage(base, secret, lang);
+  }
+};
+
+await main();

--- a/scripts/reindex.ts
+++ b/scripts/reindex.ts
@@ -3,13 +3,13 @@
  *
  * The Worker does the actual work — it reads the freshly deployed index
  * through its own ASSETS binding, so it can never embed a version of an
- * article that is not the one being served. This script only drives it:
- * one call per batch, until the Worker says nothing is left.
+ * article that is not the one being served. This script only drives it.
  *
- * It is bounded on purpose. The Worker embeds a couple of documents per
- * call to stay inside its CPU budget, so a first run over a fresh index
- * takes many calls — but a normal deploy, where one article changed,
- * takes one.
+ * It asks ONCE what is stale, then walks that list. It does not re-ask
+ * between batches: Vectorize is eventually consistent, so for a few
+ * seconds after a write the store still reports the old state, and a job
+ * that re-plans between batches keeps re-embedding what it has just done —
+ * which is exactly what it did, in a circle, on dev.
  *
  * Run: bun scripts/reindex.ts --base https://dev.comprom.org
  * Needs REINDEX_SECRET in the environment; without it the Worker answers
@@ -18,17 +18,16 @@
 import { existsSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 
-interface Progress {
+interface Plan {
   readonly total: number;
-  readonly indexed: number;
-  readonly remaining: number;
+  readonly stale: readonly string[];
 }
 
 /*
- * A runaway guard, not a budget: at 2 documents a call this is far more
- * than a full cold rebuild of every language would ever need.
+ * The Worker embeds at most this many documents per call — see its own
+ * MAX_DOCS_PER_CALL. Asking for more would silently drop the rest.
  */
-const MAX_CALLS = 400;
+const DOCS_PER_CALL = 2;
 
 const arg = (name: string): string | undefined => {
   const at = process.argv.indexOf(`--${name}`);
@@ -46,53 +45,66 @@ const languagesIn = (dist: string): readonly string[] =>
     .map((e) => e.name)
     .filter((name) => existsSync(join(dist, name, 'search-index.json')));
 
-const post = async (base: string, secret: string, lang: string): Promise<Response> =>
-  fetch(`${base}/api/reindex`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Reindex-Key': secret,
-    },
-    body: JSON.stringify({ lang }),
-  });
-
-const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+const sleep = (ms: number): Promise<void> => new Promise((done) => setTimeout(done, ms));
 
 /*
  * A deploy does not become live everywhere the moment wrangler returns.
  * Until it does, the edge still answers `/api/*` from the asset store —
  * and a POST at a static file is a 405. That is the deploy still landing,
  * not a broken Worker, so wait it out rather than fail the pipeline.
+ *
+ * A 5xx gets the same patience but much less of it: the model and the
+ * vector store are remote services, and one blip should not fail a deploy
+ * that is otherwise fine. Three tries, then say so.
  */
 const NOT_LIVE_YET = new Set([404, 405]);
 const LIVE_TRIES = 20;
 const LIVE_WAIT_MS = 6000;
+const SERVER_TRIES = 3;
+const SERVER_WAIT_MS = 5000;
 
-const callOnce = async (base: string, secret: string, lang: string): Promise<Progress> => {
+const post = async (
+  base: string,
+  secret: string,
+  body: Record<string, unknown>,
+): Promise<Response> =>
+  fetch(`${base}/api/reindex`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-Reindex-Key': secret },
+    body: JSON.stringify(body),
+  });
+
+const call = async <T>(base: string, secret: string, body: Record<string, unknown>): Promise<T> => {
+  let serverTries = 0;
   for (let attempt = 0; attempt < LIVE_TRIES; attempt += 1) {
-    const res = await post(base, secret, lang);
-    if (res.ok) return (await res.json()) as Progress;
-    if (!NOT_LIVE_YET.has(res.status)) {
-      throw new Error(`reindex ${lang}: ${res.status} ${await res.text()}`);
+    const res = await post(base, secret, body);
+    if (res.ok) return (await res.json()) as T;
+
+    if (NOT_LIVE_YET.has(res.status)) {
+      console.log(`[reindex] worker not live yet (${res.status}), waiting…`);
+      await sleep(LIVE_WAIT_MS);
+      continue;
     }
-    console.log(`[reindex] worker not live yet (${res.status}), waiting…`);
-    await sleep(LIVE_WAIT_MS);
+    if (res.status >= 500 && serverTries < SERVER_TRIES) {
+      serverTries += 1;
+      console.log(`[reindex] ${res.status} from the worker, retry ${serverTries}`);
+      await sleep(SERVER_WAIT_MS);
+      continue;
+    }
+    throw new Error(`reindex: ${res.status} ${(await res.text()).slice(0, 200)}`);
   }
-  throw new Error(`reindex ${lang}: worker never came up`);
+  throw new Error('reindex: worker never came up');
 };
 
 const reindexLanguage = async (base: string, secret: string, lang: string): Promise<void> => {
-  for (let call = 0; call < MAX_CALLS; call += 1) {
-    const { total, indexed, remaining } = await callOnce(base, secret, lang);
-    console.log(`[reindex] ${lang}: ${indexed} embedded, ${remaining} left of ${total}`);
-    if (remaining === 0) return;
-    /*
-     * Nothing left to do but nothing got done either: the Worker is not
-     * making progress, and looping MAX_CALLS times would only hide it.
-     */
-    if (indexed === 0) throw new Error(`reindex ${lang}: stuck`);
+  const { total, stale } = await call<Plan>(base, secret, { lang });
+  console.log(`[reindex] ${lang}: ${stale.length} stale of ${total}`);
+
+  for (let at = 0; at < stale.length; at += DOCS_PER_CALL) {
+    const docs = stale.slice(at, at + DOCS_PER_CALL);
+    await call(base, secret, { lang, docs });
+    console.log(`[reindex] ${lang}: embedded ${docs.join(', ')}`);
   }
-  throw new Error(`reindex ${lang}: gave up after ${MAX_CALLS} calls`);
 };
 
 const main = async (): Promise<void> => {

--- a/src/features/search/i18n.ts
+++ b/src/features/search/i18n.ts
@@ -15,6 +15,13 @@ export interface SearchStrings {
   readonly placeholder: string;
   readonly noResults: string;
   readonly resultsTitle: string;
+  /** The button that hands the query to the model. */
+  readonly semanticLabel: string;
+  readonly semanticBusy: string;
+  readonly semanticTitle: string;
+  readonly semanticError: string;
+  /** The way back: rank by spelling again. */
+  readonly exactTitle: string;
   readonly sections: Readonly<Record<SearchSection, string>>;
 }
 
@@ -23,6 +30,11 @@ const EN: SearchStrings = {
   placeholder: 'Search articles…',
   noResults: 'Nothing found.',
   resultsTitle: 'Search',
+  semanticLabel: 'Search by meaning',
+  semanticBusy: 'Searching by meaning…',
+  semanticTitle: 'By meaning',
+  semanticError: 'Meaning search is unavailable right now.',
+  exactTitle: 'By words',
   sections: {
     blog: 'Blog',
     positions: 'Positions',
@@ -39,6 +51,11 @@ const STRINGS: Readonly<Record<string, SearchStrings>> = {
     placeholder: 'Искать по статьям…',
     noResults: 'Ничего не найдено.',
     resultsTitle: 'Поиск',
+    semanticLabel: 'Искать по смыслу',
+    semanticBusy: 'Ищем по смыслу…',
+    semanticTitle: 'По смыслу',
+    semanticError: 'Поиск по смыслу сейчас недоступен.',
+    exactTitle: 'По словам',
     sections: {
       blog: 'Блог',
       positions: 'Позиции',
@@ -52,6 +69,11 @@ const STRINGS: Readonly<Record<string, SearchStrings>> = {
     placeholder: 'Cerca negli articoli…',
     noResults: 'Nessun risultato.',
     resultsTitle: 'Ricerca',
+    semanticLabel: 'Cerca per significato',
+    semanticBusy: 'Ricerca per significato…',
+    semanticTitle: 'Per significato',
+    semanticError: 'La ricerca per significato non è disponibile.',
+    exactTitle: 'Per parole',
     sections: {
       blog: 'Blog',
       positions: 'Posizioni',
@@ -65,6 +87,11 @@ const STRINGS: Readonly<Record<string, SearchStrings>> = {
     placeholder: 'Buscar artículos…',
     noResults: 'No se encontró nada.',
     resultsTitle: 'Búsqueda',
+    semanticLabel: 'Buscar por significado',
+    semanticBusy: 'Buscando por significado…',
+    semanticTitle: 'Por significado',
+    semanticError: 'La búsqueda por significado no está disponible.',
+    exactTitle: 'Por palabras',
     sections: {
       blog: 'Blog',
       positions: 'Posiciones',

--- a/src/features/search/page-view.ts
+++ b/src/features/search/page-view.ts
@@ -1,0 +1,38 @@
+import type { SearchHit } from '@prometheus/search-core';
+import type { SearchStrings } from './i18n';
+import { renderHits } from './render-list';
+
+/*
+ * The results page has two modes — by words, and by meaning — and they
+ * render into the same container. Keeping the drawing here means the
+ * controller only decides WHICH hits to show, never how.
+ */
+
+/**
+ * Draw a set of hits into the results container.
+ * @param root The results container.
+ * @param t Localised chrome.
+ * @param hits Ranked hits, best first.
+ * @param title What the list is — announced to a screen reader, since the
+ * rows themselves look identical in either mode.
+ */
+export const renderPage = (
+  root: HTMLElement,
+  t: SearchStrings,
+  hits: readonly SearchHit[],
+  title: string,
+): void => {
+  if (hits.length === 0) {
+    const empty = document.createElement('p');
+    empty.className = 'search-page-empty';
+    empty.textContent = t.noResults;
+    root.replaceChildren(empty);
+    return;
+  }
+
+  const list = document.createElement('ul');
+  list.className = 'search-page-list';
+  list.setAttribute('aria-label', title);
+  root.replaceChildren(list);
+  renderHits(list, hits, t.sections, false);
+};

--- a/src/features/search/search-page.ts
+++ b/src/features/search/search-page.ts
@@ -1,6 +1,8 @@
+import type { SearchIndex } from '@prometheus/search-core';
 import { prepare, search } from '@prometheus/search-core';
 import { searchStrings } from './i18n';
-import { renderHits } from './render-list';
+import { renderPage } from './page-view';
+import { setupSemanticToggle } from './semantic-toggle';
 
 /*
  * The results page renders from the same index the dropdown uses.
@@ -16,8 +18,23 @@ const MAX_HITS = 40;
 
 const queryOf = (): string => new URL(globalThis.location.href).searchParams.get('q')?.trim() ?? '';
 
+/*
+ * Several boxes render on this page — the header bar, the burger menu,
+ * and the page's own. Seed them all: picking "the first one" quietly
+ * seeds whichever happens to come first in the DOM, which is the header,
+ * not the one the reader is looking at.
+ */
+const seedBoxes = (query: string): void => {
+  for (const input of document.querySelectorAll<HTMLInputElement>('[data-search-input]')) {
+    input.value = query;
+  }
+};
+
+const pick = <T extends HTMLElement>(selector: string): T | undefined =>
+  document.querySelector<T>(selector) ?? undefined;
+
 /**
- * Render the results for `?q=` into the page.
+ * Render the results for `?q=` into the page, and arm the meaning search.
  * @param root The container element, carrying `data-lang`.
  */
 export const setupSearchPage = async (root: HTMLElement): Promise<void> => {
@@ -26,31 +43,23 @@ export const setupSearchPage = async (root: HTMLElement): Promise<void> => {
 
   const lang = root.getAttribute('data-lang') ?? 'en';
   const t = searchStrings(lang);
-
-  /*
-   * Several boxes render on this page — the header bar, the burger menu,
-   * and the page's own. Seed them all: picking "the first one" quietly
-   * seeds whichever happens to come first in the DOM, which is the header,
-   * not the one the reader is looking at.
-   */
-  for (const input of document.querySelectorAll<HTMLInputElement>('[data-search-input]')) {
-    input.value = query;
-  }
+  seedBoxes(query);
 
   const res = await fetch(`/${lang}/search-index.json`);
-  const hits = search(prepare(await res.json()), query, MAX_HITS);
+  const index = (await res.json()) as SearchIndex;
+  const exact = search(prepare(index), query, MAX_HITS);
+  renderPage(root, t, exact, t.exactTitle);
 
-  if (hits.length === 0) {
-    const empty = document.createElement('p');
-    empty.className = 'search-page-empty';
-    empty.textContent = t.noResults;
-    root.replaceChildren(empty);
-    return;
-  }
-
-  const list = document.createElement('ul');
-  list.className = 'search-page-list';
-  list.setAttribute('aria-label', t.resultsTitle);
-  root.replaceChildren(list);
-  renderHits(list, hits, t.sections, false);
+  const button = pick<HTMLButtonElement>('[data-semantic]');
+  const status = pick('[data-semantic-status]');
+  if (button === undefined || status === undefined) return;
+  setupSemanticToggle(button, {
+    root,
+    status,
+    t,
+    lang,
+    query,
+    docs: index.docs,
+    exact,
+  });
 };

--- a/src/features/search/semantic-client.test.ts
+++ b/src/features/search/semantic-client.test.ts
@@ -54,6 +54,13 @@ describe('semanticSearch', () => {
     });
   });
 
+  it('quotes the blurb when there is no body to quote — a magazine issue', async () => {
+    reply([{ doc: 'a', score: 0.6, start: 0, end: 0 }]);
+    const issue = { ...doc('a', ''), description: 'Первый номер' };
+    const hits = await semanticSearch('ru', 'журнал', [issue]);
+    expect(hits[0]?.snippet.text).toBe('Первый номер');
+  });
+
   it('throws when the Worker refuses, so the caller can say so', async () => {
     vi.stubGlobal(
       'fetch',

--- a/src/features/search/semantic-client.test.ts
+++ b/src/features/search/semantic-client.test.ts
@@ -1,0 +1,64 @@
+import type { SearchDoc } from '@prometheus/search-core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { semanticSearch } from './semantic-client';
+
+const doc = (id: string, body: string): SearchDoc => ({
+  id,
+  lang: 'ru',
+  section: 'blog',
+  slug: id,
+  url: `/ru/blog/${id}`,
+  title: id,
+  description: '',
+  body,
+  hash: '0',
+});
+
+const reply = (hits: unknown): void => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => new Response(JSON.stringify({ hits }), { status: 200 })),
+  );
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('semanticSearch', () => {
+  it('quotes the passage the server pointed at, from the local body', async () => {
+    reply([{ doc: 'a', score: 0.8, start: 6, end: 16 }]);
+    const hits = await semanticSearch('ru', 'нейросети', [doc('a', 'alpha beta gamma delta')]);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.snippet.text).toBe('beta gamma');
+    expect(hits[0]?.score).toBe(0.8);
+  });
+
+  it('drops an id the local index does not know — the deploy is the truth', async () => {
+    reply([
+      { doc: 'deleted', score: 0.9, start: 0, end: 5 },
+      { doc: 'a', score: 0.4, start: 0, end: 5 },
+    ]);
+    const hits = await semanticSearch('ru', 'q', [doc('a', 'alpha')]);
+    expect(hits.map((hit) => hit.doc.id)).toEqual(['a']);
+  });
+
+  it('sends only the query — never the corpus', async () => {
+    const spy = vi.fn(async () => new Response(JSON.stringify({ hits: [] }), { status: 200 }));
+    vi.stubGlobal('fetch', spy);
+    await semanticSearch('ru', 'нейросети', [doc('a', 'x'.repeat(50_000))]);
+    const [, init] = spy.mock.calls[0] ?? [];
+    expect(JSON.parse(String((init as RequestInit).body))).toEqual({
+      q: 'нейросети',
+      lang: 'ru',
+    });
+  });
+
+  it('throws when the Worker refuses, so the caller can say so', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('{}', { status: 429 })),
+    );
+    await expect(semanticSearch('ru', 'q', [])).rejects.toThrow('429');
+  });
+});

--- a/src/features/search/semantic-client.ts
+++ b/src/features/search/semantic-client.ts
@@ -49,12 +49,9 @@ export const semanticSearch = async (
   return (body.hits ?? []).flatMap((hit) => {
     const doc = byId.get(hit.doc);
     if (doc === undefined) return [];
-    return [
-      {
-        doc,
-        score: hit.score,
-        snippet: passageSnippet(doc.body, hit.start, hit.end),
-      },
-    ];
+    const passage = passageSnippet(doc.body, hit.start, hit.end);
+    /* A magazine issue has a cover and a blurb, and no body to quote. */
+    const snippet = passage.text === '' ? { text: doc.description, marks: [] } : passage;
+    return [{ doc, score: hit.score, snippet }];
   });
 };

--- a/src/features/search/semantic-client.ts
+++ b/src/features/search/semantic-client.ts
@@ -1,0 +1,60 @@
+import type { SearchDoc, SearchHit } from '@prometheus/search-core';
+import { passageSnippet } from '@prometheus/search-core';
+
+/*
+ * Meaning search. The query — and only the query — goes to the Worker,
+ * which embeds it and asks the vector store which passages are close.
+ * What comes back is coordinates: document id, and where in the body the
+ * matching passage sits. The article itself is already here, in the index
+ * the page downloaded, so nothing large ever travels.
+ *
+ * An id the local index does not know is dropped. The vector store is
+ * written by a background job and can lag a deploy by a minute; the index
+ * is the deploy. When they disagree, the deploy is right — that is what
+ * stops a just-deleted article surfacing.
+ */
+
+interface Coordinates {
+  readonly doc: string;
+  readonly score: number;
+  readonly start: number;
+  readonly end: number;
+}
+
+const ENDPOINT = '/api/semantic';
+
+/**
+ * Rank documents by meaning rather than by spelling.
+ * @param lang - Active language; the vector store is filtered by it.
+ * @param query - Raw text as typed.
+ * @param docs - The documents the page already holds.
+ * @returns Hits, best first, quoting the passage that matched.
+ * @throws When the Worker refuses (rate limit, model failure, offline).
+ */
+export const semanticSearch = async (
+  lang: string,
+  query: string,
+  docs: readonly SearchDoc[],
+): Promise<readonly SearchHit[]> => {
+  const res = await fetch(ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ q: query, lang }),
+  });
+  if (!res.ok) throw new Error(`semantic: ${res.status}`);
+
+  const body = (await res.json()) as { hits?: readonly Coordinates[] };
+  const byId = new Map(docs.map((doc) => [doc.id, doc]));
+
+  return (body.hits ?? []).flatMap((hit) => {
+    const doc = byId.get(hit.doc);
+    if (doc === undefined) return [];
+    return [
+      {
+        doc,
+        score: hit.score,
+        snippet: passageSnippet(doc.body, hit.start, hit.end),
+      },
+    ];
+  });
+};

--- a/src/features/search/semantic-toggle.ts
+++ b/src/features/search/semantic-toggle.ts
@@ -1,0 +1,72 @@
+import type { SearchDoc, SearchHit } from '@prometheus/search-core';
+import type { SearchStrings } from './i18n';
+import { renderPage } from './page-view';
+import { semanticSearch } from './semantic-client';
+
+/*
+ * "Search by meaning" is a button, not a mode the reader falls into.
+ *
+ * Word search is instant and free; this one costs a round trip and a
+ * model call, so it happens when it is asked for. Pressing again gives
+ * the word results back — the reader can always get out, and the exact
+ * hits are still in memory, so getting out is free too.
+ */
+
+/** Everything the toggle needs to answer a press. */
+export interface SemanticContext {
+  readonly root: HTMLElement;
+  readonly status: HTMLElement;
+  readonly t: SearchStrings;
+  readonly lang: string;
+  readonly query: string;
+  readonly docs: readonly SearchDoc[];
+  /** The word-search hits already on screen, to restore on release. */
+  readonly exact: readonly SearchHit[];
+}
+
+const setPressed = (button: HTMLButtonElement, on: boolean): void => {
+  button.setAttribute('aria-pressed', String(on));
+};
+
+const showExact = (button: HTMLButtonElement, ctx: SemanticContext): void => {
+  setPressed(button, false);
+  ctx.status.textContent = '';
+  renderPage(ctx.root, ctx.t, ctx.exact, ctx.t.exactTitle);
+};
+
+const showMeaning = async (button: HTMLButtonElement, ctx: SemanticContext): Promise<void> => {
+  button.disabled = true;
+  ctx.status.textContent = ctx.t.semanticBusy;
+  try {
+    const hits = await semanticSearch(ctx.lang, ctx.query, ctx.docs);
+    setPressed(button, true);
+    ctx.status.textContent = ctx.t.semanticTitle;
+    renderPage(ctx.root, ctx.t, hits, ctx.t.semanticTitle);
+  } catch {
+    /*
+     * Rate-limited, offline, or the model is down. Say so and leave the
+     * word results exactly where they were — a blank page would look
+     * like "nothing matched", which is a different and false claim.
+     */
+    ctx.status.textContent = ctx.t.semanticError;
+  } finally {
+    button.disabled = false;
+  }
+};
+
+/**
+ * Wire the meaning-search button.
+ * @param button The toggle.
+ * @param ctx What it needs to answer a press.
+ */
+export const setupSemanticToggle = (button: HTMLButtonElement, ctx: SemanticContext): void => {
+  button.hidden = false;
+  button.addEventListener('click', () => {
+    const on = button.getAttribute('aria-pressed') === 'true';
+    if (on) {
+      showExact(button, ctx);
+      return;
+    }
+    showMeaning(button, ctx).catch(() => undefined);
+  });
+};

--- a/src/pages/[lang]/search.astro
+++ b/src/pages/[lang]/search.astro
@@ -25,6 +25,32 @@ const t = searchStrings(lang);
     <div class="container">
       <h1>{t.resultsTitle}</h1>
       <SearchBox lang={lang} variant="hero" />
+
+      {/*
+        Hidden until the script arms it: without JavaScript the button
+        would be a control that does nothing. It appears only once there
+        is a query and a loaded index behind it.
+      */}
+      <div class="tools">
+        <button
+          type="button"
+          class="semantic"
+          aria-pressed="false"
+          data-semantic
+          data-testid="semantic-button"
+          hidden
+        >
+          {t.semanticLabel}
+        </button>
+        <p
+          class="semantic-status"
+          role="status"
+          data-semantic-status
+          data-testid="semantic-status"
+        >
+        </p>
+      </div>
+
       <div class="page-results" data-search-page data-lang={lang} data-testid="search-page-results"></div>
     </div>
   </div>
@@ -47,6 +73,50 @@ const t = searchStrings(lang);
     font-size: clamp(1.75rem, 5vw, 2.5rem);
     font-weight: 700;
     margin-bottom: var(--spacing-lg);
+  }
+
+  .tools {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-md);
+    flex-wrap: wrap;
+    margin-block-start: var(--spacing-md);
+  }
+
+  .semantic {
+    padding: var(--spacing-xs) var(--spacing-md);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text-primary);
+    font-size: 0.875rem;
+    cursor: pointer;
+  }
+
+  .semantic:hover:not(:disabled) {
+    border-color: var(--color-accent);
+  }
+
+  .semantic[aria-pressed='true'] {
+    background: var(--color-accent);
+    border-color: var(--color-accent);
+    color: var(--color-bg);
+  }
+
+  .semantic:disabled {
+    cursor: progress;
+    opacity: 0.6;
+  }
+
+  .semantic:focus-visible {
+    outline: 2px solid var(--color-focus-ring);
+    outline-offset: 2px;
+  }
+
+  .semantic-status {
+    margin: 0;
+    font-size: 0.8125rem;
+    color: var(--color-text-secondary);
   }
 
   .page-results {

--- a/src/worker/embed.test.ts
+++ b/src/worker/embed.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import { embed } from './embed';
+import type { Env } from './env';
+
+/*
+ * The model refuses a call over 60 000 tokens — and it refuses the WHOLE
+ * call, so one long article took the whole reindex down with it (AiError
+ * 3030, on dev, with 90 passages in one request). These tests hold the
+ * fix: the batch is what is bounded, not the article.
+ */
+
+const fakeEnv = (run: (model: string, input: { text: string[] }) => Promise<unknown>): Env =>
+  ({ AI: { run } }) as unknown as Env;
+
+const vectorsFor = (texts: readonly string[]) => ({
+  data: texts.map((text) => [text.length]),
+});
+
+describe('embed', () => {
+  it('splits a long article into calls the model will accept', async () => {
+    const sizes: number[] = [];
+    const env = fakeEnv(async (_model, input) => {
+      sizes.push(input.text.length);
+      return vectorsFor(input.text);
+    });
+
+    const texts = Array.from({ length: 45 }, (_, at) => `passage ${at}`);
+    await embed(env, texts);
+
+    expect(sizes).toEqual([20, 20, 5]);
+  });
+
+  it('keeps the vectors in the order the passages were given', async () => {
+    const env = fakeEnv(async (_model, input) => vectorsFor(input.text));
+    const texts = ['a', 'bb', 'ccc', ...Array.from({ length: 20 }, () => 'dddd')];
+
+    const vectors = await embed(env, texts);
+
+    expect(vectors.map((v) => v[0])).toEqual(texts.map((t) => t.length));
+  });
+
+  it('embeds nothing without calling the model', async () => {
+    const run = vi.fn();
+    expect(await embed(fakeEnv(run), [])).toEqual([]);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('refuses a short answer rather than misalign passages and vectors', async () => {
+    const env = fakeEnv(async () => ({ data: [[1]] }));
+    await expect(embed(env, ['a', 'b'])).rejects.toThrow('got 1');
+  });
+});

--- a/src/worker/embed.ts
+++ b/src/worker/embed.ts
@@ -1,0 +1,33 @@
+import { EMBEDDING_MODEL, type Env } from './env';
+
+/*
+ * One place that talks to the model, so the query path and the indexing
+ * path can never drift into different vector spaces — a query embedded by
+ * a different model than the documents would return confident nonsense.
+ */
+
+interface EmbeddingResponse {
+  readonly data?: readonly (readonly number[])[];
+}
+
+/**
+ * Embed a batch of texts.
+ * @param env - Worker bindings.
+ * @param texts - Texts to embed; order is preserved in the result.
+ * @returns One vector per input.
+ * @throws When the model returns fewer vectors than it was given texts.
+ */
+export const embed = async (
+  env: Env,
+  texts: readonly string[],
+): Promise<readonly (readonly number[])[]> => {
+  if (texts.length === 0) return [];
+  const res = (await env.AI.run(EMBEDDING_MODEL, {
+    text: [...texts],
+  })) as EmbeddingResponse;
+  const vectors = res.data ?? [];
+  if (vectors.length !== texts.length) {
+    throw new Error(`embedding: asked for ${texts.length} vectors, got ${vectors.length}`);
+  }
+  return vectors;
+};

--- a/src/worker/embed.ts
+++ b/src/worker/embed.ts
@@ -10,6 +10,31 @@ interface EmbeddingResponse {
   readonly data?: readonly (readonly number[])[];
 }
 
+/*
+ * The model takes 60 000 tokens per CALL, not per text. The longest
+ * article here is 72 000 characters — about 90 passages — and handing all
+ * of them over at once asked for 63 054 tokens and was refused outright.
+ *
+ * 20 passages is roughly 8 000 tokens of Russian prose: comfortably under
+ * the ceiling even if an article turns out to be denser than any we have.
+ * Indexing is a background job; there is nothing to gain by crowding it.
+ */
+const BATCH = 20;
+
+const runBatch = async (
+  env: Env,
+  texts: readonly string[],
+): Promise<readonly (readonly number[])[]> => {
+  const res = (await env.AI.run(EMBEDDING_MODEL, {
+    text: [...texts],
+  })) as EmbeddingResponse;
+  const vectors = res.data ?? [];
+  if (vectors.length !== texts.length) {
+    throw new Error(`embedding: asked for ${texts.length} vectors, got ${vectors.length}`);
+  }
+  return vectors;
+};
+
 /**
  * Embed a batch of texts.
  * @param env - Worker bindings.
@@ -21,13 +46,9 @@ export const embed = async (
   env: Env,
   texts: readonly string[],
 ): Promise<readonly (readonly number[])[]> => {
-  if (texts.length === 0) return [];
-  const res = (await env.AI.run(EMBEDDING_MODEL, {
-    text: [...texts],
-  })) as EmbeddingResponse;
-  const vectors = res.data ?? [];
-  if (vectors.length !== texts.length) {
-    throw new Error(`embedding: asked for ${texts.length} vectors, got ${vectors.length}`);
+  const out: (readonly number[])[] = [];
+  for (let at = 0; at < texts.length; at += BATCH) {
+    out.push(...(await runBatch(env, texts.slice(at, at + BATCH))));
   }
-  return vectors;
+  return out;
 };

--- a/src/worker/env.ts
+++ b/src/worker/env.ts
@@ -1,0 +1,36 @@
+import type { Ai, Fetcher, RateLimit, Vectorize } from '@cloudflare/workers-types';
+
+/** Bindings this Worker runs on. See `wrangler.jsonc`. */
+export interface Env {
+  /** The static site. Everything that is not `/api/*` is served from here. */
+  readonly ASSETS: Fetcher;
+  readonly AI: Ai;
+  /*
+   * `Vectorize`, not `VectorizeIndex`: the latter is the beta class, whose
+   * mutations were synchronous. The index here is a v2 one.
+   */
+  readonly VECTORIZE: Vectorize;
+  readonly SEMANTIC_LIMIT: RateLimit;
+  /** Shared with the CI job that rebuilds the vectors after a deploy. */
+  readonly REINDEX_SECRET?: string;
+}
+
+/**
+ * The embedding model.
+ *
+ * Multilingual on purpose, and in ONE vector space: the site publishes the
+ * same argument in Russian, English, Italian and Spanish, and a reader who
+ * asks in one language should be able to reach it in another. A per-language
+ * model would make that impossible by construction.
+ */
+export const EMBEDDING_MODEL = '@cf/baai/bge-m3';
+
+/** Reply as JSON, with no cache — an answer is per-query. */
+export const json = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'no-store',
+    },
+  });

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,0 +1,28 @@
+import type { Env } from './env';
+import { handleReindex } from './reindex';
+import { handleSemantic } from './semantic';
+
+/*
+ * The site is static. This Worker exists only for the two things a static
+ * file cannot do: embed a query, and re-embed an article. Everything else
+ * falls straight through to the assets, byte for byte as before —
+ * `run_worker_first` in wrangler.jsonc limits us to `/api/*`, so no reader
+ * pays for this on any other request.
+ */
+
+const ROUTES: Record<string, (request: Request, env: Env) => Promise<Response>> = {
+  '/api/semantic': handleSemantic,
+  '/api/reindex': handleReindex,
+};
+
+export default {
+  /**
+   * @param request Incoming request.
+   * @param env Worker bindings.
+   * @returns The API answer, or the static asset.
+   */
+  fetch: async (request: Request, env: Env): Promise<Response> => {
+    const route = ROUTES[new URL(request.url).pathname];
+    return route ? route(request, env) : env.ASSETS.fetch(request);
+  },
+};

--- a/src/worker/reindex.ts
+++ b/src/worker/reindex.ts
@@ -15,17 +15,32 @@ import { type Env, json } from './env';
  * The Worker reads the index through the ASSETS binding — the same file
  * the browser downloads, from the deploy that is already live — so there
  * is no separate content pipeline to drift from what readers see.
+ *
+ * Two shapes, and the split matters:
+ *
+ *   { lang }             → PLAN: which documents are stale
+ *   { lang, docs: [id] } → INDEX exactly these, no questions asked
+ *
+ * Vectorize is eventually consistent: for a few seconds after an upsert,
+ * `getByIds` still answers with what was there before. Re-planning after
+ * every batch therefore keeps handing back documents that were just done,
+ * and the job re-embeds them in a circle. So the plan is drawn ONCE, by
+ * the caller, and the batches that follow name their documents.
  */
 
 /*
- * An article here can be 72 000 characters — about 90 passages. Two per
- * request keeps a single call well inside the Worker's limits; the caller
- * loops until `remaining` reaches zero.
+ * An article here can be 72 000 characters — about 90 passages, five model
+ * calls. Two documents a request keeps a single call well inside the
+ * Worker's budget; the caller walks the plan.
  */
-const DOCS_PER_CALL = 2;
+const MAX_DOCS_PER_CALL = 2;
+
+/* Vectorize takes at most 100 ids in one lookup. */
+const LOOKUP_LIMIT = 100;
 
 interface Body {
   readonly lang?: unknown;
+  readonly docs?: unknown;
 }
 
 const chunkId = (docId: string, at: number): string => `${docId}#${at}`;
@@ -40,18 +55,28 @@ interface Head {
   readonly chunks: number;
 }
 
-const headOf = async (env: Env, docId: string): Promise<Head | undefined> => {
-  const found = await env.VECTORIZE.getByIds([chunkId(docId, 0)]);
-  const { hash, chunks } = (found.at(0)?.metadata ?? {}) as Partial<Record<keyof Head, unknown>>;
-  if (typeof hash !== 'string' || typeof chunks !== 'number') return undefined;
-  return { hash, chunks };
+const headsOf = async (
+  env: Env,
+  docs: readonly SearchDoc[],
+): Promise<ReadonlyMap<string, Head>> => {
+  const found = new Map<string, Head>();
+  for (let at = 0; at < docs.length; at += LOOKUP_LIMIT) {
+    const batch = docs.slice(at, at + LOOKUP_LIMIT);
+    const vectors = await env.VECTORIZE.getByIds(batch.map((doc) => chunkId(doc.id, 0)));
+    for (const vector of vectors) {
+      const { hash, chunks } = (vector.metadata ?? {}) as Partial<Record<keyof Head, unknown>>;
+      if (typeof hash === 'string' && typeof chunks === 'number') {
+        found.set(vector.id, { hash, chunks });
+      }
+    }
+  }
+  return found;
 };
 
-const indexDoc = async (env: Env, doc: SearchDoc): Promise<void> => {
-  const head = await headOf(env, doc.id);
-  if (head !== undefined && head.hash === doc.hash) return;
-
+const indexDoc = async (env: Env, doc: SearchDoc, head?: Head): Promise<void> => {
   const chunks = chunkBody(doc.body);
+  if (chunks.length === 0) return;
+
   /*
    * The title and description carry the article's subject more plainly
    * than any single paragraph does — prepend them to the first passage so
@@ -93,15 +118,40 @@ const loadIndex = async (env: Env, lang: string): Promise<readonly SearchDoc[]> 
   return body.docs ?? [];
 };
 
+const wanted = (body: Body): readonly string[] | undefined =>
+  Array.isArray(body.docs)
+    ? body.docs.filter((id): id is string => typeof id === 'string')
+    : undefined;
+
+const plan = async (env: Env, lang: string, docs: readonly SearchDoc[]): Promise<Response> => {
+  const heads = await headsOf(env, docs);
+  const stale = docs
+    .filter((doc) => heads.get(chunkId(doc.id, 0))?.hash !== doc.hash)
+    .map((doc) => doc.id);
+  return json({ lang, total: docs.length, stale });
+};
+
+const indexBatch = async (
+  env: Env,
+  lang: string,
+  docs: readonly SearchDoc[],
+  ids: readonly string[],
+): Promise<Response> => {
+  const batch = docs.filter((doc) => ids.includes(doc.id)).slice(0, MAX_DOCS_PER_CALL);
+  const heads = await headsOf(env, batch);
+  for (const doc of batch) {
+    await indexDoc(env, doc, heads.get(chunkId(doc.id, 0)));
+  }
+  return json({ lang, indexed: batch.map((doc) => doc.id) });
+};
+
 /**
- * `POST /api/reindex` — re-embed the documents whose content changed.
+ * `POST /api/reindex` — plan, or re-embed a named batch.
  *
- * Guarded by a shared secret and driven by CI after a deploy. Processes a
- * bounded batch and reports what is left, so the caller loops rather than
- * asking one request to embed the whole site.
+ * Guarded by a shared secret and driven by CI after a deploy.
  * @param request Incoming request.
  * @param env Worker bindings.
- * @returns How many documents were re-embedded, and how many remain.
+ * @returns The stale list, or what this call embedded.
  */
 export const handleReindex = async (request: Request, env: Env): Promise<Response> => {
   if (request.method !== 'POST') return json({ error: 'method' }, 405);
@@ -110,25 +160,11 @@ export const handleReindex = async (request: Request, env: Env): Promise<Respons
     return json({ error: 'forbidden' }, 403);
   }
 
-  const body = (await request.json().catch(() => undefined)) as Body | undefined;
-  const lang = typeof body?.lang === 'string' ? body.lang : '';
+  const body = ((await request.json().catch(() => undefined)) ?? {}) as Body;
+  const lang = typeof body.lang === 'string' ? body.lang : '';
   if (lang === '') return json({ error: 'lang' }, 400);
 
   const docs = await loadIndex(env, lang);
-
-  const stale: SearchDoc[] = [];
-  for (const doc of docs) {
-    const head = await headOf(env, doc.id);
-    if (head === undefined || head.hash !== doc.hash) stale.push(doc);
-  }
-
-  const batch = stale.slice(0, DOCS_PER_CALL);
-  for (const doc of batch) await indexDoc(env, doc);
-
-  return json({
-    lang,
-    total: docs.length,
-    indexed: batch.length,
-    remaining: stale.length - batch.length,
-  });
+  const ids = wanted(body);
+  return ids === undefined ? plan(env, lang, docs) : indexBatch(env, lang, docs, ids);
 };

--- a/src/worker/reindex.ts
+++ b/src/worker/reindex.ts
@@ -1,0 +1,134 @@
+import type { SearchDoc } from '@prometheus/search-core';
+import { chunkBody } from '@prometheus/search-core';
+import { embed } from './embed';
+import { type Env, json } from './env';
+
+/*
+ * Rebuild the vectors — but only for what actually changed.
+ *
+ * Every document in the index carries a content hash. Chunk 0 of a
+ * document keeps that hash in its metadata, so the vector store itself
+ * remembers what it was built from: no second database, no bookkeeping to
+ * fall out of sync. A publish that touches one article re-embeds one
+ * article, not the site.
+ *
+ * The Worker reads the index through the ASSETS binding — the same file
+ * the browser downloads, from the deploy that is already live — so there
+ * is no separate content pipeline to drift from what readers see.
+ */
+
+/*
+ * An article here can be 72 000 characters — about 90 passages. Two per
+ * request keeps a single call well inside the Worker's limits; the caller
+ * loops until `remaining` reaches zero.
+ */
+const DOCS_PER_CALL = 2;
+
+interface Body {
+  readonly lang?: unknown;
+}
+
+const chunkId = (docId: string, at: number): string => `${docId}#${at}`;
+
+/*
+ * Chunk 0 carries the hash AND the chunk count, so a document that shrank
+ * can have its leftovers deleted before the new ones go in. Without the
+ * count, stale passages would linger and keep matching.
+ */
+interface Head {
+  readonly hash: string;
+  readonly chunks: number;
+}
+
+const headOf = async (env: Env, docId: string): Promise<Head | undefined> => {
+  const found = await env.VECTORIZE.getByIds([chunkId(docId, 0)]);
+  const { hash, chunks } = (found.at(0)?.metadata ?? {}) as Partial<Record<keyof Head, unknown>>;
+  if (typeof hash !== 'string' || typeof chunks !== 'number') return undefined;
+  return { hash, chunks };
+};
+
+const indexDoc = async (env: Env, doc: SearchDoc): Promise<void> => {
+  const head = await headOf(env, doc.id);
+  if (head !== undefined && head.hash === doc.hash) return;
+
+  const chunks = chunkBody(doc.body);
+  /*
+   * The title and description carry the article's subject more plainly
+   * than any single paragraph does — prepend them to the first passage so
+   * a query about the subject can land on it.
+   */
+  const texts = chunks.map((chunk, at) =>
+    at === 0 ? `${doc.title}. ${doc.description} ${chunk.text}` : chunk.text,
+  );
+  const vectors = await embed(env, texts);
+
+  if (head !== undefined && head.chunks > chunks.length) {
+    const stale = Array.from({ length: head.chunks - chunks.length }, (_, i) =>
+      chunkId(doc.id, chunks.length + i),
+    );
+    await env.VECTORIZE.deleteByIds(stale);
+  }
+
+  await env.VECTORIZE.upsert(
+    chunks.map((chunk, at) => ({
+      id: chunkId(doc.id, at),
+      values: [...(vectors[at] ?? [])],
+      metadata: {
+        doc: doc.id,
+        lang: doc.lang,
+        start: chunk.start,
+        end: chunk.end,
+        ...(at === 0 ? { hash: doc.hash, chunks: chunks.length } : {}),
+      },
+    })),
+  );
+};
+
+const loadIndex = async (env: Env, lang: string): Promise<readonly SearchDoc[]> => {
+  const res = await env.ASSETS.fetch(
+    new Request(`https://assets.invalid/${lang}/search-index.json`),
+  );
+  if (!res.ok) return [];
+  const body = (await res.json()) as { docs?: readonly SearchDoc[] };
+  return body.docs ?? [];
+};
+
+/**
+ * `POST /api/reindex` — re-embed the documents whose content changed.
+ *
+ * Guarded by a shared secret and driven by CI after a deploy. Processes a
+ * bounded batch and reports what is left, so the caller loops rather than
+ * asking one request to embed the whole site.
+ * @param request Incoming request.
+ * @param env Worker bindings.
+ * @returns How many documents were re-embedded, and how many remain.
+ */
+export const handleReindex = async (request: Request, env: Env): Promise<Response> => {
+  if (request.method !== 'POST') return json({ error: 'method' }, 405);
+  const secret = env.REINDEX_SECRET;
+  if (!secret || request.headers.get('X-Reindex-Key') !== secret) {
+    return json({ error: 'forbidden' }, 403);
+  }
+
+  const body = (await request.json().catch(() => undefined)) as Body | undefined;
+  const lang = typeof body?.lang === 'string' ? body.lang : '';
+  if (lang === '') return json({ error: 'lang' }, 400);
+
+  const docs = await loadIndex(env, lang);
+
+  const stale: SearchDoc[] = [];
+  for (const doc of docs) {
+    const head = await headOf(env, doc.id);
+    if (head === undefined || head.hash !== doc.hash) stale.push(doc);
+  }
+
+  const batch = stale.slice(0, DOCS_PER_CALL);
+  for (const doc of batch) await indexDoc(env, doc);
+
+  return json({
+    lang,
+    total: docs.length,
+    indexed: batch.length,
+    remaining: stale.length - batch.length,
+  });
+};

--- a/src/worker/reindex.ts
+++ b/src/worker/reindex.ts
@@ -1,4 +1,4 @@
-import type { SearchDoc } from '@prometheus/search-core';
+import type { Chunk, SearchDoc } from '@prometheus/search-core';
 import { chunkBody } from '@prometheus/search-core';
 import { embed } from './embed';
 import { type Env, json } from './env';
@@ -73,8 +73,22 @@ const headsOf = async (
   return found;
 };
 
-const indexDoc = async (env: Env, doc: SearchDoc, head?: Head): Promise<void> => {
+/*
+ * A magazine issue is a cover, a title and a blurb — its body is empty.
+ * Skipping it would leave it forever unindexed AND forever "stale", since
+ * the hash lives in chunk 0 and there would be no chunk 0 to hold it: it
+ * would be re-planned on every deploy, for ever, and never done. It also
+ * has a subject a reader can ask for. One passage, from what it does have.
+ */
+const passagesOf = (doc: SearchDoc): readonly Chunk[] => {
   const chunks = chunkBody(doc.body);
+  if (chunks.length > 0) return chunks;
+  const text = `${doc.title}. ${doc.description}`.trim();
+  return text === '' ? [] : [{ text, start: 0, end: 0 }];
+};
+
+const indexDoc = async (env: Env, doc: SearchDoc, head?: Head): Promise<void> => {
+  const chunks = passagesOf(doc);
   if (chunks.length === 0) return;
 
   /*

--- a/src/worker/semantic.ts
+++ b/src/worker/semantic.ts
@@ -1,0 +1,93 @@
+import type { PassageMatch } from '@prometheus/search-core';
+import { bestPerDoc } from '@prometheus/search-core';
+import { embed } from './embed';
+import { type Env, json } from './env';
+
+/*
+ * Answer a semantic query.
+ *
+ * The reply carries document ids and CHARACTER OFFSETS — never text. The
+ * browser already holds the whole index, so it can render the title, the
+ * URL and the quoted passage itself. That is what keeps this endpoint
+ * cheap: a query goes out, a handful of coordinates come back.
+ *
+ * The browser also drops any id it does not know. That is not defensive
+ * padding — it is how a deleted article stops appearing: the vector store
+ * cannot be enumerated cheaply, so the client, which knows exactly what
+ * exists, is the authority on what may be shown.
+ */
+
+/*
+ * Long enough for a real question, short enough that nobody can post an
+ * article body and make us embed it.
+ */
+const MAX_QUERY = 200;
+
+/*
+ * Passages, not documents: one article can own many, so ask for plenty
+ * and let `bestPerDoc` collapse them.
+ */
+const TOP_PASSAGES = 40;
+const TOP_DOCS = 10;
+
+interface Body {
+  readonly q?: unknown;
+  readonly lang?: unknown;
+}
+
+/** What we wrote into a vector's metadata at index time — as it comes back. */
+interface VectorMetadata {
+  readonly doc?: unknown;
+  readonly start?: unknown;
+  readonly end?: unknown;
+}
+
+interface VectorMatch {
+  readonly score: number;
+  readonly metadata?: VectorMetadata | undefined;
+}
+
+const asPassage = (match: VectorMatch): readonly PassageMatch[] => {
+  const { doc, start, end } = match.metadata ?? {};
+  if (typeof doc !== 'string') return [];
+  return [
+    {
+      doc,
+      score: match.score,
+      start: typeof start === 'number' ? start : 0,
+      end: typeof end === 'number' ? end : 0,
+    },
+  ];
+};
+
+/**
+ * `POST /api/semantic` — find articles by meaning.
+ * @param request Incoming request.
+ * @param env Worker bindings.
+ * @returns Document ids, scores and passage offsets.
+ */
+export const handleSemantic = async (request: Request, env: Env): Promise<Response> => {
+  if (request.method !== 'POST') return json({ error: 'method' }, 405);
+
+  const ip = request.headers.get('CF-Connecting-IP') ?? 'anonymous';
+  const { success } = await env.SEMANTIC_LIMIT.limit({ key: ip });
+  if (!success) return json({ error: 'rate_limited' }, 429);
+
+  const body = (await request.json().catch(() => undefined)) as Body | undefined;
+  const q = typeof body?.q === 'string' ? body.q.trim() : '';
+  const lang = typeof body?.lang === 'string' ? body.lang : '';
+  if (q === '' || lang === '') return json({ error: 'query' }, 400);
+  if (q.length > MAX_QUERY) return json({ error: 'too_long' }, 413);
+
+  const [vector] = await embed(env, [q]);
+  if (vector === undefined) return json({ error: 'embedding' }, 502);
+
+  const result = await env.VECTORIZE.query([...vector], {
+    topK: TOP_PASSAGES,
+    filter: { lang },
+    returnMetadata: 'all',
+  });
+
+  const passages = (result.matches ?? []).flatMap((m) => asPassage(m as VectorMatch));
+  return json({ hits: bestPerDoc(passages, TOP_DOCS) });
+};

--- a/src/worker/tsconfig.json
+++ b/src/worker/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "exactOptionalPropertyTypes": true,
+    "allowUnreachableCode": false,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
     ".vite-cache",
     "node_modules",
     "src/sw",
+    "src/worker",
     "src/**/*.test.ts",
     "vitest.config.ts",
     "packages"

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,8 +1,18 @@
 {
   "name": "public-website",
   "compatibility_date": "2026-03-23",
+  /*
+   * The site is still static. This Worker exists ONLY for `/api/*`:
+   * semantic search needs a model and a vector store, and neither can
+   * live in a browser. Everything else is served straight from the asset
+   * store — `run_worker_first` names the only paths that wake the Worker,
+   * so an ordinary page load never runs a line of this code.
+   */
+  "main": "src/worker/index.ts",
   "assets": {
     "directory": "./dist",
+    "binding": "ASSETS",
+    "run_worker_first": ["/api/*"],
     /*
      * Serve src/pages/404.astro (built into dist/404.html) for any
      * path that has no asset. CF preserves the requested URL — no
@@ -11,13 +21,55 @@
      */
     "not_found_handling": "404-page"
   },
+  "ai": { "binding": "AI" },
+  "vectorize": [{ "binding": "VECTORIZE", "index_name": "comprom-search" }],
+  /*
+   * A public endpoint that runs a model costs money every time it is
+   * called. The limit is per client IP: a reader who means it will never
+   * notice, a script will.
+   */
+  "unsafe": {
+    "bindings": [
+      {
+        "name": "SEMANTIC_LIMIT",
+        "type": "ratelimit",
+        "namespace_id": "1001",
+        "simple": { "limit": 30, "period": 60 }
+      }
+    ]
+  },
   "env": {
     // Develop environment — deploys from the `develop` branch into a
     // separate CF Worker (public-website-develop) and binds it to
     // dev.comprom.org via the Custom Domain route below.
     "develop": {
       "name": "public-website-develop",
-      "routes": [{ "pattern": "dev.comprom.org", "custom_domain": true }]
+      "routes": [{ "pattern": "dev.comprom.org", "custom_domain": true }],
+      /* Named envs inherit NOTHING from the top level — repeat it all. */
+      "assets": {
+        "directory": "./dist",
+        "binding": "ASSETS",
+        "run_worker_first": ["/api/*"],
+        "not_found_handling": "404-page"
+      },
+      "ai": { "binding": "AI" },
+      /*
+       * Its OWN index. Dev builds from content/develop, prod from
+       * content/master, and a document keeps the same id in both — one
+       * shared index would mean whichever deploy reindexed last decided
+       * what prod readers get back, drafts included.
+       */
+      "vectorize": [{ "binding": "VECTORIZE", "index_name": "comprom-search-develop" }],
+      "unsafe": {
+        "bindings": [
+          {
+            "name": "SEMANTIC_LIMIT",
+            "type": "ratelimit",
+            "namespace_id": "1001",
+            "simple": { "limit": 30, "period": 60 }
+          }
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
Поиск по смыслу: кнопка «Искать по смыслу» на странице результатов, Worker на Cloudflare (`@cf/baai/bge-m3` + Vectorize), инкрементальная переиндексация после каждого деплоя.

Проверено на dev:
- запрос «машины, которые думают за человека» — слов нет ни в одной статье — находит все четыре статьи про ИИ;
- русский запрос достаёт английские статьи (модель многоязычная, один вектор-спейс);
- переиндексация инкрементальна: обычный деплой трогает ровно то, что изменилось, и проверяет, что записи действительно легли.

Первый деплой в прод заэмбеддит весь корпус (индекс `comprom-search` пуст) — это несколько минут, дальше только изменившееся.

🤖 Generated with [Claude Code](https://claude.com/claude-code)