### PR TITLE
topics: short card tag + long banner disclaimer, contrast fix

### DIFF
--- a/src/features/blog/components/PostCard.astro
+++ b/src/features/blog/components/PostCard.astro
@@ -159,7 +159,12 @@ const cardStyle = resolvedTopic ? `--topic-color: ${resolvedTopic.color}` : unde
     display: inline-block;
     padding: 0.15rem 0.55rem;
     background: color-mix(in srgb, var(--topic-color) 15%, transparent);
-    color: var(--topic-color);
+    /*
+     * Blend the label toward the theme text so it clears contrast against
+     * its own tinted pill (plain topic-colour text on a same-hue tint was
+     * unreadable — e.g. blue on light blue).
+     */
+    color: color-mix(in srgb, var(--topic-color) 60%, var(--color-text-primary));
     border: 1px solid var(--topic-color);
     font-size: 0.7rem;
     font-weight: 600;

--- a/src/features/content/helpers/topic-resolve.test.ts
+++ b/src/features/content/helpers/topic-resolve.test.ts
@@ -8,7 +8,13 @@ const topics: readonly TopicEntry[] = [
     name: { en: 'Editorial', ru: 'От редакции' },
     subtitle: { en: 'The board position', ru: 'Позиция редакции' },
   },
-  { key: 'translation', color: '#2563eb', name: { en: 'Translation' }, subtitle: {} },
+  {
+    key: 'translation',
+    color: '#2563eb',
+    name: { en: 'Translation' },
+    subtitle: { en: 'Translation' },
+    description: { en: 'A long editorial disclaimer about translations.' },
+  },
 ];
 
 describe('resolveTopic', () => {
@@ -21,23 +27,27 @@ describe('resolveTopic', () => {
     expect(resolveTopic(topics, 'does-not-exist', 'ru', 'en')).toBeUndefined();
   });
 
-  it('resolves a known key to its colour and localized text', () => {
-    expect(resolveTopic(topics, 'editorial', 'ru', 'en')).toEqual({
-      key: 'editorial',
-      color: '#b03a2e',
-      name: 'От редакции',
-      subtitle: 'Позиция редакции',
-    });
+  it('resolves colour, name and short subtitle', () => {
+    const topic = resolveTopic(topics, 'editorial', 'ru', 'en');
+    expect(topic?.color).toBe('#b03a2e');
+    expect(topic?.name).toBe('От редакции');
+    expect(topic?.subtitle).toBe('Позиция редакции');
   });
 
-  it('falls back to the default language when the locale is missing', () => {
+  it('uses the long description for the banner when present', () => {
+    const topic = resolveTopic(topics, 'translation', 'en', 'en');
+    expect(topic?.subtitle).toBe('Translation');
+    expect(topic?.description).toBe('A long editorial disclaimer about translations.');
+  });
+
+  it('falls back description to the subtitle when there is no description', () => {
+    const topic = resolveTopic(topics, 'editorial', 'ru', 'en');
+    expect(topic?.description).toBe('Позиция редакции');
+  });
+
+  it('falls back to the default language then the key/empty string', () => {
     const topic = resolveTopic(topics, 'translation', 'it', 'en');
     expect(topic?.name).toBe('Translation');
-  });
-
-  it('falls back to the key for a name and empty string for a subtitle', () => {
-    const topic = resolveTopic(topics, 'translation', 'xx', 'zz');
-    expect(topic?.name).toBe('translation');
-    expect(topic?.subtitle).toBe('');
+    expect(topic?.description).toBe('A long editorial disclaimer about translations.');
   });
 });

--- a/src/features/content/helpers/topic-resolve.ts
+++ b/src/features/content/helpers/topic-resolve.ts
@@ -4,6 +4,8 @@ export interface TopicEntry {
   readonly color: string;
   readonly name: Record<string, string>;
   readonly subtitle: Record<string, string>;
+  /** Optional long disclaimer shown only on the article banner. */
+  readonly description?: Record<string, string>;
 }
 
 /** A topic resolved for one page language, ready to render. */
@@ -11,7 +13,10 @@ export interface ResolvedTopic {
   readonly key: string;
   readonly color: string;
   readonly name: string;
+  /** Short приписка — the listing card tag. */
   readonly subtitle: string;
+  /** Long disclaimer for the article banner; falls back to the subtitle. */
+  readonly description: string;
 }
 
 const localize = (
@@ -22,9 +27,10 @@ const localize = (
 ): string => dict[lang] ?? dict[defaultLang] ?? fallback;
 
 /**
- * Resolve a topic key against a topic set to its colour + localized name
- * and subtitle. Pure and content-free so it unit-tests without the
- * content repo present: the data and default language are injected.
+ * Resolve a topic key against a topic set to its colour, short subtitle
+ * (the card tag) and long description (the article banner disclaimer,
+ * which falls back to the subtitle when absent). Pure and content-free so
+ * it unit-tests without the content repo present.
  *
  * Tolerant by design — an absent or unknown key yields `undefined` (no
  * marker), and a missing locale falls back to the default language, then
@@ -45,10 +51,14 @@ export const resolveTopic = (
   if (!key) return undefined;
   const entry = topics.find((t) => t.key === key);
   if (!entry) return undefined;
+  const subtitle = localize(entry.subtitle, lang, defaultLang, '');
   return {
     key: entry.key,
     color: entry.color,
     name: localize(entry.name, lang, defaultLang, entry.key),
-    subtitle: localize(entry.subtitle, lang, defaultLang, ''),
+    subtitle,
+    description: entry.description
+      ? localize(entry.description, lang, defaultLang, subtitle)
+      : subtitle,
   };
 };

--- a/src/pages/[lang]/blog/[...slug].astro
+++ b/src/pages/[lang]/blog/[...slug].astro
@@ -152,7 +152,7 @@ const magazineRef = await (async () => {
           {topic && (
             <aside class="topic-banner" style={`--topic-color: ${topic.color}`} data-topic={topic.key}>
               <span class="topic-name">{topic.name}</span>
-              {topic.subtitle && <span class="topic-subtitle">{topic.subtitle}</span>}
+              {topic.description && <span class="topic-subtitle">{topic.description}</span>}
             </aside>
           )}
           <span class="category">{getCategoryLabel(post.data.category, lang)}</span>
@@ -247,30 +247,46 @@ const magazineRef = await (async () => {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: var(--spacing-2xs, 0.25rem);
-    padding: clamp(var(--spacing-md), 4vw, var(--spacing-xl)) var(--spacing-md);
+    justify-content: center;
+    gap: var(--spacing-sm);
+    /*
+     * `padding-block` (not the 4-value `padding`) guarantees the top and
+     * bottom breathing room are the SAME length, so the name sits equally
+     * far from either edge regardless of how many lines the disclaimer
+     * wraps to.
+     */
+    padding-block: clamp(var(--spacing-lg), 4vw, var(--spacing-2xl));
+    padding-inline: var(--spacing-lg);
     margin-bottom: var(--spacing-lg);
     border-radius: var(--radius-lg);
     border-bottom: 3px solid var(--topic-color);
     background: linear-gradient(
       to bottom,
       transparent,
-      color-mix(in srgb, var(--topic-color) 20%, transparent)
+      color-mix(in srgb, var(--topic-color) 16%, transparent)
     );
   }
 
   .topic-name {
     font-size: clamp(1.5rem, 4vw, 2.25rem);
     font-weight: 800;
-    line-height: 1.1;
+    line-height: 1;
     letter-spacing: 0.02em;
     text-transform: uppercase;
-    color: var(--topic-color);
+    /*
+     * Blend the topic colour toward the theme's primary text so the name
+     * keeps its hue but stays legible on its own tinted background — pure
+     * `--topic-color` on a same-hue wash (e.g. blue on light blue) failed
+     * contrast.
+     */
+    color: color-mix(in srgb, var(--topic-color) 68%, var(--color-text-primary));
   }
 
   .topic-subtitle {
     font-size: clamp(0.9rem, 2vw, 1.05rem);
-    color: var(--color-text-secondary);
+    line-height: 1.5;
+    max-width: 60ch;
+    color: var(--color-text-primary);
   }
 
   .category {


### PR DESCRIPTION
Follow-up to the topics feature (tested on dev).

- Split the model: topics gain an optional long `description` (article banner disclaimer); the card keeps the short `subtitle` tag. `description` falls back to `subtitle`.
- Contrast: the topic name (and card tag) blend the topic colour toward the theme text so a hue like blue is legible on its own tint.
- Banner padding is symmetric (`padding-block`) so the name sits equally far from top and bottom.

Pairs with admin#<admin-pr>. Verified on dev after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)