### PR TITLE
fix(worker): promote reindex 20-id cap + deploy/reindex decoupling to master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,18 @@ name: Deploy to Cloudflare Workers
 on:
   push:
     branches: [master, develop]
+  # A content update in `public-website-content` triggers a deploy of the
+  # matching branch through this dispatch — NOT by pushing an empty commit
+  # into this repo. That keeps the code branches free of content-driven
+  # commits, so a `develop → master` PR here is a review of code alone.
+  # `content: true` marks such a redeploy so the E2E gate is skipped (a
+  # content-only change can't move code-shaped assertions).
+  workflow_dispatch:
+    inputs:
+      content:
+        description: Content redeploy (skip the E2E gate)
+        type: boolean
+        default: false
 
 # Serialise deploys per ref. When a new commit arrives while an older
 # deploy is still building, cancel the in-flight one — its image would
@@ -62,11 +74,11 @@ jobs:
       # apply there. Skip E2E on develop deploys; master deploys still
       # gate on green E2E.
       - name: Installing Playwright browsers
-        if: ${{ github.ref_name == 'master' && !startsWith(github.event.head_commit.message, 'content:') }}
+        if: ${{ github.ref_name == 'master' && github.event.inputs.content != 'true' }}
         run: bunx playwright install --with-deps chromium
 
       - name: Running E2E tests (chromium, skip lighthouse/mobile)
-        if: ${{ github.ref_name == 'master' && !startsWith(github.event.head_commit.message, 'content:') }}
+        if: ${{ github.ref_name == 'master' && github.event.inputs.content != 'true' }}
         run: bunx playwright test --project=chromium --reporter=line
 
       # The build above (and the e2e it feeds) keep the archive section
@@ -99,7 +111,15 @@ jobs:
       # It runs after the deploy because the Worker indexes what the
       # deploy is actually serving — it reads the index through its own
       # ASSETS binding.
+      #
+      # `continue-on-error`: the deploy above IS the publication — the site
+      # is already live. Re-embedding is a follow-on that keeps semantic
+      # search fresh; if it fails the article is still published, so it must
+      # NOT turn the run red. A failed step stays visible (and now returns a
+      # diagnosable JSON error via the Worker's top-level guard) without
+      # conflating "published" with "indexed".
       - name: Re-embedding changed articles
+        continue-on-error: true
         run: bun scripts/reindex.ts --base "$SITE_BASE"
         env:
           REINDEX_SECRET: ${{ secrets.REINDEX_SECRET }}

--- a/.github/workflows/redeploy-on-content.yml
+++ b/.github/workflows/redeploy-on-content.yml
@@ -1,28 +1,31 @@
 name: Redeploy on content update
 
-# Replaces the old subtree-pull workflow. Content is no longer
-# committed into this repo; instead the deploy build clones it from
-# `public-website-content`. So the only thing we need on a content
-# push is to kick off a fresh deploy of the matching branch — we do
-# that with an empty commit on the corresponding branch, which then
-# triggers `Deploy to Cloudflare Workers` via the regular push event.
+# Content is not committed into this repo; the deploy build clones it from
+# `public-website-content`. On a content push we only need to kick off a
+# fresh deploy of the matching branch.
 #
-# Branch mapping is symmetric: a push to `master` of the content repo
-# redeploys `master` here; a push to `develop`/`dev` redeploys the
-# matching branch. The branch comes from the dispatch payload.
+# We do that by DISPATCHING `Deploy to Cloudflare Workers` on that branch —
+# not by pushing an empty commit here. Empty commits polluted the code
+# branches with content-driven history, so a `develop → master` PR carried
+# content churn instead of being a review of code alone. A dispatch leaves
+# the code branches untouched.
+#
+# Branch mapping is symmetric: a content push to `master` redeploys
+# `master` here; a push to `develop` redeploys `develop`. The branch comes
+# from the dispatch payload.
 
 on:
   repository_dispatch:
     types: [content-updated]
 
 # Serialise per branch so two content pushes in quick succession queue
-# behind one another instead of producing competing empty commits.
+# behind one another instead of racing to dispatch the same branch.
 concurrency:
   group: redeploy-${{ github.event.client_payload.branch }}
   cancel-in-progress: false
 
-# Least-privilege GITHUB_TOKEN - deploys use dedicated secrets,
-# nothing here needs repo write access via the ambient token.
+# No repo write needed — the dispatch is an Actions API call authenticated
+# by GH_PAT, which carries the `workflow` scope.
 permissions:
   contents: read
 
@@ -30,23 +33,12 @@ jobs:
   redeploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          ref: ${{ github.event.client_payload.branch }}
-          token: ${{ secrets.GH_PAT }}
-
-      - name: Configure git author from content commit
+      - name: Dispatch a deploy of the matching branch
         env:
-          AUTHOR_NAME: ${{ github.event.client_payload.author_name }}
-          AUTHOR_EMAIL: ${{ github.event.client_payload.author_email }}
-        run: |
-          git config user.name "$AUTHOR_NAME"
-          git config user.email "$AUTHOR_EMAIL"
-
-      - name: Empty commit to trigger deploy
-        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
           BRANCH: ${{ github.event.client_payload.branch }}
-          MSG: ${{ github.event.client_payload.commit_message }}
         run: |
-          git commit --allow-empty -m "content: $MSG"
-          git push origin "$BRANCH"
+          gh workflow run deploy.yml \
+            --repo "${{ github.repository }}" \
+            --ref "$BRANCH" \
+            -f content=true

--- a/src/worker/guard.test.ts
+++ b/src/worker/guard.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import type { Env } from './env';
+import { guardErrors } from './guard';
+
+const env = {} as unknown as Env;
+const request = new Request('https://dev.comprom.org/api/reindex', { method: 'POST' });
+
+describe('guardErrors', () => {
+  it('passes a successful response straight through', async () => {
+    const ok = new Response('{"ok":true}', { status: 200 });
+    const guarded = guardErrors(async () => ok);
+    expect(await guarded(request, env)).toBe(ok);
+  });
+
+  it('turns a thrown Error into a JSON 500 carrying its message', async () => {
+    const guarded = guardErrors(async () => {
+      throw new Error('VECTORIZE.getByIds failed');
+    });
+    const res = await guarded(request, env);
+    expect(res.status).toBe(500);
+    expect(res.headers.get('Content-Type')).toContain('application/json');
+    expect(await res.json()).toEqual({ error: 'VECTORIZE.getByIds failed' });
+  });
+
+  it('coerces a non-Error throw to a string message', async () => {
+    const guarded = guardErrors(async () => {
+      throw 'boom';
+    });
+    const res = await guarded(request, env);
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'boom' });
+  });
+});

--- a/src/worker/guard.ts
+++ b/src/worker/guard.ts
@@ -1,0 +1,27 @@
+import { type Env, json } from './env';
+
+type Handler = (request: Request, env: Env) => Promise<Response>;
+
+/**
+ * Wrap an `/api/*` handler so a thrown exception becomes a JSON 500
+ * carrying the real message, instead of the Workers runtime's opaque
+ * `1101` HTML error page.
+ *
+ * Without this, a throw inside a handler — e.g. `VECTORIZE.getByIds`
+ * rejecting during a reindex plan — reaches the edge uncaught and the
+ * caller sees only `<!DOCTYPE html> … error code: 1101`. The reindex CI
+ * job then fails with a status it cannot diagnose. A JSON body lets the
+ * job (and the logs) name the cause.
+ * @param handler The route handler to protect.
+ * @returns A handler that never rejects: it answers 500 + `{ error }`.
+ */
+export const guardErrors =
+  (handler: Handler): Handler =>
+  async (request, env) => {
+    try {
+      return await handler(request, env);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return json({ error }, 500);
+    }
+  };

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,4 +1,5 @@
 import type { Env } from './env';
+import { guardErrors } from './guard';
 import { handleReindex } from './reindex';
 import { handleSemantic } from './semantic';
 
@@ -11,8 +12,8 @@ import { handleSemantic } from './semantic';
  */
 
 const ROUTES: Record<string, (request: Request, env: Env) => Promise<Response>> = {
-  '/api/semantic': handleSemantic,
-  '/api/reindex': handleReindex,
+  '/api/semantic': guardErrors(handleSemantic),
+  '/api/reindex': guardErrors(handleReindex),
 };
 
 export default {

--- a/src/worker/reindex.test.ts
+++ b/src/worker/reindex.test.ts
@@ -1,0 +1,77 @@
+import type { SearchDoc } from '@prometheus/search-core';
+import { describe, expect, it } from 'vitest';
+import type { Env } from './env';
+import { handleReindex } from './reindex';
+
+const SECRET = 'test-reindex-secret';
+
+const doc = (n: number): SearchDoc => ({
+  id: `ru/blog/article-${n}`,
+  lang: 'ru',
+  section: 'blog',
+  slug: `article-${n}`,
+  url: `https://comprom.org/ru/blog/article-${n}`,
+  title: `Title ${n}`,
+  description: `Description ${n}`,
+  body: `Body ${n}`,
+  hash: `hash-${n}`,
+});
+
+/** An ASSETS stub that serves the search index for the requested language. */
+const assetsServing = (docs: readonly SearchDoc[]): Env['ASSETS'] =>
+  ({
+    fetch: async (): Promise<Response> => new Response(JSON.stringify({ docs }), { status: 200 }),
+  }) as unknown as Env['ASSETS'];
+
+/*
+ * A Vectorize stub enforcing the real `getByIds` cap: the live index
+ * answers more than 20 ids with HTTP 400, code 40007. Recording each
+ * call's size lets a test prove the lookup was split under the cap.
+ */
+const vectorizeCappedAt20 = (sizes: number[]): Env['VECTORIZE'] =>
+  ({
+    getByIds: async (ids: readonly string[]): Promise<readonly never[]> => {
+      sizes.push(ids.length);
+      if (ids.length > 20) {
+        throw new Error(`too many ids in payload; max id count is 20, got ${ids.length}`);
+      }
+      return [];
+    },
+  }) as unknown as Env['VECTORIZE'];
+
+const planRequest = (): Request =>
+  new Request('https://dev.comprom.org/api/reindex', {
+    method: 'POST',
+    headers: { 'X-Reindex-Key': SECRET, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ lang: 'ru' }),
+  });
+
+const envWith = (docs: readonly SearchDoc[], sizes: number[]): Env =>
+  ({
+    REINDEX_SECRET: SECRET,
+    ASSETS: assetsServing(docs),
+    VECTORIZE: vectorizeCappedAt20(sizes),
+  }) as unknown as Env;
+
+describe('handleReindex — plan lookup batching', () => {
+  it('splits the id lookup so no call exceeds the 20-id cap (ru has 22)', async () => {
+    const sizes: number[] = [];
+    const docs = Array.from({ length: 22 }, (_, i) => doc(i));
+
+    const res = await handleReindex(planRequest(), envWith(docs, sizes));
+
+    expect(res.status).toBe(200);
+    expect(sizes).toEqual([20, 2]);
+    expect(Math.max(...sizes)).toBeLessThanOrEqual(20);
+  });
+
+  it('plans every document as stale when the index holds no heads', async () => {
+    const sizes: number[] = [];
+    const docs = Array.from({ length: 22 }, (_, i) => doc(i));
+
+    const res = await handleReindex(planRequest(), envWith(docs, sizes));
+    const body = (await res.json()) as { stale: readonly string[] };
+
+    expect(body.stale).toHaveLength(22);
+  });
+});

--- a/src/worker/reindex.ts
+++ b/src/worker/reindex.ts
@@ -35,8 +35,15 @@ import { type Env, json } from './env';
  */
 const MAX_DOCS_PER_CALL = 2;
 
-/* Vectorize takes at most 100 ids in one lookup. */
-const LOOKUP_LIMIT = 100;
+/*
+ * Vectorize caps `getByIds` at 20 ids per call (HTTP 400, code 40007:
+ * "too many ids in payload; max id count is 20") — a hard limit the
+ * published limits table omits. `plan` looks up every document of a
+ * language at once, so a language with 21+ articles (ru: 22) blew past
+ * the cap and the uncaught 400 surfaced as a Cloudflare 1101. Batch at
+ * the cap so no single lookup can exceed it.
+ */
+const LOOKUP_LIMIT = 20;
 
 interface Body {
   readonly lang?: unknown;


### PR DESCRIPTION
Promotes the develop fixes to production `master`. **Code-only** diff (worker src + CI workflows + tests) — no content.

## Why
Production `master` still runs the old worker (`LOOKUP_LIMIT=100`): every content publish deterministically fails the post-deploy re-embed on `ru` (24 articles > Vectorize's undocumented 20-id `getByIds` cap → HTTP 400/40007 → CF 1101 → red run). Verified live on develop that the fix resolves it (`ru: 4 stale of 24`, plan passes).

## What promotes
- `src/worker/reindex.ts` — `LOOKUP_LIMIT` 100→20 so no `getByIds` lookup exceeds the cap (+ regression test).
- `src/worker/guard.ts` — top-level try/catch → uncaught handler throw returns a JSON 500 `{error}` instead of an opaque 1101 HTML page (makes the remaining intermittent embed-500s diagnosable).
- `.github/workflows/deploy.yml` — `workflow_dispatch` for content redeploys; reindex step `continue-on-error` so a flaky re-embed no longer reds a successful publish.
- `.github/workflows/redeploy-on-content.yml` — dispatch instead of empty commits (keeps code branches code-only).

## Known follow-up (not this PR's regression)
Intermittent `500` during the *embed* step on large `ru` docs (AI model), currently absorbed by reindex retries + `continue-on-error`. Separate from the deterministic plan-500 fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)