### PR TITLE
Promote topics feature to master

### DIFF
--- a/e2e/blog-topic.pw.ts
+++ b/e2e/blog-topic.pw.ts
@@ -1,0 +1,52 @@
+import { expect, expectMinCount, test, visit } from '@prometheus/e2e-toolkit';
+
+/**
+ * Editorial topic markers E2E.
+ *
+ * A topic (settings/topics.json) colours the article header banner and
+ * the listing card. These guards lean on the `editorial` topic seeded on
+ * the cyber-tool article: the banner must render name + subtitle above
+ * the title, and the card must carry the subtitle tag plus a border in
+ * the topic colour that differs from a topic-less card.
+ */
+
+const ARTICLE = '/ru/blog/cyber-tool';
+const BLOG = '/ru/blog';
+
+test('article header renders the topic banner with name and subtitle', async ({ page }) => {
+  await visit(page, ARTICLE);
+
+  const banner = page.locator('.topic-banner');
+  await expect(banner).toBeVisible();
+  await expect(banner).toHaveAttribute('data-topic', 'editorial');
+  await expect(banner.locator('.topic-name')).not.toBeEmpty();
+  await expect(banner.locator('.topic-subtitle')).not.toBeEmpty();
+
+  // The accent border proves the topic colour reached the banner.
+  const borderColor = await banner.evaluate((el) => getComputedStyle(el).borderBottomColor);
+  expect(borderColor).not.toBe('rgba(0, 0, 0, 0)');
+});
+
+test('listing card shows the topic tag and a topic-coloured border', async ({ page }) => {
+  await visit(page, BLOG);
+
+  const topicCells = page.locator('[data-topic="editorial"]');
+  await expectMinCount(page, topicCells, 1);
+
+  const card = topicCells.first().locator('.post-card');
+  const tag = card.locator('.topic-tag');
+  await expect(tag).toBeVisible();
+  await expect(tag).not.toBeEmpty();
+
+  /*
+   * A topic-less card keeps the neutral border; the topic card must not.
+   * Comparing the two resolved colours proves the marker without pinning
+   * the test to a specific hex the editor could later change.
+   */
+  const neutralCard = page.locator('[data-category]:not([data-topic]) .post-card').first();
+  const [topicBorder, neutralBorder] = await Promise.all([
+    card.evaluate((el) => getComputedStyle(el).borderTopColor),
+    neutralCard.evaluate((el) => getComputedStyle(el).borderTopColor),
+  ]);
+  expect(topicBorder).not.toBe(neutralBorder);
+});

--- a/src/components/cp/CpCard.astro
+++ b/src/components/cp/CpCard.astro
@@ -3,9 +3,11 @@ interface Props {
   hoverable?: boolean;
   elevated?: boolean;
   class?: string;
+  /** Inline style passthrough — lets a caller set per-card CSS vars (e.g. a topic colour). */
+  style?: string | undefined;
 }
 
-const { hoverable = false, elevated = false, class: className } = Astro.props;
+const { hoverable = false, elevated = false, class: className, style } = Astro.props;
 
 const classes = ['card', hoverable ? 'hoverable' : '', elevated ? 'elevated' : '', className ?? '']
   .filter(Boolean)
@@ -15,7 +17,7 @@ const role = hoverable ? 'button' : 'article';
 const tabindex = hoverable ? '0' : undefined;
 ---
 
-<div class={classes} role={role} tabindex={tabindex}>
+<div class={classes} role={role} tabindex={tabindex} {...(style ? { style } : {})}>
   <slot />
 </div>
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -34,6 +34,16 @@ const blogCollection = defineCollection({
       image: image().optional(),
       lang: langEnum,
       /*
+       * Optional editorial topic key (see settings/topics.json). A topic
+       * is a parallel marker to `category`: it colours the article header
+       * (a transparent→topic-colour gradient with the topic name and
+       * subtitle) and the listing card (coloured border + subtitle tag),
+       * letting readers tell editorial pieces from translations and
+       * likbez readers at a glance. Optional so existing articles and
+       * drafts stay valid; an unknown key degrades to no marker.
+       */
+      topic: z.string().optional(),
+      /*
        * Optional magazine-issue slug this article appeared in. The blog
        * detail page renders "Published in: <issue>" linking back to
        * /<lang>/magazine/<slug> when present. `newspaper` is the

--- a/src/features/blog/components/PostCard.astro
+++ b/src/features/blog/components/PostCard.astro
@@ -159,7 +159,12 @@ const cardStyle = resolvedTopic ? `--topic-color: ${resolvedTopic.color}` : unde
     display: inline-block;
     padding: 0.15rem 0.55rem;
     background: color-mix(in srgb, var(--topic-color) 15%, transparent);
-    color: var(--topic-color);
+    /*
+     * Blend the label toward the theme text so it clears contrast against
+     * its own tinted pill (plain topic-colour text on a same-hue tint was
+     * unreadable — e.g. blue on light blue).
+     */
+    color: color-mix(in srgb, var(--topic-color) 60%, var(--color-text-primary));
     border: 1px solid var(--topic-color);
     font-size: 0.7rem;
     font-weight: 600;

--- a/src/features/blog/components/PostCard.astro
+++ b/src/features/blog/components/PostCard.astro
@@ -4,12 +4,15 @@ import CpCard from '@/components/cp/CpCard.astro';
 import type { Language } from '@/config/i18n';
 import BlogPicture from '@/features/blog/components/BlogPicture.astro';
 import { getCategoryLabel } from '@/features/content/helpers/getCategoryLabel';
+import { getTopic } from '@/features/content/helpers/getTopic';
 
 interface Props {
   title: string;
   description: string;
   /** Optional category badge — omitted for sections without categories (e.g. archive). */
   category?: string | undefined;
+  /** Optional editorial topic key — colours the card border and adds a subtitle tag. */
+  topic?: string | undefined;
   slug: string;
   image?: ImageMetadata | undefined;
   lang: Language;
@@ -28,14 +31,20 @@ interface Props {
   readMoreLabel?: string;
 }
 
-const { title, description, category, slug, image, lang, headingLevel = 3 } = Astro.props;
+const { title, description, category, topic, slug, image, lang, headingLevel = 3 } = Astro.props;
 const href = Astro.props.href ?? `/${lang}/blog/${slug}`;
+const resolvedTopic = getTopic(topic, lang);
+/* The topic colour cascades to the border and tag via this CSS var. */
+const cardStyle = resolvedTopic ? `--topic-color: ${resolvedTopic.color}` : undefined;
 ---
 
-<CpCard hoverable elevated class="post-card">
+<CpCard hoverable elevated class="post-card" style={cardStyle}>
   {image && <div class="post-image"><BlogPicture image={image} alt={title} preset="thumbnail" /></div>}
   <div class="post-content">
-    {category && <span class="category">{getCategoryLabel(category, lang)}</span>}
+    <span class="badges">
+      {category && <span class="category">{getCategoryLabel(category, lang)}</span>}
+      {resolvedTopic?.subtitle && <span class="topic-tag" data-topic={resolvedTopic.key}>{resolvedTopic.subtitle}</span>}
+    </span>
     {/*
       The heading anchor + `::before` overlay pattern: the link is
       attached to the title (so screen readers announce a real
@@ -75,6 +84,13 @@ const href = Astro.props.href ?? `/${lang}/blog/${slug}`;
     overflow: hidden;
     padding: 0;
     position: relative;
+    /*
+     * When the card carries a topic, `--topic-color` is set inline and
+     * paints the border in the topic colour; with no topic the var is
+     * unset and the fallback keeps the default neutral border — so the
+     * marker is opt-in without a separate class.
+     */
+    border-color: var(--topic-color, var(--color-border));
     transition:
       transform var(--transition-base),
       box-shadow var(--transition-fast);
@@ -112,6 +128,14 @@ const href = Astro.props.href ?? `/${lang}/blog/${slug}`;
     min-height: 0;
   }
 
+  .badges {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--spacing-xs);
+    flex-shrink: 0;
+  }
+
   .category {
     display: inline-block;
     padding: 0.15rem 0.55rem;
@@ -123,6 +147,24 @@ const href = Astro.props.href ?? `/${lang}/blog/${slug}`;
     width: fit-content;
     text-transform: uppercase;
     letter-spacing: 0.05em;
+    flex-shrink: 0;
+  }
+
+  /*
+   * Topic tag: a tinted outline pill in the topic colour, deliberately
+   * lighter than the solid category badge so the two read as distinct
+   * markers. Colour comes from the inline `--topic-color` on the card.
+   */
+  .topic-tag {
+    display: inline-block;
+    padding: 0.15rem 0.55rem;
+    background: color-mix(in srgb, var(--topic-color) 15%, transparent);
+    color: var(--topic-color);
+    border: 1px solid var(--topic-color);
+    font-size: 0.7rem;
+    font-weight: 600;
+    border-radius: var(--radius-sm);
+    width: fit-content;
     flex-shrink: 0;
   }
 

--- a/src/features/content/helpers/getTopic.ts
+++ b/src/features/content/helpers/getTopic.ts
@@ -1,0 +1,20 @@
+import { DEFAULT_LANGUAGE } from '@/config/i18n';
+import topicsData from '@/content/settings/topics.json';
+import { type ResolvedTopic, resolveTopic, type TopicEntry } from './topic-resolve';
+
+export type { ResolvedTopic } from './topic-resolve';
+
+const topics = topicsData as readonly TopicEntry[];
+
+/**
+ * Resolve an article's topic key to its colour + localized name and
+ * subtitle, using the seeded `settings/topics.json` and the site's
+ * default language. Thin wrapper over the pure `resolveTopic`; see it for
+ * the fallback semantics.
+ *
+ * @param key - Topic key from article frontmatter, or undefined
+ * @param lang - Current page language code
+ * @returns The resolved topic, or undefined when there is no marker
+ */
+export const getTopic = (key: string | undefined, lang: string): ResolvedTopic | undefined =>
+  resolveTopic(topics, key, lang, DEFAULT_LANGUAGE);

--- a/src/features/content/helpers/topic-resolve.test.ts
+++ b/src/features/content/helpers/topic-resolve.test.ts
@@ -8,7 +8,13 @@ const topics: readonly TopicEntry[] = [
     name: { en: 'Editorial', ru: 'От редакции' },
     subtitle: { en: 'The board position', ru: 'Позиция редакции' },
   },
-  { key: 'translation', color: '#2563eb', name: { en: 'Translation' }, subtitle: {} },
+  {
+    key: 'translation',
+    color: '#2563eb',
+    name: { en: 'Translation' },
+    subtitle: { en: 'Translation' },
+    description: { en: 'A long editorial disclaimer about translations.' },
+  },
 ];
 
 describe('resolveTopic', () => {
@@ -21,23 +27,27 @@ describe('resolveTopic', () => {
     expect(resolveTopic(topics, 'does-not-exist', 'ru', 'en')).toBeUndefined();
   });
 
-  it('resolves a known key to its colour and localized text', () => {
-    expect(resolveTopic(topics, 'editorial', 'ru', 'en')).toEqual({
-      key: 'editorial',
-      color: '#b03a2e',
-      name: 'От редакции',
-      subtitle: 'Позиция редакции',
-    });
+  it('resolves colour, name and short subtitle', () => {
+    const topic = resolveTopic(topics, 'editorial', 'ru', 'en');
+    expect(topic?.color).toBe('#b03a2e');
+    expect(topic?.name).toBe('От редакции');
+    expect(topic?.subtitle).toBe('Позиция редакции');
   });
 
-  it('falls back to the default language when the locale is missing', () => {
+  it('uses the long description for the banner when present', () => {
+    const topic = resolveTopic(topics, 'translation', 'en', 'en');
+    expect(topic?.subtitle).toBe('Translation');
+    expect(topic?.description).toBe('A long editorial disclaimer about translations.');
+  });
+
+  it('falls back description to the subtitle when there is no description', () => {
+    const topic = resolveTopic(topics, 'editorial', 'ru', 'en');
+    expect(topic?.description).toBe('Позиция редакции');
+  });
+
+  it('falls back to the default language then the key/empty string', () => {
     const topic = resolveTopic(topics, 'translation', 'it', 'en');
     expect(topic?.name).toBe('Translation');
-  });
-
-  it('falls back to the key for a name and empty string for a subtitle', () => {
-    const topic = resolveTopic(topics, 'translation', 'xx', 'zz');
-    expect(topic?.name).toBe('translation');
-    expect(topic?.subtitle).toBe('');
+    expect(topic?.description).toBe('A long editorial disclaimer about translations.');
   });
 });

--- a/src/features/content/helpers/topic-resolve.test.ts
+++ b/src/features/content/helpers/topic-resolve.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { resolveTopic, type TopicEntry } from './topic-resolve';
+
+const topics: readonly TopicEntry[] = [
+  {
+    key: 'editorial',
+    color: '#b03a2e',
+    name: { en: 'Editorial', ru: 'От редакции' },
+    subtitle: { en: 'The board position', ru: 'Позиция редакции' },
+  },
+  { key: 'translation', color: '#2563eb', name: { en: 'Translation' }, subtitle: {} },
+];
+
+describe('resolveTopic', () => {
+  it('returns undefined for an absent key', () => {
+    expect(resolveTopic(topics, undefined, 'ru', 'en')).toBeUndefined();
+    expect(resolveTopic(topics, '', 'ru', 'en')).toBeUndefined();
+  });
+
+  it('returns undefined for an unknown key', () => {
+    expect(resolveTopic(topics, 'does-not-exist', 'ru', 'en')).toBeUndefined();
+  });
+
+  it('resolves a known key to its colour and localized text', () => {
+    expect(resolveTopic(topics, 'editorial', 'ru', 'en')).toEqual({
+      key: 'editorial',
+      color: '#b03a2e',
+      name: 'От редакции',
+      subtitle: 'Позиция редакции',
+    });
+  });
+
+  it('falls back to the default language when the locale is missing', () => {
+    const topic = resolveTopic(topics, 'translation', 'it', 'en');
+    expect(topic?.name).toBe('Translation');
+  });
+
+  it('falls back to the key for a name and empty string for a subtitle', () => {
+    const topic = resolveTopic(topics, 'translation', 'xx', 'zz');
+    expect(topic?.name).toBe('translation');
+    expect(topic?.subtitle).toBe('');
+  });
+});

--- a/src/features/content/helpers/topic-resolve.ts
+++ b/src/features/content/helpers/topic-resolve.ts
@@ -4,6 +4,8 @@ export interface TopicEntry {
   readonly color: string;
   readonly name: Record<string, string>;
   readonly subtitle: Record<string, string>;
+  /** Optional long disclaimer shown only on the article banner. */
+  readonly description?: Record<string, string>;
 }
 
 /** A topic resolved for one page language, ready to render. */
@@ -11,7 +13,10 @@ export interface ResolvedTopic {
   readonly key: string;
   readonly color: string;
   readonly name: string;
+  /** Short приписка — the listing card tag. */
   readonly subtitle: string;
+  /** Long disclaimer for the article banner; falls back to the subtitle. */
+  readonly description: string;
 }
 
 const localize = (
@@ -22,9 +27,10 @@ const localize = (
 ): string => dict[lang] ?? dict[defaultLang] ?? fallback;
 
 /**
- * Resolve a topic key against a topic set to its colour + localized name
- * and subtitle. Pure and content-free so it unit-tests without the
- * content repo present: the data and default language are injected.
+ * Resolve a topic key against a topic set to its colour, short subtitle
+ * (the card tag) and long description (the article banner disclaimer,
+ * which falls back to the subtitle when absent). Pure and content-free so
+ * it unit-tests without the content repo present.
  *
  * Tolerant by design — an absent or unknown key yields `undefined` (no
  * marker), and a missing locale falls back to the default language, then
@@ -45,10 +51,14 @@ export const resolveTopic = (
   if (!key) return undefined;
   const entry = topics.find((t) => t.key === key);
   if (!entry) return undefined;
+  const subtitle = localize(entry.subtitle, lang, defaultLang, '');
   return {
     key: entry.key,
     color: entry.color,
     name: localize(entry.name, lang, defaultLang, entry.key),
-    subtitle: localize(entry.subtitle, lang, defaultLang, ''),
+    subtitle,
+    description: entry.description
+      ? localize(entry.description, lang, defaultLang, subtitle)
+      : subtitle,
   };
 };

--- a/src/features/content/helpers/topic-resolve.ts
+++ b/src/features/content/helpers/topic-resolve.ts
@@ -1,0 +1,54 @@
+/** A raw topic entry as stored in settings/topics.json. */
+export interface TopicEntry {
+  readonly key: string;
+  readonly color: string;
+  readonly name: Record<string, string>;
+  readonly subtitle: Record<string, string>;
+}
+
+/** A topic resolved for one page language, ready to render. */
+export interface ResolvedTopic {
+  readonly key: string;
+  readonly color: string;
+  readonly name: string;
+  readonly subtitle: string;
+}
+
+const localize = (
+  dict: Record<string, string>,
+  lang: string,
+  defaultLang: string,
+  fallback: string,
+): string => dict[lang] ?? dict[defaultLang] ?? fallback;
+
+/**
+ * Resolve a topic key against a topic set to its colour + localized name
+ * and subtitle. Pure and content-free so it unit-tests without the
+ * content repo present: the data and default language are injected.
+ *
+ * Tolerant by design — an absent or unknown key yields `undefined` (no
+ * marker), and a missing locale falls back to the default language, then
+ * the raw key (name) or an empty string (subtitle).
+ *
+ * @param topics - Available topic entries
+ * @param key - Topic key from article frontmatter, or undefined
+ * @param lang - Current page language code
+ * @param defaultLang - Fallback language code
+ * @returns The resolved topic, or undefined when there is no marker
+ */
+export const resolveTopic = (
+  topics: readonly TopicEntry[],
+  key: string | undefined,
+  lang: string,
+  defaultLang: string,
+): ResolvedTopic | undefined => {
+  if (!key) return undefined;
+  const entry = topics.find((t) => t.key === key);
+  if (!entry) return undefined;
+  return {
+    key: entry.key,
+    color: entry.color,
+    name: localize(entry.name, lang, defaultLang, entry.key),
+    subtitle: localize(entry.subtitle, lang, defaultLang, ''),
+  };
+};

--- a/src/pages/[lang]/blog/[...slug].astro
+++ b/src/pages/[lang]/blog/[...slug].astro
@@ -247,14 +247,18 @@ const magazineRef = await (async () => {
   .topic-banner {
     display: flex;
     flex-direction: column;
-    align-items: flex-start;
-    gap: var(--spacing-xs);
-    padding: var(--spacing-sm) var(--spacing-lg);
+    gap: var(--spacing-sm);
+    padding: clamp(var(--spacing-md), 3vw, var(--spacing-lg))
+      clamp(var(--spacing-md), 4vw, var(--spacing-xl));
+    /*
+     * Pull the banner up into the section's generous top padding so it
+     * sits near the header instead of floating far below it.
+     */
+    margin-top: calc(-1 * var(--spacing-xl));
     margin-bottom: var(--spacing-lg);
     border-radius: var(--radius-md);
     border-bottom: 3px solid var(--topic-color);
     background: color-mix(in srgb, var(--topic-color) 13%, transparent);
-    text-align: left;
   }
 
   .topic-name {
@@ -263,6 +267,9 @@ const magazineRef = await (async () => {
     line-height: 1;
     letter-spacing: 0.02em;
     text-transform: uppercase;
+    text-align: center;
+    /* Balance the wrapped lines of the (short) name for an even look. */
+    text-wrap: balance;
     /*
      * Blend the topic colour toward the theme's primary text so the name
      * keeps its hue but stays legible on its own tinted background — pure
@@ -276,7 +283,12 @@ const magazineRef = await (async () => {
     font-size: clamp(1.05rem, 2.2vw, 1.25rem);
     line-height: 1.6;
     max-width: 72ch;
-    text-align: left;
+    /* Justify both edges (no ragged right); hyphenate so the narrow
+       mobile column doesn't open up rivers of white space. `pretty`
+       still tidies the left-aligned last line. */
+    text-align: justify;
+    hyphens: auto;
+    text-wrap: pretty;
     color: var(--color-text-primary);
   }
 

--- a/src/pages/[lang]/blog/[...slug].astro
+++ b/src/pages/[lang]/blog/[...slug].astro
@@ -13,6 +13,7 @@ import ArticleTocSidebar from '@/features/content/components/ArticleTocSidebar.a
 import SuggestChangesLink from '@/features/content/components/SuggestChangesLink.astro';
 import { deriveDescription } from '@/features/content/helpers/deriveDescription';
 import { getCategoryLabel } from '@/features/content/helpers/getCategoryLabel';
+import { getTopic } from '@/features/content/helpers/getTopic';
 import { formatArticleDate } from '@/features/i18n/format-date';
 import MissingTranslation from '@/features/i18n/MissingTranslation.astro';
 import { getAllIssues } from '@/features/magazine/helpers/getMagazineItems';
@@ -80,6 +81,14 @@ const publishedDate = post ? (post.data.publishDate ?? post.data.pubDate) : unde
 const isoDate = publishedDate?.toISOString();
 
 /*
+ * The editorial topic (see settings/topics.json). Resolved once here and
+ * rendered as a gradient banner above the title; undefined when the
+ * article has no topic or an unknown key, so the header degrades to the
+ * plain category badge it always had.
+ */
+const topic = post ? getTopic(post.data.topic, lang) : undefined;
+
+/*
  * Article-level JSON-LD triggers Google's "Article" rich result and
  * lets the publisher (Organization) anchor cleanly to the global
  * Organization block in BaseLayout. Microdata `itemscope` further
@@ -140,6 +149,12 @@ const magazineRef = await (async () => {
       <ArticleTocSidebar headings={headings} label={tocLabel} articleTitle={post.data.title} />
       <div class="container">
         <header class="post-header" id="article-top">
+          {topic && (
+            <aside class="topic-banner" style={`--topic-color: ${topic.color}`} data-topic={topic.key}>
+              <span class="topic-name">{topic.name}</span>
+              {topic.subtitle && <span class="topic-subtitle">{topic.subtitle}</span>}
+            </aside>
+          )}
           <span class="category">{getCategoryLabel(post.data.category, lang)}</span>
           <h1 itemprop="name">{post.data.title}</h1>
           <p class="post-meta">
@@ -219,6 +234,43 @@ const magazineRef = await (async () => {
     margin-inline: auto;
     text-align: center;
     margin-bottom: var(--spacing-xl);
+  }
+
+  /*
+   * Editorial topic banner: a transparent→topic-colour gradient wash
+   * (the colour arrives inline as `--topic-color`) carrying the topic
+   * name in large type and its subtitle beneath, set above the title.
+   * `color-mix` keeps the wash a light tint of whatever colour the
+   * editor picked, so text stays legible in both themes.
+   */
+  .topic-banner {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--spacing-2xs, 0.25rem);
+    padding: clamp(var(--spacing-md), 4vw, var(--spacing-xl)) var(--spacing-md);
+    margin-bottom: var(--spacing-lg);
+    border-radius: var(--radius-lg);
+    border-bottom: 3px solid var(--topic-color);
+    background: linear-gradient(
+      to bottom,
+      transparent,
+      color-mix(in srgb, var(--topic-color) 20%, transparent)
+    );
+  }
+
+  .topic-name {
+    font-size: clamp(1.5rem, 4vw, 2.25rem);
+    font-weight: 800;
+    line-height: 1.1;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    color: var(--topic-color);
+  }
+
+  .topic-subtitle {
+    font-size: clamp(0.9rem, 2vw, 1.05rem);
+    color: var(--color-text-secondary);
   }
 
   .category {

--- a/src/pages/[lang]/blog/[...slug].astro
+++ b/src/pages/[lang]/blog/[...slug].astro
@@ -152,7 +152,7 @@ const magazineRef = await (async () => {
           {topic && (
             <aside class="topic-banner" style={`--topic-color: ${topic.color}`} data-topic={topic.key}>
               <span class="topic-name">{topic.name}</span>
-              {topic.subtitle && <span class="topic-subtitle">{topic.subtitle}</span>}
+              {topic.description && <span class="topic-subtitle">{topic.description}</span>}
             </aside>
           )}
           <span class="category">{getCategoryLabel(post.data.category, lang)}</span>
@@ -247,30 +247,46 @@ const magazineRef = await (async () => {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: var(--spacing-2xs, 0.25rem);
-    padding: clamp(var(--spacing-md), 4vw, var(--spacing-xl)) var(--spacing-md);
+    justify-content: center;
+    gap: var(--spacing-sm);
+    /*
+     * `padding-block` (not the 4-value `padding`) guarantees the top and
+     * bottom breathing room are the SAME length, so the name sits equally
+     * far from either edge regardless of how many lines the disclaimer
+     * wraps to.
+     */
+    padding-block: clamp(var(--spacing-lg), 4vw, var(--spacing-2xl));
+    padding-inline: var(--spacing-lg);
     margin-bottom: var(--spacing-lg);
     border-radius: var(--radius-lg);
     border-bottom: 3px solid var(--topic-color);
     background: linear-gradient(
       to bottom,
       transparent,
-      color-mix(in srgb, var(--topic-color) 20%, transparent)
+      color-mix(in srgb, var(--topic-color) 16%, transparent)
     );
   }
 
   .topic-name {
     font-size: clamp(1.5rem, 4vw, 2.25rem);
     font-weight: 800;
-    line-height: 1.1;
+    line-height: 1;
     letter-spacing: 0.02em;
     text-transform: uppercase;
-    color: var(--topic-color);
+    /*
+     * Blend the topic colour toward the theme's primary text so the name
+     * keeps its hue but stays legible on its own tinted background — pure
+     * `--topic-color` on a same-hue wash (e.g. blue on light blue) failed
+     * contrast.
+     */
+    color: color-mix(in srgb, var(--topic-color) 68%, var(--color-text-primary));
   }
 
   .topic-subtitle {
     font-size: clamp(0.9rem, 2vw, 1.05rem);
-    color: var(--color-text-secondary);
+    line-height: 1.5;
+    max-width: 60ch;
+    color: var(--color-text-primary);
   }
 
   .category {

--- a/src/pages/[lang]/blog/[...slug].astro
+++ b/src/pages/[lang]/blog/[...slug].astro
@@ -237,34 +237,24 @@ const magazineRef = await (async () => {
   }
 
   /*
-   * Editorial topic banner: a transparent→topic-colour gradient wash
-   * (the colour arrives inline as `--topic-color`) carrying the topic
-   * name in large type and its subtitle beneath, set above the title.
-   * `color-mix` keeps the wash a light tint of whatever colour the
-   * editor picked, so text stays legible in both themes.
+   * Editorial topic banner: a flat topic-colour tint (the colour arrives
+   * inline as `--topic-color`) with a bottom accent, carrying the topic
+   * name and its disclaimer above the title. Content is left-aligned and
+   * the padding is tight and symmetric — a transparent-topped gradient
+   * used to leave a big empty gap above the name. `color-mix` keeps the
+   * tint legible in both themes.
    */
   .topic-banner {
     display: flex;
     flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap: var(--spacing-sm);
-    /*
-     * `padding-block` (not the 4-value `padding`) guarantees the top and
-     * bottom breathing room are the SAME length, so the name sits equally
-     * far from either edge regardless of how many lines the disclaimer
-     * wraps to. Kept tight so the name doesn't float too far from the top.
-     */
-    padding-block: clamp(var(--spacing-sm), 2vw, var(--spacing-md));
-    padding-inline: var(--spacing-lg);
+    align-items: flex-start;
+    gap: var(--spacing-xs);
+    padding: var(--spacing-sm) var(--spacing-lg);
     margin-bottom: var(--spacing-lg);
-    border-radius: var(--radius-lg);
+    border-radius: var(--radius-md);
     border-bottom: 3px solid var(--topic-color);
-    background: linear-gradient(
-      to bottom,
-      transparent,
-      color-mix(in srgb, var(--topic-color) 16%, transparent)
-    );
+    background: color-mix(in srgb, var(--topic-color) 13%, transparent);
+    text-align: left;
   }
 
   .topic-name {
@@ -283,9 +273,10 @@ const magazineRef = await (async () => {
   }
 
   .topic-subtitle {
-    font-size: clamp(0.9rem, 2vw, 1.05rem);
-    line-height: 1.5;
-    max-width: 60ch;
+    font-size: clamp(1.05rem, 2.2vw, 1.25rem);
+    line-height: 1.6;
+    max-width: 72ch;
+    text-align: left;
     color: var(--color-text-primary);
   }
 

--- a/src/pages/[lang]/blog/[...slug].astro
+++ b/src/pages/[lang]/blog/[...slug].astro
@@ -253,9 +253,9 @@ const magazineRef = await (async () => {
      * `padding-block` (not the 4-value `padding`) guarantees the top and
      * bottom breathing room are the SAME length, so the name sits equally
      * far from either edge regardless of how many lines the disclaimer
-     * wraps to.
+     * wraps to. Kept tight so the name doesn't float too far from the top.
      */
-    padding-block: clamp(var(--spacing-lg), 4vw, var(--spacing-2xl));
+    padding-block: clamp(var(--spacing-sm), 2vw, var(--spacing-md));
     padding-inline: var(--spacing-lg);
     margin-bottom: var(--spacing-lg);
     border-radius: var(--radius-lg);

--- a/src/pages/[lang]/blog/index.astro
+++ b/src/pages/[lang]/blog/index.astro
@@ -45,11 +45,12 @@ const readMore = labels?.data.readMore ?? 'Read more';
           <CategoryFilter categories={categories} lang={lang} allLabel={allCategory} />
           <div class="grid grid-2">
             {posts.map((post) => (
-              <div data-category={post.data.category}>
+              <div data-category={post.data.category} data-topic={post.data.topic}>
                 <PostCard
                   title={post.data.title}
                   description={post.data.description ?? deriveSummary(post.body) ?? ''}
                   category={post.data.category}
+                  topic={post.data.topic}
                   slug={getArticleSlug(post)}
                   image={post.data.image}
                   lang={lang}


### PR DESCRIPTION
Code-only develop→master promotion of the editorial **topics** feature: schema field, getTopic/topic-resolve, article banner (centered name + justified disclaimer), PostCard border+tag, and E2E. Content (topics.json all langs + Battaglia Comunista tags) already on content master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)