### PR TITLE
topics: banner top gap, padding, centered title, justified disclaimer

### DIFF
--- a/src/pages/[lang]/blog/[...slug].astro
+++ b/src/pages/[lang]/blog/[...slug].astro
@@ -247,14 +247,18 @@ const magazineRef = await (async () => {
   .topic-banner {
     display: flex;
     flex-direction: column;
-    align-items: flex-start;
-    gap: var(--spacing-xs);
-    padding: var(--spacing-sm) var(--spacing-lg);
+    gap: var(--spacing-sm);
+    padding: clamp(var(--spacing-md), 3vw, var(--spacing-lg))
+      clamp(var(--spacing-md), 4vw, var(--spacing-xl));
+    /*
+     * Pull the banner up into the section's generous top padding so it
+     * sits near the header instead of floating far below it.
+     */
+    margin-top: calc(-1 * var(--spacing-xl));
     margin-bottom: var(--spacing-lg);
     border-radius: var(--radius-md);
     border-bottom: 3px solid var(--topic-color);
     background: color-mix(in srgb, var(--topic-color) 13%, transparent);
-    text-align: left;
   }
 
   .topic-name {
@@ -263,6 +267,9 @@ const magazineRef = await (async () => {
     line-height: 1;
     letter-spacing: 0.02em;
     text-transform: uppercase;
+    text-align: center;
+    /* Balance the wrapped lines of the (short) name for an even look. */
+    text-wrap: balance;
     /*
      * Blend the topic colour toward the theme's primary text so the name
      * keeps its hue but stays legible on its own tinted background — pure
@@ -276,7 +283,12 @@ const magazineRef = await (async () => {
     font-size: clamp(1.05rem, 2.2vw, 1.25rem);
     line-height: 1.6;
     max-width: 72ch;
-    text-align: left;
+    /* Justify both edges (no ragged right); hyphenate so the narrow
+       mobile column doesn't open up rivers of white space. `pretty`
+       still tidies the left-aligned last line. */
+    text-align: justify;
+    hyphens: auto;
+    text-wrap: pretty;
     color: var(--color-text-primary);
   }
 

--- a/src/pages/[lang]/blog/[...slug].astro
+++ b/src/pages/[lang]/blog/[...slug].astro
@@ -237,34 +237,24 @@ const magazineRef = await (async () => {
   }
 
   /*
-   * Editorial topic banner: a transparent→topic-colour gradient wash
-   * (the colour arrives inline as `--topic-color`) carrying the topic
-   * name in large type and its subtitle beneath, set above the title.
-   * `color-mix` keeps the wash a light tint of whatever colour the
-   * editor picked, so text stays legible in both themes.
+   * Editorial topic banner: a flat topic-colour tint (the colour arrives
+   * inline as `--topic-color`) with a bottom accent, carrying the topic
+   * name and its disclaimer above the title. Content is left-aligned and
+   * the padding is tight and symmetric — a transparent-topped gradient
+   * used to leave a big empty gap above the name. `color-mix` keeps the
+   * tint legible in both themes.
    */
   .topic-banner {
     display: flex;
     flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap: var(--spacing-sm);
-    /*
-     * `padding-block` (not the 4-value `padding`) guarantees the top and
-     * bottom breathing room are the SAME length, so the name sits equally
-     * far from either edge regardless of how many lines the disclaimer
-     * wraps to. Kept tight so the name doesn't float too far from the top.
-     */
-    padding-block: clamp(var(--spacing-sm), 2vw, var(--spacing-md));
-    padding-inline: var(--spacing-lg);
+    align-items: flex-start;
+    gap: var(--spacing-xs);
+    padding: var(--spacing-sm) var(--spacing-lg);
     margin-bottom: var(--spacing-lg);
-    border-radius: var(--radius-lg);
+    border-radius: var(--radius-md);
     border-bottom: 3px solid var(--topic-color);
-    background: linear-gradient(
-      to bottom,
-      transparent,
-      color-mix(in srgb, var(--topic-color) 16%, transparent)
-    );
+    background: color-mix(in srgb, var(--topic-color) 13%, transparent);
+    text-align: left;
   }
 
   .topic-name {
@@ -283,9 +273,10 @@ const magazineRef = await (async () => {
   }
 
   .topic-subtitle {
-    font-size: clamp(0.9rem, 2vw, 1.05rem);
-    line-height: 1.5;
-    max-width: 60ch;
+    font-size: clamp(1.05rem, 2.2vw, 1.25rem);
+    line-height: 1.6;
+    max-width: 72ch;
+    text-align: left;
     color: var(--color-text-primary);
   }
 


### PR DESCRIPTION
Visual polish per review: pull the banner up (kill the top gap), larger inner padding, centred name, justified + hyphenated disclaimer (clean edges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)